### PR TITLE
関数名と変数名についてデフォルトで大文字小文字を区別しないよう変更

### DIFF
--- a/SLANG/ConstTableManager.cs
+++ b/SLANG/ConstTableManager.cs
@@ -32,6 +32,8 @@ namespace SLANGCompiler.SLANG
         /// <summary>CONST値(CODEを参照する場合のシンボル名)</summary>
         public string SymbolString { get; set; }
 
+        public bool CaseSensitive { get; set; }
+
         /// <summary>値を持つCONST値のコンストラクタ</summary>
         public ConstInfo(int value)
         {
@@ -88,6 +90,8 @@ namespace SLANGCompiler.SLANG
 
         private Dictionary<string, ConstInfo> constTableDictionary = new Dictionary<string, ConstInfo>();
 
+        public bool CaseSensitive { get; set; }
+
         /// <summary>
         /// CONST定義されたシンボルと値を追加する
         /// </summary>
@@ -109,10 +113,23 @@ namespace SLANGCompiler.SLANG
         /// </summary>
         public bool TryGetValue(string name, out ConstInfo info)
         {
-            if(constTableDictionary.TryGetValue(name, out info))
+            if(CaseSensitive)
             {
-                return true;
+                if(constTableDictionary.TryGetValue(name, out info))
+                {
+                    return true;
+                }
+            } else {
+                foreach(var pair in constTableDictionary)
+                {
+                    if(pair.Key.ToUpper() == name.ToUpper())
+                    {
+                        info = pair.Value;
+                        return true;
+                    }
+                }
             }
+            info = null;
             return false;
         }
 

--- a/SLANG/SLANG.Parser.Function.cs
+++ b/SLANG/SLANG.Parser.Function.cs
@@ -110,6 +110,7 @@ namespace SLANGCompiler.SLANG
             functionSymbolTableManagerList.Add(localSymbolTableManager);
             localSymbolTableManager = new SymbolTableManager(this);
             localSymbolTableManager.UseOriginalSymbol = symbolTableManager.UseOriginalSymbol;
+            localSymbolTableManager.CaseSensitive = symbolTableManager.CaseSensitive;
             funcNumber++;
 
             // 関数のパラメータがくっついているTreeを探す

--- a/SLANG/SLANG.Parser.Symbol.cs
+++ b/SLANG/SLANG.Parser.Symbol.cs
@@ -94,6 +94,16 @@ namespace SLANGCompiler.SLANG
         }
 
         /// <summary>
+        /// シンボルテーブルとCONSTテーブルについて大文字小文字の区別をする場合はtrue、しない場合はfalseを指定する
+        /// </summary>
+        public void SetCaseSensitiveSymbol(bool caseSensitive)
+        {
+            symbolTableManager.CaseSensitive = caseSensitive;
+            localSymbolTableManager.CaseSensitive = caseSensitive;
+            constTableManager.CaseSensitive = caseSensitive;
+        }
+
+        /// <summary>
         /// シンボルテーブルの状態を表示する(デバッグ用)
         /// </summary>
         public void dispSymbolTable()

--- a/SLANG/SymbolManager.cs
+++ b/SLANG/SymbolManager.cs
@@ -24,11 +24,14 @@ namespace SLANGCompiler.SLANG
 
         public bool UseOriginalSymbol { get; set; }
 
+        public bool CaseSensitive { get; set; }
+
         public SymbolTableManager(IErrorReporter errorReporter)
         {
             this.errorReporter = errorReporter;
             Initialize();
             UseOriginalSymbol = false;
+            CaseSensitive = false;
         }
 
         /// <summary>
@@ -114,11 +117,12 @@ namespace SLANGCompiler.SLANG
         /// </summary>
         public SymbolTable SearchSymbol(string name)
         {
-            var symName = name;
+            var symName = CaseSensitive ? name : name.ToUpper();
             foreach(var table in symbolTableList)
             {
+                var tableName = CaseSensitive ? table.Name : table.Name.ToUpper();
                 // シンボル名を探す
-                if(symName == table.Name)
+                if(symName == tableName)
                 {
                     return table;
                 }
@@ -128,7 +132,8 @@ namespace SLANGCompiler.SLANG
                 {
                     foreach(var aliasName in table.AliasNameList)
                     {
-                        if(symName == aliasName)
+                        var aName = CaseSensitive ? aliasName : aliasName.ToUpper();
+                        if(symName == aName)
                         {
                             return table;
                         }


### PR DESCRIPTION
* --case-sensitiveオプションをつける事で区別するようになります