### PR TITLE
SLANGソースをアセンブラソースにコメントとして含めるオプションを追加

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -27,6 +27,8 @@ namespace SLANGCompiler
 
             [Option("case-sensitive", Required = false, HelpText = "Set symbols to be case-sensitive.")]
             public bool CaseSensitive { get; set; }
+            [Option("source-comment", Required = false, HelpText = "Include source code as comments.")]
+            public bool SourceComment { get; set; }
 
             [Value(0, Required = true, MetaName = "input files")]
             public IEnumerable<string> Files { get; set; }
@@ -99,6 +101,7 @@ namespace SLANGCompiler
             // ソースファイルで指定した変数名、関数名をそのまま使うか、使わないか
             parser.SetOriginalSymbolUse(opt.UseOriginalSymbol);
             parser.SetCaseSensitiveSymbol(opt.CaseSensitive);
+            parser.SetSourceComment(opt.SourceComment);
 
             // 環境名を設定する(設定されていない場合はLSX-Dodgers環境をデフォルトとする)
             string envName = opt.EnvironmentName;

--- a/SLANG/SLANG.Parser.cs
+++ b/SLANG/SLANG.Parser.cs
@@ -35,6 +35,8 @@ namespace SLANGCompiler.SLANG
 
         CodeOptimizer codeOptimizer;
 
+        bool isSourceComment;
+
 
         private int orgValue = 0x100;
         private int workAddressValue = -1;
@@ -360,6 +362,15 @@ namespace SLANGCompiler.SLANG
             errorTextWriter = errorWriter;
         }
 
+
+        /// <summary>
+        /// SLANGのソースコードをアセンブラソースにコメントとして含めるかどうかを設定する
+        /// </summary>
+        public void SetSourceComment(bool sourceComment)
+        {
+            this.isSourceComment = sourceComment;
+        }
+
         public void ParseConstExpr(string code, ConstTableManager constTableManager = null)
         {
             try
@@ -402,6 +413,7 @@ namespace SLANGCompiler.SLANG
                 slangScanner.currentFileName = "inner-code";
                 slangScanner.SetConstTableManager(constTableManager);
                 slangScanner.SetCodeRepository(codeRepository);
+                slangScanner.SetSourceComment(isSourceComment);
 
                 StartParse();
                 this.Parse();
@@ -434,6 +446,7 @@ namespace SLANGCompiler.SLANG
                 slangScanner.currentFileName = fileName;
                 slangScanner.SetConstTableManager(constTableManager);
                 slangScanner.SetCodeRepository(codeRepository);
+                slangScanner.SetSourceComment(isSourceComment);
 
                 StartParse();
                 genInitCode();

--- a/SLANG/SLANG.Scanner.cs
+++ b/SLANG/SLANG.Scanner.cs
@@ -6,10 +6,11 @@ namespace SLANGCompiler.SLANG
 {
     internal partial class SLANGScanner
     {
-
         CodeRepository codeRepository;
         ConstTableManager constTableManager;
         SLANGParser constParser = new SLANGParser();
+
+        private bool isSourceComment = false;
 
         public void SetCodeRepository(CodeRepository codeRepository)
         {
@@ -229,15 +230,25 @@ namespace SLANGCompiler.SLANG
 
         private void genSourceComment(string source)
         {
-
-            var comments = source.Replace("\r","").Split("\n");
-            foreach(var comment in comments)
+            if(isSourceComment)
             {
-                if(!string.IsNullOrEmpty(comment))
+                var comments = source.Replace("\r","").Split("\n");
+                foreach(var comment in comments)
                 {
-                    codeRepository.AddComment(comment);
+                    if(!string.IsNullOrEmpty(comment))
+                    {
+                        codeRepository.AddComment(comment);
+                    }
                 }
             }
+        }
+
+        /// <summary>
+        /// SLANGのソースコードをアセンブラソースにコメントとして含めるかどうかを設定する
+        /// </summary>
+        public void SetSourceComment(bool isSourceComment)
+        {
+            this.isSourceComment = isSourceComment;
         }
     }
 }


### PR DESCRIPTION
* --source-comment を追加するとソースがコメントとして含まれます