### PR TITLE
変数名や関数名についてソース定義の名前を使うか使わないかをオプション指定可能にした

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -20,6 +20,8 @@ namespace SLANGCompiler
             [Option('O', "output", Required = false, HelpText = "Output file path.")]
             public string OutputPath { get; set; }
 
+            [Option("use-symbol", Required = false, HelpText = "Use original symbol name.")]
+            public bool UseOriginalSymbol { get; set; }
 
             [Value(0, Required = true, MetaName = "input files")]
             public IEnumerable<string> Files { get; set; }
@@ -86,6 +88,9 @@ namespace SLANGCompiler
             //    Environment.Exit(0);
             //}
             var parser = new SLANG.SLANGParser();
+
+            // ソースファイルで指定した変数名、関数名をそのまま使うか、使わないか
+            parser.SetOriginalSymbolUse(opt.UseOriginalSymbol);
 
             // ライブラリ指定がない場合はデフォルトを読む
             if(opt.LibraryNames == null || opt.LibraryNames.Count() == 0)

--- a/SLANG/SLANG.Parser.Expr.cs
+++ b/SLANG/SLANG.Parser.Expr.cs
@@ -193,7 +193,7 @@ namespace SLANGCompiler.SLANG
             if(table == null)
             {
                 // 宣言されていない識別子は一時定義関数として自動定義してやり、定義時に差し替える。定義されなかった場合はエラーとなる。
-                table = symbolTableManager.AddSymbol(name, TypeInfo.TempFunc);
+                table = symbolTableManager.AddSymbol(name, TypeInfo.TempFunc, null);
             }
 
             // 該当シンボルが使われた(^BCなどが使われない場合、CALL関数を最適化するために利用している)

--- a/SLANG/SLANG.Parser.Function.cs
+++ b/SLANG/SLANG.Parser.Function.cs
@@ -84,7 +84,13 @@ namespace SLANGCompiler.SLANG
             symbol = symbolDecl(tree, SymbolClass.Global, DeclNode.Func);
             if(symbol != null)
             {
-                symbolTableManager.Add(symbol);
+                // MAIN関数だけは何があってもそのまま使う
+                bool? useOriginalSymbol = null;
+                if(symbol.Name.ToUpper() == "MAIN")
+                {
+                    useOriginalSymbol = true;
+                }
+                symbol = symbolTableManager.Add(symbol, useOriginalSymbol);
             }
 
             if(symbol == null)

--- a/SLANG/SLANG.Parser.RuntimeManager.cs
+++ b/SLANG/SLANG.Parser.RuntimeManager.cs
@@ -141,7 +141,7 @@ namespace SLANGCompiler.SLANG
                 }
 
                 // シンボルテーブル側に反映させておく
-                symbolTableManager.AddFunction(runtimeCode.functionType, label, info.InsideName, runtimeCode.paramCount, address);
+                symbolTableManager.AddFunction(runtimeCode.functionType, label, info.InsideName, runtimeCode.paramCount, address, true);
             }
 
             /// <summary>

--- a/SLANG/SLANG.Parser.Symbol.cs
+++ b/SLANG/SLANG.Parser.Symbol.cs
@@ -70,17 +70,25 @@ namespace SLANGCompiler.SLANG
             };
             symbolTableManager.Add(memw);
 
-            symbolTableManager.AddSymbol("^BC", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^DE", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^HL", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^IX", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^IY", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^AF", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^A", TypeInfo.WordTypeInfo);      // AについてはAFの2バイト目を指すように改竄されるので注意。その関係でワークは1バイト無駄が出る。
-            symbolTableManager.AddSymbol("^CARRY", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^ZERO", TypeInfo.WordTypeInfo);
-            symbolTableManager.AddSymbol("^SP", TypeInfo.WordTypeInfo);
+            symbolTableManager.AddSymbol("^BC", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^DE", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^HL", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^IX", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^IY", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^AF", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^A", TypeInfo.WordTypeInfo, true);      // AについてはAFの2バイト目を指すように改竄されるので注意。その関係でワークは1バイト無駄が出る。
+            symbolTableManager.AddSymbol("^CARRY", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^ZERO", TypeInfo.WordTypeInfo, true);
+            symbolTableManager.AddSymbol("^SP", TypeInfo.WordTypeInfo, true);
 
+        }
+
+        /// <summary>
+        /// シンボルテーブルについてソースコードで使われた変数名、関数名をそのまま使う場合はtrue、内部番号に置換する場合はfalseを指定する
+        /// </summary>
+        public void SetOriginalSymbolUse(bool originalUse)
+        {
+            symbolTableManager.UseOriginalSymbol = originalUse;
         }
 
         /// <summary>

--- a/SLANG/SLANG.Parser.cs
+++ b/SLANG/SLANG.Parser.cs
@@ -205,7 +205,7 @@ namespace SLANGCompiler.SLANG
                 TypeInfo = new TypeInfo(TypeInfoClass.Array, 256, TypeDataSize.Byte, TypeInfo.ByteTypeInfo),
                 Size = 256
             };
-            symbolTableManager.Add(workArray);
+            symbolTableManager.Add(workArray, true);
 
             // WORK指定がされていて、それがORGのアドレスより前の場合は先にWORKの宣言を出力する(念のため)
             if(workAddressValue >=0 && workAddressValue < orgValue)

--- a/SLANG/SymbolTable.cs
+++ b/SLANG/SymbolTable.cs
@@ -40,7 +40,12 @@ namespace SLANGCompiler.SLANG
         {
             get
             {
-                return "_" + LabelHeader+"_"+normalizeName;
+                if(UseOriginalSymbol)
+                {
+                    return "_" + LabelHeader+"_"+normalizeName;
+                } else {
+                    return "_" + LabelHeader+"_SYM"+Id;
+                }
             }
         }
 
@@ -63,6 +68,11 @@ namespace SLANGCompiler.SLANG
         /// シンボルの内部名称(ランタイムにて、プログラムで使われる名称と実際のラベル名称が異なる場合の、ラベル名称)
         /// </summary>
         public string InsideName { get; set; }
+
+        /// <summary>
+        /// シンボルID
+        /// </summary>
+        public int Id { get; set; }
 
         /// <summary>
         /// ランタイム関数において実際にアセンブラソースで使われる名称
@@ -109,6 +119,11 @@ namespace SLANGCompiler.SLANG
         public bool Used { get; set; }
 
         /// <summary>
+        /// シンボル名称を変数名、関数名などそのまま使うか、シンボル番号で置換するか
+        /// </summary>
+        public bool UseOriginalSymbol { get; set; }
+
+        /// <summary>
         /// シンボルが関数の場合、ユーザー定義の関数か、MACHINE定義(or ランタイム)の関数かを示す
         /// </summary>
         public FunctionType FunctionType;
@@ -125,6 +140,7 @@ namespace SLANGCompiler.SLANG
             this.InitialValueList = null;
             this.Used = false;
             this.FunctionType = FunctionType.Normal;
+            this.UseOriginalSymbol = false;
         }
 
         /// <summary>


### PR DESCRIPTION
* --use-symbol をつけると元々の変数名・関数名がアセンブラソースに使われる。つけない場合は内部の管理番号に置き換えられる(漢字や、シンボルとして不正な文字を使っている場合は指定しないようにしてください)