### PR TITLE
プリプロセッサIFの定数評価をlex側で行うよう変更(他)

### DIFF
--- a/SLANG/SLANG.Parser.CodeGen.cs
+++ b/SLANG/SLANG.Parser.CodeGen.cs
@@ -2035,10 +2035,10 @@ namespace SLANGCompiler.SLANG
                         gencode(" ADD HL,DE\n");
                     }
                 }
-            } else if(right.Opcode == Opcode.Adr)
-            {
-                // なんだここ
-                Error("scaleadd error (Adr)");
+//            } else if(right.Opcode == Opcode.Adr)
+//            {
+//                // なんだここ
+//                Error("scaleadd error (Adr)");
             } else {
                 if(left.CanLoadDirect())
                 {

--- a/SLANG/SLANG.Parser.Expr.cs
+++ b/SLANG/SLANG.Parser.Expr.cs
@@ -92,7 +92,10 @@ namespace SLANGCompiler.SLANG
                     return leftValue >> rightValue;
                 case Opcode.SShr:
                     return (short)leftValue >> (short)rightValue;
-
+                case Opcode.And:
+                    return leftValue & rightValue;
+                case Opcode.Or:
+                    return leftValue | rightValue;
                 case Opcode.Eq: return leftValue == rightValue ? 1 : 0;
                 case Opcode.Neq: return leftValue != rightValue ? 1 : 0;
 
@@ -982,6 +985,13 @@ namespace SLANGCompiler.SLANG
             }
             Error("=: type mismatch " + ltype + "\n:" + rtype);
             return null;
+        }
+
+        public Expr LastConstExpr { get; private set; }
+        // 最終評価されたCONST式を保存しておく
+        void setConstExpr(Expr expr)
+        {
+            LastConstExpr = expr;
         }
     }
 }

--- a/SLANG/SLANG.Parser.Function.cs
+++ b/SLANG/SLANG.Parser.Function.cs
@@ -121,6 +121,7 @@ namespace SLANGCompiler.SLANG
                 }
             }
 
+            int paramCount = 0;
             for(p = p.Second; p != null; p = p.Second)
             {
                 var s = paramDecl(p.First.First.TypeInfo, p.First.First);
@@ -128,7 +129,10 @@ namespace SLANGCompiler.SLANG
                 {
                     localSymbolTableManager.Add(s);
                 }
+                paramCount++;
             }
+            // 関数の引数の数を設定
+            symbol.Size = paramCount;
 
         }
 

--- a/SLANG/SLANG.Parser.Symbol.cs
+++ b/SLANG/SLANG.Parser.Symbol.cs
@@ -19,6 +19,7 @@ namespace SLANGCompiler.SLANG
 
         // CONST値管理マネージャ
         private ConstTableManager constTableManager;
+        public ConstTableManager ConstTableManager => constTableManager;
 
         // シンボルテーブル群を初期化する。言語標準の変数もあわせて定義する。
         private void initSymbolTable()

--- a/SLANG/SLANG.Scanner.cs
+++ b/SLANG/SLANG.Scanner.cs
@@ -8,11 +8,26 @@ namespace SLANGCompiler.SLANG
     {
 
         ConstTableManager constTableManager;
+        SLANGParser constParser = new SLANGParser();
 
         public void SetConstTableManager(ConstTableManager constTableManager)
         {
             this.constTableManager = constTableManager;
         }
+
+        public bool CheckConst(string constStr)
+        {
+            constParser.ParseConstExpr("#CCHK" + constStr, constTableManager);
+            if(constParser.LastConstExpr.IsConst())
+            {
+                // Console.WriteLine("Check:" + constParser.LastConstExpr.Value);
+                return constParser.LastConstExpr.Value != 0;
+            } else {
+                error("expr must be const.");
+            }
+            return false;
+        }
+
 
         void GetChar(string charStr)
         {


### PR DESCRIPTION
* 文括弧と配列用の括弧の開始を分けるよう対応(強引)
* ユーザー定義関数の引数設定がされていなかったのを修正
* ANDとORの定数計算が出来なかったのを修正
* 関数定義が怪しかったのを調整
* #END IFではなく #ENDIF でも大丈夫なように調整(#END IFは仕様の間違い？？)