### PR TITLE
ファイル入出力ライブラリのMSX-DOS2対応など

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ SLANG Compilerはランタイムライブラリとして、複数のファイル
 例えば掛け算や割り算など、OSなどの環境に関わらないルーチンはこちらに含まれています。普通のYAML形式のテキストファイルなので、
 より高速なものに自分で差し替える事も可能です(というか、いいコードが出来たらプルリクください)。
 
-##  lib.yml / liblsx.yml (for LSX-Dodgers)
+##  lib.yml / liblsx.yml (for LSX-Dodgers/MSX-DOS(2))
 こちらは、ライブラリのうち、OSに依存するルーチンが含まれるものとなります。
 現状X1/turbo/ZやMZ-700/1500やPC-8801mkIISRでCP/M80やMSX-DOSのソフトを実行するためのOS [LSX-Dodgers](https://github.com/tablacus/LSX-Dodgers) 用のコードになっています(初期化処理やPRINT、LOCATEなど)。
 
@@ -57,7 +57,9 @@ SLANG Compilerはランタイムライブラリとして、複数のファイル
 
 -L オプションに何も指定しない場合はこのファイルが読み込まれます。
 
-また、明示的に -L lsx を指定する事で liblsx.yml が読み込まれますが、lib.ymlとliblsx.ymlは同じ内容となっています。
+また、明示的に -L lsx を指定する事で liblsx.yml が読み込まれますが、lib.ymlとliblsx.ymlはほぼ同じ内容となっています。
+
+liblsx.ymlではファイルオープンの際のMSX-DOS2の処理を省略しています。
 
 ## libx1.yml (for SHARP X1)
 こちらはLSX-Dodgers版をベースに、WIDTH関数とPRINT関数のみX1専用に書き換えたランタイムライブラリとなります。
@@ -70,6 +72,11 @@ SLANG Compilerはランタイムライブラリとして、複数のファイル
 S-OS版のランタイムです。これを読み込む事で、従来のSLANGで作られたアプリをコンパイルし、S-OSで実行出来ます。
 
 -L sos とオプションを付与する事で、lib.ymlのかわりにこちらを読み込みます。
+
+## libmsx2.yml (for MSX-DOS2)
+こちらは、ライブラリのうち、OSに依存するルーチンが含まれるものとなります。
+lib.ymlをベースにファイル入出力ライブラリをファイルハンドルを用いたものに差し替えています。
+lib.ymlでもMSX-DOS2であればファイル入出力ライブラリが使えますが、FCBを用いているためにMSX-DOS2ではカレントデディレクトリにしか対応していないので、サブディレクトリを使う場合はこちらを使用してください。
 
 
 ## ランタイムのパスについて

--- a/examples/slcopy.sl
+++ b/examples/slcopy.sl
@@ -1,0 +1,41 @@
+/*
+ファイル入出力ライブラリのテスト
+(fopen/fread/fwrite/fclose)
+
+使い方:
+slcopy コピー元ファイル名 コピー先ファイル名
+
+*/
+ORG	$100
+
+array byte buf[32768];
+
+main ()
+	var	n;
+{
+	n = $81;
+	while (MEM[n] == $20) {
+		++n;
+	}
+	if (fopen(0, n, 0) != 0) {
+		return;
+	}
+	while (MEM[n] > $20) {
+		++n;
+	}
+	if (fopen(1, n, 3) != 0) {
+		return;
+	}
+	while (1) {
+		n = fread(0, buf, 32768);
+		if (n == -1 || n == 0) {
+			exit;
+		}
+		if (fwrite(1, buf, n) != 0) {
+			print("Write error",/);
+			exit;
+		}
+	}
+	fclose(1);
+	fclose(0);
+}

--- a/examples/sltype.sl
+++ b/examples/sltype.sl
@@ -1,0 +1,28 @@
+/*
+
+ファイル入出力ライブラリのテスト
+(fopen/fgetc/fclose)
+
+使い方:
+sltype ファイル名
+
+*/
+ORG	$100
+
+main ()
+var	c;
+{
+	if (fopen(0, $81, 0) != 0) {
+		return;
+	}
+	while (1) {
+		c = fgetc(0);
+		if (c > $ff OR c == $1a) {
+			exit;
+		}
+		^DE = c;
+		^BC = 2;					//コンソール出力(_CONOUT)
+		CALL(5);
+	}
+	fclose(0);
+}

--- a/lib.yml
+++ b/lib.yml
@@ -29,6 +29,9 @@ LSXCALLS:
     CONST	EQU	$0B
     lSCRN EQU $EFD0
     lLOC EQU $EFD6
+    FCB1	EQU	005CH
+    FCB2	EQU	006CH
+    DTA1	EQU	0080H
 
 WIDTH:
   param_count: 1
@@ -497,6 +500,9 @@ FOPEN:
   code: |
     ; HL=fnum DE=fname addr BC=mode
     LD (LSXFCB),HL
+    LD A,C
+    AND 3
+    LD C,A
     LD (LSXFMODE),BC
 
     CALL LSXFCHECKNUM
@@ -511,7 +517,31 @@ FOPEN:
     CALL LSXCALCFCB
     LD (LSXFCB),HL
 
+    PUSH DE
+    LD C,$6F  ; _DOSVER
+    CALL BDOS
+    POP DE
+    LD A,B
+    CP 2
+    JR NC,.fopen_dos2
+    LD C,$29  ; _PPATH    ;for LSX-Dodgers
+    LD HL,(LSXFCB)
+    JR .fopen_lsx
+    .fopen_dos2           ;for MSX-DOS2
+    LD A,(DE)
+    CP $20
+    JR NZ,.fopen_dos2_1
+    INC DE
+    JR .fopen_dos2
+    .fopen_dos2_1
+    LD BC,$005B ; _PARSE
+    CALL BDOS
+    EX DE,HL
+    LD HL,(LSXFCB)
+    LD (HL),C
+    INC HL
     LD C,$5C  ; _PFILE
+    .fopen_lsx
     CALL BDOS
 
     LD HL,(LSXFMODE)
@@ -568,9 +598,42 @@ FSEEK:
     JP C,.fseek_head
 
     ; fseek_tail
-    ; not support!
-    LD HL,1
-    RET
+    PUSH DE
+    PUSH HL
+    LD BC,33
+    ADD HL,BC
+    EX DE,HL    ; DE=(FCB)Random record
+    POP HL
+    LD BC,16
+    ADD HL,BC   ; HL=(FCB)File size
+    EX (SP),HL
+    CALL NEGHL
+    EX (SP),HL
+    POP BC      ; BC=-offset
+
+    LD A,(HL)
+    INC HL
+    SCF
+    SBC A,C
+    LD (DE),A
+    INC DE
+
+    LD A,(HL)
+    INC HL
+    SBC A,B
+    LD (DE),A
+    INC DE
+
+    LD A,(HL)
+    INC HL
+    SBC A,0
+    LD (DE),A
+    INC DE
+
+    LD A,(HL)
+    SBC A,0
+    LD (DE),A
+    JR .fseek_end
 
     .fseek_head
     LD BC,33
@@ -803,10 +866,11 @@ FREAD:
 
     LD C,$27
     CALL BDOS
-
+    ADD A,1
+    SBC A,A
+    RET NC
     LD L,A
-    LD H,0
-
+    LD H,A  ;HL=$FFFF CF=1
     RET
 
 FWRITE:

--- a/libmsx2.yml
+++ b/libmsx2.yml
@@ -467,14 +467,10 @@ LSXFILE:
   code: |
     ; fnum to FCB address
     LSXCALCFCB:
-    PUSH BC
     PUSH DE
-    LD DE,37
-    CALL MULHLDE
     LD DE,LSXFCBS
     ADD HL,DE
     POP DE
-    POP BC
     RET
 
     ; HL >= 8 ?
@@ -512,13 +508,32 @@ FOPEN:
     RET
 
     .fopen1
-    ; LSXFCB=fnum*37+LSXFCBS
+    ; LSXFCB=fnum+LSXFCBS
+    .fopen_sp1           ;SPCUT
+    LD A,(DE)
+    CP $20
+    JR NZ,.fopen_sp2
+    INC DE
+    JR .fopen_sp1
+    .fopen_sp2
+
+    LD B,64
+    LD HL,LSXPATH
+    .fopen_path1
+    LD A,(DE)
+    CP $20+1
+    JR C,.fopen_path2
+    INC DE
+    LD (HL),A
+    INC HL
+    DJNZ .fopen_path1
+    .fopen_path2
+    XOR A
+    LD (HL),A
+
     LD HL,(LSXFCB)
     CALL LSXCALCFCB
     LD (LSXFCB),HL
-
-    LD C,$29  ; _PPATH
-    CALL BDOS
 
     LD HL,(LSXFMODE)
     ; mode >= 3
@@ -526,28 +541,24 @@ FOPEN:
     OR A
     SBC HL,DE
     JR C,.fopen2
-    LD C,$16  ; _FMAKE
+    LD BC,$2044  ; _CREATE
     JR .fopen3
     .fopen2
-    LD C,$0F  ; _FOPEN
+    LD C,$43  ; _OPEN
     .fopen3
-    LD DE,(LSXFCB)
+
+    LD DE,LSXPATH
+    XOR A
     CALL BDOS
-
-    ; SET RANDOM RECORD to 0(4bytes)
+    LD C,A
     LD HL,(LSXFCB)
-    LD DE,33
-    ADD HL,DE
-    LD (HL),0
-    INC HL
-    LD (HL),0
-    INC HL
-    LD (HL),0
-    INC HL
-    LD (HL),0
-
+    LD (HL),B
+    LD A,C
     LD L,A
-    LD H,0
+    ADD A,0FFH
+    SBC A,A
+    LD H,A
+    LD A,L
     RET
 
 FSEEK:
@@ -564,89 +575,23 @@ FSEEK:
     RET
 
     .fseek1
-    ; LSXFCB=fnum*37+LSXFCBS
+    ; LSXFCB=fnum+LSXFCBS
     CALL LSXCALCFCB
-    LD (LSXFCB),HL
-
-    LD A,C
-    CP 1
-    JP Z,.fseek_current
-    JP C,.fseek_head
-
-    ; fseek_tail
-    PUSH DE
-    PUSH HL
-    LD BC,33
-    ADD HL,BC
-    EX DE,HL    ; DE=(FCB)Random record
-    POP HL
-    LD BC,16
-    ADD HL,BC   ; HL=(FCB)File size
-    EX (SP),HL
-    CALL NEGHL
-    EX (SP),HL
-    POP BC      ; BC=-offset
-
-    LD A,(HL)
-    INC HL
-    SCF
-    SBC A,C
-    LD (DE),A
-    INC DE
-
-    LD A,(HL)
-    INC HL
-    SBC A,B
-    LD (DE),A
-    INC DE
-
-    LD A,(HL)
-    INC HL
-    SBC A,0
-    LD (DE),A
-    INC DE
-
-    LD A,(HL)
-    SBC A,0
-    LD (DE),A
-    JP .fseek_end
-
-    .fseek_head
-    LD BC,33
-    ADD HL,BC
-    LD (HL),E ; FCB+33
-    INC HL
-    LD (HL),D ; FCB+34
-    INC HL
-    LD (HL),0 ; FCB+35
-    INC HL
-    LD (HL),0 ; FCB=36
-
-    JP .fseek_end
-
-    .fseek_current
-    LD BC,33
-    ADD HL,BC
-
-    ; FCB+33-36 += DE
-    LD A,E
-    ADD A,(HL)
-    LD (HL),A
-    LD A,D
-    INC HL
-    ADC A,(HL)
-    LD (HL),A
-    INC HL
-    LD A,0
-    ADC A,(HL)
-    LD (HL),A
-    INC HL
-    LD A,0
-    ADC A,(HL)
-    LD (HL),A
-
-    .fseek_end
-    LD HL,0
+    LD B,(HL)
+    EX DE,HL
+    LD A,H
+    ADD A,A
+    SBC A,A
+    LD E,A
+    LD D,A
+    LD C,$4A  ; _SEEK
+    CALL BDOS
+    LD L,A
+    LD A,L
+    ADD A,0FFH
+    SBC A,A
+    LD H,A
+    LD A,L
     RET
 
 FGETC:
@@ -664,32 +609,14 @@ FGETC:
     RET
 
     .fgetc1
-    ; LSXFCB=fnum*37+LSXFCBS
+    ; LSXFCB=fnum+LSXFCBS
     CALL LSXCALCFCB
-    LD (LSXFCB),HL
+    LD B,(HL)
 
-    ; SET DTA
-    PUSH HL
     LD  DE,.fgetbuf
-    LD  C,$1A ; _SETDTA
+    LD  HL,1
+    LD  C,$48 ; _READ
     CALL  BDOS
-    POP HL
-
-    ; FCB head to DE
-    LD E,L
-    LD D,H
-
-    ; SET RECORD SIZE(FCB+14)
-    LD BC,14
-    ADD HL,BC
-    LD (HL),1
-    INC HL
-    LD (HL),0
-
-    LD HL,1     ; read record size
-
-    LD C,$27    ; _RDBLK
-    CALL BDOS
     CP 0
     JR NZ,.fgeterr
 
@@ -724,38 +651,15 @@ FPUTC:
     LD HL,255
     RET
 
-    .fgetc1
-    ; LSXFCB=fnum*37+LSXFCBS
+    .fputc1
+    ; LSXFCB=fnum+LSXFCBS
     CALL LSXCALCFCB
-    LD (LSXFCB),HL
+    LD B,(HL)
 
-
-    ; SET DTA
-    PUSH HL
-
-    LD HL,.fputbuf
-    LD (HL),E
-
-    LD  DE,.fputbuf
-    LD  C,$1A ; _SETDTA
+    LD  DE,.fgetbuf
+    LD  HL,1
+    LD  C,$49 ; _WRITE
     CALL  BDOS
-    POP HL
-
-    ; FCB head to DE
-    LD E,L
-    LD D,H
-
-    ; SET RECORD SIZE(FCB+14)
-    LD BC,14
-    ADD HL,BC
-    LD (HL),1
-    INC HL
-    LD (HL),0
-
-    LD HL,1     ; write record size
-
-    LD C,$26    ; _WRBLK
-    CALL BDOS
     CP 0
     JR NZ,.fputerr
 
@@ -785,45 +689,21 @@ FCLOSE:
   code: |
     ; HL=fnum
     CALL LSXCALCFCB
-    EX DE,HL
-    LD C,$10  ; _FCLOSE
+    LD B,(HL)
+    LD (HL),0
+    LD C,$45  ; _CLOSE
     CALL BDOS
     LD L,A
     LD H,0
     RET
 
 
-FREADWRITE:
-  code: |
-    ; SET DTA (DE)
-    PUSH BC
-    LD  C,$1A ; _SETDTA
-    CALL  BDOS
-
-    ; SET RECORD SIZE(FCB+14)
-    LD HL,(LSXFCB)
-    LD BC,14
-    ADD HL,BC
-    LD (HL),1
-    INC HL
-    LD (HL),0
-
-    POP BC
-
-    LD HL,(LSXFCB)  ; DE->FCB
-    EX DE,HL
-
-    LD L,C          ; HL->read record size
-    LD H,B
-
-    RET
 
 FREAD:
   calls:
     - LSXCALLS
     - FWORK
     - LSXFILE
-    - FREADWRITE
   code: |
     ; HL=fnum DE=address BC=size
 
@@ -834,15 +714,14 @@ FREAD:
     RET
 
     .fread1
-    ; LSXFCB=fnum*37+LSXFCBS
+    ; LSXFCB=fnum+LSXFCBS
     CALL LSXCALCFCB
-    LD (LSXFCB),HL
-
-    CALL FREADWRITE
-
-    LD C,$27
+    PUSH BC
+    LD B,(HL)
+    POP HL
+    LD C,$48 ; _READ
     CALL BDOS
-    ADD A,1
+    ADD A,$FF
     SBC A,A
     RET NC
     LD L,A
@@ -854,7 +733,6 @@ FWRITE:
     - LSXCALLS
     - FWORK
     - LSXFILE
-    - FREADWRITE
   code: |
     ; HL=fnum DE=address BC=size
 
@@ -865,13 +743,12 @@ FWRITE:
     RET
 
     .fread1
-    ; LSXFCB=fnum*37+LSXFCBS
+    ; LSXFCB=fnum+LSXFCBS
     CALL LSXCALCFCB
-    LD (LSXFCB),HL
-
-    CALL FREADWRITE
-
-    LD C,$26
+    PUSH BC
+    LD B,(HL)
+    POP HL
+    LD C,$49  ; _WRITE
     CALL BDOS
 
     LD L,A
@@ -881,10 +758,10 @@ FWRITE:
 
 FWORK:
   code: |
-    LSXFCBS: DS 37*8
+    LSXFCBS: DS 8
     LSXFCB: DW 0
     LSXFMODE: DW 0
-
+    LSXPATH: DS 64
 
 sSYSTEM:
   param_count: 0


### PR DESCRIPTION
- ファイル入出力ライブラリのMSX-DOS2対応(libmsx2.yml)
- FSEEKの2:ファイルの終端のサポート
- FREADの戻り値を変更
成功：HLに読み込んだバイト数
失敗：HLに-1($FFFF)