### PR TITLE
[WIP]FLOAT型の対応

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -92,3 +92,19 @@ UTF Unknown
 ------
 The library is subject to the Mozilla Public License Version 1.1 (the "License"). Alternatively, it may be used under the terms of either the GNU General Public License Version 2 or later (the "GPL"), or the GNU Lesser General Public License Version 2.1 or later (the "LGPL").
 
+z80float
+------
+   Copyright 2018 Zeda A.K. Thomas
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/SLANG/ConstTableManager.cs
+++ b/SLANG/ConstTableManager.cs
@@ -15,7 +15,9 @@ namespace SLANGCompiler.SLANG
     public enum ConstInfoType
     {
         /// <summary>数値型</summary>
-        Value,
+        IntValue,
+        /// <summary>浮動小数型</summary>
+        FloatValue,
         /// <summary>CODEアドレス参照型</summary>
         Code,
         String,
@@ -30,6 +32,7 @@ namespace SLANGCompiler.SLANG
         public ConstInfoType ConstInfoType { get; set; }
         /// <summary>CONST値(値)</summary>
         public int Value { get; set; }
+        public float FloatValue { get; set; }
         /// <summary>CONST値(CODEを参照する場合のシンボル名)</summary>
         public string SymbolString { get; set; }
 
@@ -38,8 +41,17 @@ namespace SLANGCompiler.SLANG
         /// <summary>値を持つCONST値のコンストラクタ</summary>
         public ConstInfo(int value)
         {
-            this.ConstInfoType = ConstInfoType.Value;
-            this.Value = value;
+            this.ConstInfoType = ConstInfoType.IntValue;
+            this.FloatValue = this.Value = value;
+            this.SymbolString = null;
+        }
+
+        /// <summary>FLOAT値を持つCONST値のコンストラクタ</summary>
+        public ConstInfo(float value)
+        {
+            this.ConstInfoType = ConstInfoType.FloatValue;
+            this.FloatValue = value;
+            this.Value = (int)value;
             this.SymbolString = null;
         }
 
@@ -54,10 +66,14 @@ namespace SLANGCompiler.SLANG
         /// <summary>CONST値の複製</summary>
         public ConstInfo Clone()
         {
-            if(ConstInfoType == ConstInfoType.Value)
+            if(ConstInfoType == ConstInfoType.IntValue)
             {
                 return new ConstInfo(Value);
+            } else if(ConstInfoType == ConstInfoType.FloatValue)
+            {
+                return new ConstInfo(FloatValue);
             } else {
+                // code or string
                 return new ConstInfo(SymbolString, ConstInfoType == ConstInfoType.Code);
             }
         }

--- a/SLANG/EnvironmentManager.cs
+++ b/SLANG/EnvironmentManager.cs
@@ -64,7 +64,7 @@ namespace SLANGCompiler.SLANG
                 // デフォルトのORGを設定
                 if(!string.IsNullOrEmpty(info.defaultOrg))
                 {
-                    var orgNum = SLANGCommonUtility.GetValue(info.defaultOrg);
+                    var orgNum = SLANGCommonUtility.GetIntValue(info.defaultOrg);
                     orgSetter.SetOrg(orgNum);
                 }
 

--- a/SLANG/Expr.cs
+++ b/SLANG/Expr.cs
@@ -316,6 +316,15 @@ namespace SLANGCompiler.SLANG
             return Opcode == Opcode.Const && ConstValue.ConstInfoType == ConstInfoType.FloatValue;
         }
 
+        public bool IsFloat()
+        {
+            if(OpType == OperatorType.Float)
+            {
+                return true;
+            }
+            return Opcode == Opcode.Const && ConstValue.ConstInfoType == ConstInfoType.FloatValue;
+        }
+
         /// <summary>
         /// CONST値を文字列で返す
         /// </summary>
@@ -350,7 +359,7 @@ namespace SLANGCompiler.SLANG
             }
 
             // キャストでは(他の)レジスタは変化しないので、キャストの下を対象としてチェックする
-            if(Opcode == Opcode.WtoB || Opcode == Opcode.BtoW)
+            if(Opcode == Opcode.WtoB || Opcode == Opcode.BtoW || Opcode == Opcode.FtoW || Opcode == Opcode.WtoF)
             {
                 checkTarget = Left;
             }

--- a/SLANG/SLANG.Language.analyzer.lex
+++ b/SLANG/SLANG.Language.analyzer.lex
@@ -77,7 +77,8 @@ CHRD  [Cc][Hh][Rr]\$
 SPCD  [Ss][Pp][Cc]\$
 CRD   [Cc][Rr]\$
 TABD  [Tt][Aa][Bb]\$
-STRFUNC {FORMD}|{DECID}|{PND}|{HEX2D}|{HEX4D}|{MSGD}|{MSXD}|{STRD}|{CHRD}|{SPCD}|{CRD}|{TABD}
+FLD   [Ff][Ll]\$
+STRFUNC {FORMD}|{DECID}|{PND}|{HEX2D}|{HEX4D}|{MSGD}|{MSXD}|{STRD}|{CHRD}|{SPCD}|{CRD}|{TABD}|{FLD}
 
 %{
     StringBuilder lexStrBuffer = null;

--- a/SLANG/SLANG.Language.analyzer.lex
+++ b/SLANG/SLANG.Language.analyzer.lex
@@ -20,10 +20,11 @@ Eol             (\r\n?|\n)
 dotchr          [^\r\n]
 NotWh           [^ \t\r\n]
 Space           [ \t]
-Number          ([0-9]+|$[0-9a-fA-F]+|[0-9a-fA-F]+[Hh]|[01]+[Bb])|0x[0-9a-fA-F]+
+Number          ([0-9]+|[0-9]+\.[0-9]+|$[0-9a-fA-F]+|[0-9a-fA-F]+[Hh]|[01]+[Bb])|0x[0-9a-fA-F]+
 IdentSymbol     [_@\^]
 Identifier      ({IdentSymbol}|[a-zA-Z\u3041-\u3096\u30A1-\u30FA々〇〻\u3400-\u9FFF\uF900-\uFAFF\uD840-\uD87F\uDC00-\uDFFF])({IdentSymbol}|[0-9a-zA-Z\u3041-\u3096\u30A1-\u30FA々〇〻\u3400-\u9FFF\uF900-\uFAFF\uD840-\uD87F\uDC00-\uDFFF])*
 
+FLOAT   \%\%
 
 PREIF   #[Ii][Ff]
 PREELSE #[Ee][Ll][Ss][Ee]
@@ -176,6 +177,7 @@ STRFUNC {FORMD}|{DECID}|{PND}|{HEX2D}|{HEX4D}|{MSGD}|{MSXD}|{STRD}|{CHRD}|{SPCD}
 
 {STRFUNC}       { yylval.symbol = yytext; return (int)Token.STRFUNC; }
 {EXC}           { yylval.symbol = "!"; return (int)Token.EXC; }
+{FLOAT}         { return (int)Token.FLOAT; }
 
 {Eol}           { LocationNextLine(); nextBraceIsArray = false;
                 genSourceComment(buffer.GetString(prevTokEPos,tokEPos));

--- a/SLANG/SLANG.Language.grammar.y
+++ b/SLANG/SLANG.Language.grammar.y
@@ -29,7 +29,7 @@
 %token <constValue>  CONSTANT
 %token <str>         STRING PLAIN
 %token <symbol> EXC
-%token               VAR BYTE WORD ARRAY CONST PER
+%token               VAR BYTE WORD FLOAT ARRAY CONST PER
 %token IF THEN ELSE ELIF ENDIF
 %token WHILE DO WEND REPEAT UNTIL CASE OTHERS OF LOOP
 %token FOR TO DOWNTO NEXT
@@ -487,9 +487,14 @@ declarator
        : byte_spec declarator2 { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Byte, $2); }
        | byte_spec declarator2 OP_EQ begin code_expr_list end { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Byte, $2.SetInitialValueCode($5)); }
        | byte_spec declarator2 OP_EQ expr { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Byte, $2.UpdateIdentifier( null, $4)); }
+
        | word_spec declarator2 OP_EQ begin code_expr_list end { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Word, $2.SetInitialValueCode($5)); }
        | word_spec declarator2 { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Word, $2); }
        | word_spec declarator2 OP_EQ expr { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Word, $2.UpdateIdentifier(null, $4)); }
+
+       | float_spec declarator2 OP_EQ begin code_expr_list end { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Float, $2.SetInitialValueCode($5)); }
+       | float_spec declarator2 { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Float, $2); }
+       | float_spec declarator2 OP_EQ expr { $$ = Tree.CreateIdentifierTypeTree(TypeDataSize.Float, $2.UpdateIdentifier(null, $4)); }
        ;
 
 // 宣言のWORDは省略可能
@@ -501,6 +506,10 @@ word_spec
 byte_spec
        : BYTE
        | EXC
+       ;
+
+float_spec
+       : FLOAT
        ;
 
 declarator2

--- a/SLANG/SLANG.Parser.CodeGen.cs
+++ b/SLANG/SLANG.Parser.CodeGen.cs
@@ -289,19 +289,33 @@ namespace SLANGCompiler.SLANG
                             var varExpr = (Expr)obj[idx];
                             var symbol = varExpr.Symbol;
 
+
                             string baseAdr;
                             string offsetAdr = "";
+                            int offsetValue = varExpr.SymbolOffset;
+
+                            if(i+1 < format.Length)
+                            {
+                                var ofsChar = format[i+1];
+                                if(ofsChar >= 0x30 && ofsChar <= 0x39)
+                                {
+                                    // オフセット値として有効
+                                    offsetValue = offsetValue >= 0 ? offsetValue + (ofsChar - 0x30) : (ofsChar - 0x30);
+                                    i++;
+                                }
+                            }
+
                             if(symbol.Address != null)
                             {
                                 // 数値なので加算してやる
-                                var ofs = varExpr.SymbolOffset >= 0 ? varExpr.SymbolOffset : 0;
+                                var ofs = offsetValue;
                                 var adr = symbol.Address.GetConstStr(symbolTableManager);
                                 sb.Append($"({adr}+${ofs:X4})");
                             } else {
                                 baseAdr = $"{symbol.LabelName}";
-                                if(varExpr.SymbolOffset > 0)
+                                if(offsetValue > 0)
                                 {
-                                    offsetAdr = $"+{varExpr.SymbolOffset}";
+                                    offsetAdr = $"+{offsetValue}";
                                 }
                                 sb.Append($"({baseAdr}{offsetAdr})");
                             }
@@ -360,7 +374,7 @@ namespace SLANGCompiler.SLANG
             {
                 case Opcode.Add:
                 {
-                    genadd(left, right);
+                    genadd(left, right, expr.OpType);
                     break;
                 }
                 case Opcode.Sub:
@@ -456,7 +470,11 @@ namespace SLANGCompiler.SLANG
             Expr left = expr.Left;
             Expr right = expr.Right;
 
+            // BYTE or WORD or FLOAT
+            TypeDataSize assignType = left.TypeInfo.GetDataSize();
             bool isByte = left.TypeInfo.GetDataSize() == TypeDataSize.Byte;
+            bool isWord = left.TypeInfo.GetDataSize() == TypeDataSize.Word;
+            bool isFloat = left.TypeInfo.GetDataSize() == TypeDataSize.Float;
 
             if(left.Opcode == Opcode.PortAccess)
             {
@@ -475,18 +493,17 @@ namespace SLANGCompiler.SLANG
                 var symbol = left.Left.Symbol;
                 var typeInfo = left.Left.Symbol.TypeInfo;
 
-
                 if(symbol.SymbolClass == SymbolClass.Param || symbol.SymbolClass == SymbolClass.Local)
                 {
                     var ofs = symbol.Address.GetConstStr(symbolTableManager) + "+" + left.Left.SymbolOffset;
                     if(right.IsConst())
                     {
-                        if(right.IsValueConst())
+                        if(right.IsIntValueConst())
                         {
                             var lowVal = right.ConstValue.Value & 0xff;
                             var highVal = (right.ConstValue.Value >> 8) & 0xff;
                             gencode($" LD (IY+{ofs}),{lowVal}\n");
-                            if(!isByte)
+                            if(isWord)
                             {
                                 gencode($" LD (IY+{ofs}+1),{highVal}\n");
                             }
@@ -499,7 +516,7 @@ namespace SLANGCompiler.SLANG
                             if(constStr != null)
                             {
                                 gencode($" LD (IY+{ofs}),LOW {constStr}\n");
-                                if(!isByte)
+                                if(isWord)
                                 {
                                     gencode($" LD (IY+{ofs}+1),HIGH {constStr}\n");
                                 }
@@ -511,6 +528,10 @@ namespace SLANGCompiler.SLANG
                         if(!isByte)
                         {
                             gencode($" LD (IY+{ofs}+1),H\n");
+                        }
+                        if(isFloat)
+                        {
+                            gencode($" LD (IY+{ofs}+2),A\n");
                         }
                     }
                 } else {
@@ -531,6 +552,12 @@ namespace SLANGCompiler.SLANG
                         {
                             gencode(" EX DE,HL\n");
                         }
+                    } else if(isFloat)
+                    {
+                        // AHLを代入(うーん)
+                        genexp(right);
+                        gencode(" LD %v,HL\n", left.Left);
+                        gencode(" LD %v2,A\n", left.Left);
                     } else{
                         genexp(right);
                         gencode(" LD %v,HL\n", left.Left);
@@ -631,7 +658,7 @@ namespace SLANGCompiler.SLANG
             if(expr.Left.IsConst())
             {
                 var constExpr = expr.Left;
-                if(constExpr.IsValueConst())
+                if(constExpr.IsIntValueConst())
                 {
                     var val = ~expr.ConstValue.Value;
                     gencode($" LD HL,{val}\n");
@@ -651,7 +678,7 @@ namespace SLANGCompiler.SLANG
             if(expr.Left.IsConst())
             {
                 var constExpr = expr.Left;
-                if(constExpr.IsValueConst())
+                if(constExpr.IsIntValueConst())
                 {
                     var val = expr.ConstValue.Value * -1;
                     gencode($" LD HL,{val}\n");
@@ -671,7 +698,7 @@ namespace SLANGCompiler.SLANG
             if(expr.Left.IsConst())
             {
                 var constExpr = expr.Left;
-                if(constExpr.IsValueConst())
+                if(constExpr.IsIntValueConst())
                 {
                     var val = expr.ConstValue.Value == 0 ? 1 : 0;
                     gencode($" LD HL,{val}\n");
@@ -687,7 +714,7 @@ namespace SLANGCompiler.SLANG
         }
 
         // 加算式を出力する
-        private void genadd(Expr left, Expr right)
+        private void genadd(Expr left, Expr right, OperatorType opType)
         {
             if(left.IsConst())
             {
@@ -709,7 +736,7 @@ namespace SLANGCompiler.SLANG
                     {
                         gencode($" LD DE,{right.ConstValue.SymbolString}\n");
                         gencode($" ADD HL,DE\n");
-                    } else {
+                    } else if(right.IsIntValueConst()){
                         // 4加算まではINCにしてそれ以上は普通に足してみる
                         var constVal = right.ConstValue.Value;
                         if(constVal < 4)
@@ -722,6 +749,15 @@ namespace SLANGCompiler.SLANG
                             gencode($" LD DE,{constVal}\n");
                             gencode($" ADD HL,DE\n");
                         }
+                    } else if(right.IsFloatValueConst())
+                    {
+                        // Floatの定数加算
+                        // DEの指定だが、CDE に入る
+                        genld(Register.DE, right, TypeDataSize.Float);
+                        genRuntimeCall("f24add");
+                        // AHLに計算結果が入る
+                    } else {
+                        Error("can not add.");
                     }
                 }
                 // TODO 本当に全ての演算はキャストされるのか？後でチェック。
@@ -738,6 +774,9 @@ namespace SLANGCompiler.SLANG
                 //        gencode($" ADD L,{right.Value}\n");
                 //    }
                 //}
+            } else if(opType == OperatorType.Float)
+            {
+                genFloatCall("f24add", left, right);
             } else if(right.CanLoadDirect())
             {
                 // これとここの下、Byte加算に対応していないので注意(手前で左右ともにWORDになっているはず)
@@ -759,10 +798,47 @@ namespace SLANGCompiler.SLANG
             }
         }
 
+        private void genFloatCall1(string funcStr, Expr left)
+        {
+            genexp(left);
+            genRuntimeCall(funcStr);
+        }
+
+        private void genFloatCall(string funcStr, Expr left, Expr right)
+        {
+            if(right.CanLoadDirect())
+            {
+                genexp(left);
+                genld(Register.DE, right, TypeDataSize.Float);
+                genRuntimeCall(funcStr);
+            } else if(left.CanLoadDirect())
+            {
+                genexp(right);
+                gencode(" EX DE,HL\n");
+                gencode(" LD C,A\n");
+                genld(Register.HL, left, TypeDataSize.Float);
+                genRuntimeCall(funcStr);
+            } else {
+                // 24bit保存でいいはずだが、諦める(で、いいのか？)
+                genexp(left);
+                gencode(" PUSH AF\n");
+                gencode(" PUSH HL\n");
+                genexp(right);
+                gencode(" EX DE,HL\n");
+                gencode(" LD C,A\n");
+                gencode(" POP HL\n");
+                gencode(" POP AF\n");
+                genRuntimeCall(funcStr);
+            }
+        }
+
         // 減算式を生成する
         private void gensub(Expr left, Expr right)
         {
-            if(right != null && right.IsConst())
+            if(left.OpType == OperatorType.Float || right.OpType == OperatorType.Float)
+            {
+                genFloatCall("f24sub", left, right);
+            } else if(right != null && right.IsConst())
             {
                 if(right.ConstValue.ConstInfoType == ConstInfoType.Code)
                 {
@@ -827,15 +903,51 @@ namespace SLANGCompiler.SLANG
         private void genmul(Expr left, Expr right, bool isUnsigned = true)
         {
             string callName = isUnsigned ? "MULHLDE" : "MULHLDE";       // Signedは無い？
+
             if(left.IsConst())
             {
                 var tmp = left;
                 left = right;
                 right = tmp;
             }
-            if(right.IsConst() && isUnsigned)
+            if(left.OpType == OperatorType.Float || right.OpType == OperatorType.Float)
             {
-                if(!right.IsValueConst())
+                if(right.IsValueConst())
+                {
+                    var floatValue = right.GetConstFloatValue();
+                    int mulValue = 0;
+                    if(floatValue == 2.0f)
+                    {
+                        mulValue = 2;
+                    } else if(floatValue == 3.0f)
+                    {
+                        mulValue = 3;
+                    } else if(floatValue == 4.0f)
+                    {
+                        mulValue = 4;
+                    }
+                    // 2, 3, 4倍は最適化可能
+                    if(mulValue > 0)
+                    {
+                        if(mulValue == 2)
+                        {
+                            genFloatCall1("f24mul2", left);
+                        } else if(mulValue == 3)
+                        {
+                            genFloatCall1("f24mul3", left);
+                        } else if(mulValue == 4)
+                        {
+                            genFloatCall1("f24mul2", left);
+                            genRuntimeCall("f24mul2");
+                        }
+                        return;
+                    }
+                }
+
+                genFloatCall("f24mul", left, right);
+            } else if(right.IsConst() && isUnsigned)
+            {
+                if(!right.IsIntValueConst())
                 {
                     Error("CODE Const can not mul");
                     return;
@@ -890,7 +1002,7 @@ namespace SLANGCompiler.SLANG
         {
             if(left.IsConst() && right.IsConst())
             {
-                if(!left.IsValueConst() || !right.IsValueConst())
+                if(!left.IsIntValueConst() || !right.IsIntValueConst())
                 {
                     Error("CODE Const can not shift");
                     return;
@@ -1028,20 +1140,37 @@ namespace SLANGCompiler.SLANG
             Expr left = expr.Left;
             Expr right = expr.Right;
             OperatorType opType = left.OpType;
+            var isFloatCompare = adjust(left, right) == OperatorType.Float;
+
 
             if(DebugEnabled)
             {
                 Console.WriteLine("gencompare:" + opType);
             }
-            ComparisonOp boolOp = expr.ComparisonOp;;
-            if(expr.ComparisonOp == ComparisonOp.SGt || expr.ComparisonOp == ComparisonOp.SLe)
+            ComparisonOp boolOp = expr.ComparisonOp;
+            if(isFloatCompare)
+            {
+                // Floatの比較は強制的に符号ありになる(内部的には符号なしOpに差し替える)
+                switch(boolOp)
+                {
+                    case ComparisonOp.SGt:
+                        boolOp = ComparisonOp.Gt;
+                        break;
+                    case ComparisonOp.SLe:
+                        boolOp = ComparisonOp.Le;
+                        break;
+                }
+            }
+
+
+            if(boolOp == ComparisonOp.SGt || boolOp == ComparisonOp.SLe)
             {
                 string[] boolCalls = new string[]
                 {
                     "OPSGTHLDE",
                     "OPSLEHLDE"
                 };
-                var callName = boolCalls[expr.ComparisonOp == ComparisonOp.SGt ? 0 : 1];
+                var callName = boolCalls[boolOp == ComparisonOp.SGt ? 0 : 1];
                 if(right.CanLoadDirect())
                 {
                     genexp(left);
@@ -1061,16 +1190,22 @@ namespace SLANGCompiler.SLANG
                 gencondjump(opType, ComparisonOp.Neq, trueLabelNum, falseLabelNum);
             } else {
                 // 右が0でEQ or NEQの場合はいちいちSBCしないで0かどうかのみ調べる
-                if(right.IsValueConst() && right.ConstValue.Value == 0 && (expr.ComparisonOp == ComparisonOp.Eq || expr.ComparisonOp == ComparisonOp.Neq))
+                if(right.IsIntValueConst() && right.ConstValue.Value == 0 && (boolOp == ComparisonOp.Eq || boolOp == ComparisonOp.Neq))
                 {
                     genexp(left);
                     gencode(" LD A,H\n");
+                    gencode(" OR L\n");
+                } else if(right.IsFloatValueConst() && right.ConstValue.FloatValue == 0f && (boolOp == ComparisonOp.Eq || boolOp == ComparisonOp.Neq))
+                {
+                    genexp(left);
+                    // A or H or L
+                    gencode(" OR H\n");
                     gencode(" OR L\n");
                 } else {
                     // この場合は逆条件にしないといけない？
                     if(trueLabelNum == 0)
                     {
-                        switch(expr.ComparisonOp)
+                        switch(boolOp)
                         {
                             case ComparisonOp.Gt:
                             {
@@ -1091,19 +1226,24 @@ namespace SLANGCompiler.SLANG
                         }
                     }
 
-                    if(right.CanLoadDirect())
+                    if(isFloatCompare)
                     {
-                        genexp(left);
-                        genld(Register.DE, right);
-                        gencode(" OR A\n");
-                        gencode(" SBC HL,DE\n");
+                        genFloatCall("f24cmp",left, right);
                     } else {
-                        genexp(right);
-                        gencode(" PUSH HL\n");
-                        genexp(left);
-                        gencode(" POP DE\n");
-                        gencode(" OR A\n");
-                        gencode(" SBC HL,DE\n");
+                        if(right.CanLoadDirect())
+                        {
+                            genexp(left);
+                            genld(Register.DE, right);
+                            gencode(" OR A\n");
+                            gencode(" SBC HL,DE\n");
+                        } else {
+                            genexp(right);
+                            gencode(" PUSH HL\n");
+                            genexp(left);
+                            gencode(" POP DE\n");
+                            gencode(" OR A\n");
+                            gencode(" SBC HL,DE\n");
+                        }
                     }
                 }
                 gencondjump(opType, boolOp, trueLabelNum, falseLabelNum);
@@ -1226,6 +1366,26 @@ namespace SLANGCompiler.SLANG
                 genexp(expr);
             }
         }
+        
+        // WORDをFLOATにキャスト
+        private void genwtof(Expr expr)
+        {
+            if(expr != null)
+            {
+                genexp(expr);
+                genRuntimeCall("i16tof24");
+            }
+        }
+
+        // FLOATをWORDにキャスト
+        private void genftow(Expr expr)
+        {
+            if(expr != null)
+            {
+                genexp(expr);
+                genRuntimeCall("f24toi16");
+            }
+        }
 
         // 比較ジャンプを生成する
         private void genbool(Expr expr, int trueLabelNum, int falseLabelNum)
@@ -1316,6 +1476,7 @@ namespace SLANGCompiler.SLANG
             if(runtimeSymbol == null)
             {
                 Error($"can not found runtime call {runtimeName}");
+                return;
             }
             if(runtimeSymbol.Address != null)
             {
@@ -1344,7 +1505,10 @@ namespace SLANGCompiler.SLANG
             {
                 callName = "S" + callName;
             }
-            if(right != null && right.IsConst() && isUnsigned)
+            if(left.OpType == OperatorType.Float || right.OpType == OperatorType.Float)
+            {
+                genFloatCall(isDiv ? "f24div" : "f24mod", left, right);
+            } else if(right != null && right.IsConst() && isUnsigned)
             {
                 // HL / DEまたはHL % DEで、HLに返す
                 genexp(left);
@@ -1381,9 +1545,15 @@ namespace SLANGCompiler.SLANG
                     if(symbol.TypeInfo.GetDataSize()== TypeDataSize.Byte)
                     {
                         gencode($" LD L,(IY+{ofs})\n");
-                    } else {
+                    } else if(typeInfo.GetDataSize() == TypeDataSize.Word)
+                    {
                         gencode($" LD L,(IY+{ofs})\n");
                         gencode($" LD H,(IY+{ofs+1})\n");
+                    } else if(typeInfo.GetDataSize() == TypeDataSize.Float)
+                    {
+                        gencode($" LD L,(IY+{ofs})\n");
+                        gencode($" LD H,(IY+{ofs+1})\n");
+                        gencode($" LD A,(IY+{ofs+2})\n");
                     }
                 } else {
                     var isIndirect = symbol.TypeInfo.IsIndirectType();
@@ -1391,8 +1561,13 @@ namespace SLANGCompiler.SLANG
                     {
                         gencode(" LD HL,%a\n", expr.Left);
                         gencode(" LD L,(HL)\n");
-                    } else {
+                    } else if(typeInfo.GetDataSize() == TypeDataSize.Word)
+                    {
                         gencode(" LD HL,%v\n", expr.Left);
+                    } else if(typeInfo.GetDataSize() == TypeDataSize.Float)
+                    {
+                        gencode(" LD HL,%v\n", expr.Left);
+                        gencode(" LD A,%v2\n", expr.Left);
                     }
                 }
             } else if(expr.Left.Opcode == Opcode.Indir && expr.Left.Left.Opcode == Opcode.Adr)
@@ -1773,7 +1948,7 @@ namespace SLANGCompiler.SLANG
             // HLに現在のFOR変数の値が入っているのでそれを使うと良い
             if(forExpr.IsConst())
             {
-                if(!forExpr.IsValueConst())
+                if(!forExpr.IsIntValueConst())
                 {
                     Error("for expr is not value const");
                     return;
@@ -1857,8 +2032,14 @@ namespace SLANGCompiler.SLANG
                     } else if(expr.ConstValue.ConstInfoType == ConstInfoType.String)
                     {
                         gencode($" LD HL,{expr.ConstValue.SymbolString}\n");
-                    } else {
+                    } else if(expr.ConstValue.ConstInfoType == ConstInfoType.IntValue){
                         gencode($" LD HL,{expr.ConstValue.Value}\n");
+                    } else if(expr.ConstValue.ConstInfoType == ConstInfoType.FloatValue){
+                        // 浮動小数点値を24bit floatに変換する
+                        var f24Val = SLANGCommonUtility.ValueToFloat24(expr.ConstValue.FloatValue);
+                        gencode($"; float : {expr.ConstValue.FloatValue}\n");
+                        gencode($" LD HL,${f24Val & 0xffff:X2}\n");
+                        gencode($" LD A,${(f24Val >> 16) & 0xff:X1}\n");
                     }
                     break;
                 }
@@ -1875,7 +2056,7 @@ namespace SLANGCompiler.SLANG
                 }
                 case Opcode.Add:
                 {
-                    genadd(left, right);
+                    genadd(left, right, expr.OpType);
                     break;
                 }
                 case Opcode.Sub:
@@ -1999,6 +2180,16 @@ namespace SLANGCompiler.SLANG
                     genwtob(expr.Left);
                     break;
                 }
+                case Opcode.WtoF:
+                {
+                    genwtof(expr.Left);
+                    break;
+                }
+                case Opcode.FtoW:
+                {
+                    genftow(expr.Left);
+                    break;
+                }
                 case Opcode.PostInc:
                 case Opcode.PostDec:
                 case Opcode.PreInc:
@@ -2042,6 +2233,12 @@ namespace SLANGCompiler.SLANG
             var targetReg = register.GetCode();
             var regLow    = targetReg.Substring(1, 1);
             var regHigh   = targetReg.Substring(0, 1);
+            string higherReg = "A";
+            if(register == Register.DE)
+            {
+                higherReg = "C";
+            }
+
 
             var targetExpr = expr;
             // BtoW または WtoB の場合は leftがcanLoadDirectであれば代入してからBtoW、WtoBの処理をする
@@ -2053,7 +2250,7 @@ namespace SLANGCompiler.SLANG
             // DE or HLにexprを代入する
             if(targetExpr.IsConst())
             {
-                if(targetExpr.IsValueConst())
+                if(targetExpr.IsIntValueConst())
                 {
                     var val = targetExpr.ConstValue.Value;
                     switch(dataSize)
@@ -2063,6 +2260,26 @@ namespace SLANGCompiler.SLANG
                             break;
                         default:
                             gencode($" LD {targetReg},{val}\n");
+                            break;
+                    }
+                } else if(targetExpr.IsFloatValueConst())
+                {
+                    var val = (int)targetExpr.ConstValue.FloatValue;
+                    var f24Val = SLANGCommonUtility.ValueToFloat24(targetExpr.ConstValue.FloatValue);
+
+                    // BYTE、WORDに入れる場合はここで小数部を削除してから代入してやる
+                    switch(dataSize)
+                    {
+                        case TypeDataSize.Byte:
+                            gencode($" LD {regLow},{val & 0xff}\n");
+                            break;
+                        case TypeDataSize.Word:
+                            gencode($" LD {targetReg},{val}\n");
+                            break;
+                        default:
+                            // float value
+                            gencode($" LD {targetReg},${f24Val & 0xffff:X2}\n");
+                            gencode($" LD {higherReg},${(f24Val >> 16) & 0xff:X}\n");
                             break;
                     }
                 } else {
@@ -2109,6 +2326,18 @@ namespace SLANGCompiler.SLANG
                     {
                         gencode($" LD A,%v\n", targetExpr.Left);
                         gencode($" LD {regLow},A\n");
+                    } else if(targetExpr.Left.Symbol.TypeInfo.IsFloatTypeInfo())
+                    {
+                        gencode($" LD {targetReg},%v\n", targetExpr.Left);
+                        if(higherReg == "A")
+                        {
+                            gencode($" LD {higherReg},%v2\n", targetExpr.Left);
+                        } else {
+                            gencode(" EX AF,AF'\n");
+                            gencode($" LD A,%v2\n", targetExpr.Left);
+                            gencode($" LD {higherReg},A\n");
+                            gencode(" EX AF,AF'\n");
+                        }
                     } else {
                         gencode($" LD {targetReg},%v\n", targetExpr.Left);
                     }
@@ -2223,13 +2452,13 @@ namespace SLANGCompiler.SLANG
 
             if(right.IsConst())
             {
-                if(!right.IsValueConst())
+                if(!right.IsIntValueConst())
                 {
                     Error("const scaled error");
                     return;
                 }
                 // 二次元配列の添字が両方とも定数の場合は混ぜられる
-                if(left.Opcode == Opcode.ScaleAdd && left.Right.IsValueConst())
+                if(left.Opcode == Opcode.ScaleAdd && left.Right.IsIntValueConst())
                 {
                     int rightScale = computeSize(left.Left.TypeInfo.Parent) * left.Right.ConstValue.Value;
                     genld(Register.HL, left.Left, TypeDataSize.Word);

--- a/SLANG/SLANG.Parser.Common.cs
+++ b/SLANG/SLANG.Parser.Common.cs
@@ -16,6 +16,10 @@ namespace SLANGCompiler.SLANG
         HL,
         DE,
         BC,
+        A,
+        C,
+
+        Invalid
     }
     public static partial class RegisterExtend {
             private static readonly string[] registerString = new string[]
@@ -23,6 +27,9 @@ namespace SLANGCompiler.SLANG
                 "HL",
                 "DE",
                 "BC",
+                "A",
+                "C",
+                "(Invalid)"
             };
             /// <summary>
             /// レジスタを示すenum値をZ80ニーモニックとして返す

--- a/SLANG/SLANG.Parser.Expr.cs
+++ b/SLANG/SLANG.Parser.Expr.cs
@@ -366,6 +366,7 @@ namespace SLANGCompiler.SLANG
             {"SPC$",  "PSPC" },
             {"CR$",   "PCR" },
             {"TAB$",  "PTAB" },
+            {"FL$", "PFLOAT"}
         };
 
         // 文字列関数呼び出し式を作る
@@ -410,7 +411,12 @@ namespace SLANGCompiler.SLANG
                 }
                 if(param.TypeInfo.IsNumeric())
                 {
-                    p.Expr = coerce(param, OperatorType.Word);
+                    if(param.OpType == OperatorType.Float)
+                    {
+                        p.Expr = coerce(param, OperatorType.Float);
+                    } else {
+                        p.Expr = coerce(param, OperatorType.Word);
+                    }
                 }
                 paramCount++;
             }
@@ -788,7 +794,12 @@ namespace SLANGCompiler.SLANG
             {
                 return logNot(enBool(expr));
             }
-            return makeNode1(opcode, OperatorType.Word, expr.TypeInfo, coerce(expr, OperatorType.Word));
+            var opType = expr.OpType;
+            if(opType == OperatorType.Byte)
+            {
+                opType = OperatorType.Word;
+            }
+            return makeNode1(opcode, opType, expr.TypeInfo, coerce(expr, opType));
         }
 
         // 論理NOT式を作る
@@ -902,12 +913,12 @@ namespace SLANGCompiler.SLANG
             OperatorType opType = adjust(left, right);
 
             // BYTE加算は対応していないのでWORDにする
-            if(opType == OperatorType.Byte)
+            if(opType == OperatorType.Byte || opType == OperatorType.Constant)
             {
                 opType = OperatorType.Word;
             }
 
-            // このタイミングでWord or Floatのはずだが、念のためエラーを出してやる
+            // このタイミングでWord or Float or Constantのはずだが、念のためエラーを出してやる
             if(opType != OperatorType.Word && opType != OperatorType.Float)
             {
                 Error($"could not add type : {opType}");

--- a/SLANG/SLANG.Parser.Expr.cs
+++ b/SLANG/SLANG.Parser.Expr.cs
@@ -120,6 +120,62 @@ namespace SLANGCompiler.SLANG
             return 0;
         }
 
+        // 演算子により左右の式を1つにまとめた定数を得る(float版)
+        private float fold2(Opcode opcode, float leftValue, float rightValue)
+        {
+            switch(opcode)
+            {
+                //case Opcode.Plus: return leftValue + rightValue;
+                //case Opcode.Minus: return leftValue - rightValue;
+                case Opcode.Add: return leftValue + rightValue;
+                case Opcode.Sub: return leftValue - rightValue;
+                case Opcode.Mul:
+                case Opcode.SMul:
+                    return leftValue * rightValue;
+                case Opcode.Div:
+                    return leftValue / rightValue;
+                case Opcode.SDiv:
+                    return (short)leftValue / (short)rightValue;
+                case Opcode.Mod:
+                    return leftValue % rightValue;
+                case Opcode.SMod:
+                    return (short)leftValue % (short)rightValue;
+                case Opcode.Shl:
+                    return (int)leftValue << (int)rightValue;
+                case Opcode.SShl:
+                    return (short)leftValue << (short)rightValue;
+                case Opcode.Shr:
+                    return (int)leftValue >> (int)rightValue;
+                case Opcode.SShr:
+                    return (short)leftValue >> (short)rightValue;
+                case Opcode.And:
+                    return (int)leftValue & (int)rightValue;
+                case Opcode.Or:
+                    return (int)leftValue | (int)rightValue;
+                case Opcode.Eq: return leftValue == rightValue ? 1 : 0;
+                case Opcode.Neq: return leftValue != rightValue ? 1 : 0;
+
+                case Opcode.Gt:
+                    return leftValue > rightValue ? 1 : 0;
+                case Opcode.SGt:
+                    return (short)leftValue > (short)rightValue ? 1 : 0;
+                case Opcode.Ge:
+                    return leftValue >= rightValue ? 1 : 0;
+                case Opcode.SGe:
+                    return (short)leftValue >= (short)rightValue ? 1 : 0;
+                case Opcode.Lt:
+                    return leftValue < rightValue ? 1 : 0;
+                case Opcode.SLt:
+                    return (short)leftValue < (short)rightValue ? 1 : 0;
+                case Opcode.Le:
+                    return leftValue <= rightValue ? 1 : 0;
+                case Opcode.SLe:
+                    return (short)leftValue <= (short)rightValue ? 1 : 0;
+            }
+            bug("could not fold2 float op : " + opcode);
+            return 0;
+        }
+
         // 演算子により式の定数を演算して返す
         private int fold1(Opcode opcode, int value)
         {
@@ -133,6 +189,25 @@ namespace SLANGCompiler.SLANG
                     return value == 0 ? 1 : 0;
                 case Opcode.Cpl:
                     return ~value;
+                default:
+                    bug("fold1");
+                    break;
+            }
+            return value;
+        }
+
+        // 演算子により式の定数を演算して返す
+        private float fold1(Opcode opcode, float value)
+        {
+            switch(opcode)
+            {
+                case Opcode.Plus:
+                    return value;
+                case Opcode.Minus:
+                    return -value;    
+                case Opcode.Not:
+                    return value == 0 ? 1 : 0;
+                case Opcode.Cpl:
                 default:
                     bug("fold1");
                     break;
@@ -172,6 +247,12 @@ namespace SLANGCompiler.SLANG
         public Expr expConst(ConstInfo c, TypeDataSize dataSize = TypeDataSize.Word)
         {
             TypeInfo typeInfo = dataSize == TypeDataSize.Word ? TypeInfo.WordTypeInfo : TypeInfo.ByteTypeInfo;
+
+            if(c.ConstInfoType == ConstInfoType.FloatValue)
+            {
+                typeInfo = TypeInfo.FloatTypeInfo;
+            }
+
             Expr result = makeNode1( Opcode.Const, OperatorType.Constant, typeInfo, null );
             result.ConstValue = c.Clone();
             // TODO 本来は不必要
@@ -406,6 +487,27 @@ namespace SLANGCompiler.SLANG
             from = a.OpType;
             switch(toType)
             {
+                case OperatorType.Float:
+                {
+                    switch(from)
+                    {
+                        case OperatorType.Float:
+                            return a;
+                        case OperatorType.Word:
+                            return makeNode1(Opcode.WtoF, OperatorType.Float, TypeInfo.WordTypeInfo, a);
+                        case OperatorType.Constant:
+                        {
+                            if(a.ConstValue.ConstInfoType == ConstInfoType.FloatValue)
+                            {
+                                return a;
+                            } else {
+                                return makeNode1(Opcode.WtoF, OperatorType.Float, TypeInfo.FloatTypeInfo, a);
+                            }
+                        }
+                    }
+                    Error($"not supported(float) {from} to {toType}");
+                    return a;
+                }
                 case OperatorType.Byte:
                 {
                     switch(from)
@@ -432,6 +534,74 @@ namespace SLANGCompiler.SLANG
                         case OperatorType.Constant:
                             a.TypeInfo = TypeInfo.WordTypeInfo;
                             return a;
+                        case OperatorType.Float:
+                        {
+                            switch(a.Opcode)
+                            {
+                                case Opcode.Adr:
+                                case Opcode.Indir:
+                                case Opcode.Const:
+                                case Opcode.Str:
+                                case Opcode.Assign:
+                                case Opcode.PreInc:
+                                case Opcode.PreDec:
+                                case Opcode.PostInc:
+                                case Opcode.PostDec:
+                                case Opcode.WtoB:
+                                case Opcode.BtoW:
+                                case Opcode.High:
+                                case Opcode.Low:
+                                    return makeNode1(Opcode.FtoW, OperatorType.Word, TypeInfo.WordTypeInfo, a);
+                                case Opcode.Add:
+                                case Opcode.Sub:
+                                case Opcode.Mod:
+                                case Opcode.Div:
+                                case Opcode.Mul:
+                                case Opcode.Shr:
+                                case Opcode.Shl:
+                                case Opcode.Gt:
+                                case Opcode.Ge:
+                                case Opcode.Lt:
+                                case Opcode.Le:
+                                case Opcode.Eq:
+                                case Opcode.Neq:
+                                case Opcode.And:
+                                case Opcode.Xor:
+                                case Opcode.Or:
+                                case Opcode.Land:
+                                case Opcode.Lor:
+                                    a.Left  = coerce(a.Left, OperatorType.Float);
+                                    a.Right = coerce(a.Right, OperatorType.Float);
+                                    a.OpType = OperatorType.Float;
+                                    a.TypeInfo = TypeInfo.FloatTypeInfo;
+                                    return a;
+                                case Opcode.Plus:
+                                case Opcode.Minus:
+                                case Opcode.Bnot:
+                                    a.Left  = coerce(a.Left, OperatorType.Float);
+                                    a.OpType = OperatorType.Float;
+                                    a.TypeInfo = TypeInfo.FloatTypeInfo;
+                                    return a;
+                                case Opcode.Cond:
+                                    a.Right  = coerce(a.Right, OperatorType.Float);
+                                    a.Third = coerce(a.Third, OperatorType.Float);
+                                    a.OpType = OperatorType.Float;
+                                    a.TypeInfo = TypeInfo.FloatTypeInfo;
+                                    return a;
+                                case Opcode.PortAccess:
+                                    return a;
+                                case Opcode.DeBool:
+                                    return a;
+                                default:
+                                    bug("coerce2 : " + a.Opcode);
+                                    if(a.Left != null)
+                                    {
+                                        bug($"  left float op={a.Left.Opcode}" );
+                                    }
+                                    break;
+                            }
+                            break;
+                        }
                         case OperatorType.Word:
                         case OperatorType.Pointer:
                             return a;
@@ -604,9 +774,14 @@ namespace SLANGCompiler.SLANG
                 Error($"{opcode} type mismatch");
                 return null;
             }
-            if(expr.IsValueConst())
+            if(expr.IsIntValueConst())
             {
                 expr.ConstValue = new ConstInfo(fold1(opcode, expr.ConstValue.Value));
+                return expr;
+            }
+            if(expr.IsFloatValueConst())
+            {
+                expr.ConstValue = new ConstInfo(fold1(opcode, expr.ConstValue.FloatValue));
                 return expr;
             }
             if(opcode == Opcode.Not)
@@ -687,7 +862,7 @@ namespace SLANGCompiler.SLANG
                 return null;
             }
             // 事前最適化
-            if(expr.IsValueConst())
+            if(expr.IsIntValueConst())
             {
                 int value;
                 if(opcode == Opcode.Low)
@@ -712,13 +887,31 @@ namespace SLANGCompiler.SLANG
             TypeInfo ltype = left.TypeInfo;
             TypeInfo rtype = right.TypeInfo;
             // 加減算をまとめる
-            if(left.IsValueConst() && right.IsValueConst())
+            if(left.IsIntValueConst() && right.IsIntValueConst())
             {
                 left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.Value, right.ConstValue.Value));
                 return left;
+            } else if((left.IsFloatValueConst() || left.IsFloatValueConst()) && (right.IsIntValueConst() || right.IsFloatValueConst()))
+            {
+                left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.FloatValue, right.ConstValue.FloatValue));
+                return left;
             }
-            // 強制的にWORD同士の演算にする
-            var opType = OperatorType.Word;
+
+
+            // var opType = OperatorType.Word;
+            OperatorType opType = adjust(left, right);
+
+            // BYTE加算は対応していないのでWORDにする
+            if(opType == OperatorType.Byte)
+            {
+                opType = OperatorType.Word;
+            }
+
+            // このタイミングでWord or Floatのはずだが、念のためエラーを出してやる
+            if(opType != OperatorType.Word && opType != OperatorType.Float)
+            {
+                Error($"could not add type : {opType}");
+            }
             return makeNode2(opcode, opType, opType.ToType(), coerce(left, opType), coerce(right, opType) );
         }
 
@@ -732,7 +925,7 @@ namespace SLANGCompiler.SLANG
             TypeInfo ltype = left.TypeInfo;
             TypeInfo rtype = right.TypeInfo;
             // 定数はまとめる
-            if(left.IsValueConst() && right.IsValueConst())
+            if(left.IsIntValueConst() && right.IsIntValueConst())
             {
                 left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.Value, right.ConstValue.Value));
                 return left;
@@ -755,7 +948,7 @@ namespace SLANGCompiler.SLANG
                 return null;
             }
             // 乗除算をまとめる
-            if(left.IsValueConst() && right.IsValueConst())
+            if(left.IsIntValueConst() && right.IsIntValueConst())
             {
                 left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.Value, right.ConstValue.Value));
                 return left;
@@ -783,12 +976,16 @@ namespace SLANGCompiler.SLANG
                 return null;
             }
             // 乗除算をまとめる
-            if(left.IsValueConst() && right.IsValueConst())
+            if(left.IsIntValueConst() && right.IsIntValueConst())
             {
                 left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.Value, right.ConstValue.Value));
                 return left;
+            } else if((left.IsFloatValueConst() || left.IsFloatValueConst()) && (right.IsIntValueConst() || right.IsFloatValueConst()))
+            {
+                left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.FloatValue, right.ConstValue.FloatValue));
+                return left;
             }
-            var opType = adjust(left.OpType, right.OpType);
+            var opType = adjust(left, right);
 
             // BoolのANDまたはORの場合はLAnd、LOrに差し替えて戻す
             if(left.OpType == OperatorType.Bool && right.OpType == OperatorType.Bool && (opcode == Opcode.And || opcode == Opcode.Or))
@@ -800,10 +997,13 @@ namespace SLANGCompiler.SLANG
             {
                 opType = OperatorType.Byte;
             }
-            // この計算についてはWORD専用の関数を呼ぶため、WORDに拡張しないと駄目
+            // この計算についてはBYTE未対応なのでBYTEの場合は拡張してやる
             if(opcode == Opcode.Mul || opcode == Opcode.Div || opcode == Opcode.Mod)
             {
-                opType = OperatorType.Word;
+                if(opType == OperatorType.Byte)
+                {
+                    opType = OperatorType.Word;
+                }
             }
             return makeNode2(opcode, opType, opType.ToType(), coerce(left, opType), coerce(right, opType) );
         }
@@ -816,7 +1016,7 @@ namespace SLANGCompiler.SLANG
             {
                 return null;
             }
-            if(left.IsValueConst() && right.IsValueConst())
+            if(left.IsIntValueConst() && right.IsIntValueConst())
             {
                 left.ConstValue = new ConstInfo(fold2(opcode, left.ConstValue.Value, right.ConstValue.Value));
                 return left;
@@ -892,7 +1092,15 @@ namespace SLANGCompiler.SLANG
                     break;
             }
 
-            var opType =  OperatorType.Word;
+            var opType2 = adjust(left, right);
+            OperatorType opType;
+            // Floatの時のみ特例で上書きする(従来と動きを変えないための不気味な対応)
+            if(opType2 == OperatorType.Float)
+            {
+                opType = OperatorType.Float;
+            } else {
+                opType = OperatorType.Word;
+            }
             var p = makeNode2(Opcode.Bool, OperatorType.Bool, TypeInfo.WordTypeInfo.Clone(), coerce(left, opType), coerce(right, opType));
             p.ComparisonOp = boolOp;
             return p;

--- a/SLANG/SLANG.Parser.Function.cs
+++ b/SLANG/SLANG.Parser.Function.cs
@@ -154,7 +154,7 @@ namespace SLANGCompiler.SLANG
                             {
                                 address = tree.Address;
                             }
-                            int dataSize = (firstTypeInfo.DataSize == TypeDataSize.Byte) ? 1 : 2;
+                            int dataSize = firstTypeInfo.DataSize.GetDataSize();
                             SymbolTable s = new SymbolTable()
                             {
                                 Name = tree.IdentifierName,
@@ -233,6 +233,10 @@ namespace SLANGCompiler.SLANG
                 if(p.TypeInfo.IsArray())
                 {
                     offset += p.Size;
+                } else if(p.TypeInfo.GetDataSize() == TypeDataSize.Float)
+                {
+                    // FLOATは3バイト必要
+                    offset++;
                 }
                 offset += 2;
             }

--- a/SLANG/SLANG.Parser.Statements.cs
+++ b/SLANG/SLANG.Parser.Statements.cs
@@ -139,7 +139,7 @@ namespace SLANGCompiler.SLANG
             } else if(expr.IsConst())
             {
                 // 単独一致
-                if(expr.IsValueConst())
+                if(expr.IsIntValueConst())
                 {
                     gencode($" LD HL,{expr.ConstValue.Value}\n");
                 } else {

--- a/SLANG/SLANG.Parser.Symbol.cs
+++ b/SLANG/SLANG.Parser.Symbol.cs
@@ -71,6 +71,16 @@ namespace SLANGCompiler.SLANG
             };
             symbolTableManager.Add(memw);
 
+            var memf = new SymbolTable()
+            {
+                Name = "MEMF",
+                SymbolClass = SymbolClass.Global,
+                TypeInfo = TypeInfo.MemoryFloat,
+                Address = new ConstInfo(0),
+                Size = 65536
+            };
+            symbolTableManager.Add(memf);
+
             symbolTableManager.AddSymbol("^BC", TypeInfo.WordTypeInfo, true);
             symbolTableManager.AddSymbol("^DE", TypeInfo.WordTypeInfo, true);
             symbolTableManager.AddSymbol("^HL", TypeInfo.WordTypeInfo, true);
@@ -156,7 +166,7 @@ namespace SLANGCompiler.SLANG
                             {
                                 address = tree.Address;
                             }
-                            int dataSize = (firstTypeInfo.DataSize == TypeDataSize.Byte) ? 1 : 2;
+                            int dataSize = firstTypeInfo.DataSize.GetDataSize();
                             if(arrayTree != null)
                             {
                                 dataSize *= arraySize;
@@ -176,8 +186,14 @@ namespace SLANGCompiler.SLANG
                                 if(baseTypeInfo.DataSize == TypeDataSize.Byte)
                                 {
                                     typeInfo = TypeInfo.IndirectByteTypeInfo.Clone();
-                                } else{
+                                } else if(baseTypeInfo.DataSize == TypeDataSize.Word)
+                                {
                                     typeInfo = TypeInfo.IndirectWordTypeInfo.Clone();
+                                } else if(baseTypeInfo.DataSize == TypeDataSize.Float)
+                                {
+                                    typeInfo = TypeInfo.IndirectFloatTypeInfo.Clone();
+                                } else {
+                                    bug("unknown type");
                                 }
                             }
                             s = new SymbolTable()

--- a/SLANG/SLANG.Parser.Tree.cs
+++ b/SLANG/SLANG.Parser.Tree.cs
@@ -16,7 +16,7 @@ namespace SLANGCompiler.SLANG
         /// </summary>
         public Tree DefineConst(Tree symbolTree, Expr value)
         {
-            if(value.IsValueConst())
+            if(value.IsIntValueConst())
             {
                 // 普通の数値
                 constTableManager.Add(symbolTree.IdentifierName, value.Value);

--- a/SLANG/SLANG.Scanner.cs
+++ b/SLANG/SLANG.Scanner.cs
@@ -48,8 +48,17 @@ namespace SLANGCompiler.SLANG
         }
         void GetNumber()
         {
-            var number = SLANGCommonUtility.GetValue(yytext);
-            var constValue = new ConstInfo(number);
+            ConstInfo constValue = null;
+            if(yytext.Contains('.'))
+            {
+                // FLOAT値
+                var floatNumber = float.Parse(yytext);
+                constValue = new ConstInfo(floatNumber);
+            } else {
+                // INT値
+                var number = SLANGCommonUtility.GetIntValue(yytext);
+                constValue = new ConstInfo(number);
+            }
             yylval.constValue = constValue;
         }
 
@@ -58,6 +67,7 @@ namespace SLANGCompiler.SLANG
             {"VAR", Token.VAR},
             {"BYTE", Token.BYTE},
             {"WORD", Token.WORD},
+            {"FLOAT", Token.FLOAT},
             {"ARRAY", Token.ARRAY},
             {"CONST", Token.CONST},
             {"IF", Token.IF},

--- a/SLANG/SLANGCommonUtility.cs
+++ b/SLANG/SLANGCommonUtility.cs
@@ -1,10 +1,172 @@
 using System;
+using System.Collections.Generic;
 
 namespace SLANGCompiler.SLANG
 {
     public class SLANGCommonUtility
     {
-        public static int GetValue(string valueString)
+        
+        public static int Float24ToInt(int f24)
+        {
+            int a  = (f24 >> 16) & 0xff;
+            int hl = (f24 & 0xffff);
+            bool isMinus = (a & 0x80) != 0;
+            int c = a;
+
+            a *= 2;
+            a &= 0xff;
+            // Check if the input is 0
+            if(a == 0)
+            {
+                // return zero
+                return 0;
+            }
+            // check if inf or NaN
+            if(a == 0xfe)
+            {
+                if(hl == 0)
+                {
+                    // return zero
+                    return 0;
+                }
+                if(!isMinus)
+                {
+                    return 32767;
+                }
+                return -32768;
+            }
+            // ;now if exponent is less than 0, just return 0
+            if(a < 63*2)
+            {
+                return 0;
+            }
+
+            // ;if the exponent is greater than 14, return +- "inf"
+            // 右ローテート(だが必ずここにくる時はキャリーは0なので右シフト相当)
+            a = (a >> 1);
+            a -= 63;
+            a &= 0xff;
+            if( a >= 15 )
+            {
+                if(!isMinus)
+                {
+                    return 32767;
+                }
+                return -32768;
+            }
+            // ;all is good!
+            // ;A is the exponent
+            // ;1+A is the number of bits to read
+            var aIsZero = (a == 0);
+            int b = a;
+            int d = 0;
+            a = 1;
+            if(!aIsZero)
+            { 
+                do{
+                    hl *= 2;
+                    int carry = 0;
+                    if((hl & 0xffff0000) != 0)
+                    {
+                        carry = 1;
+                    }
+                    hl &= 0xffff;
+                    // 左ローテート
+                    a = (a << 1) | carry;
+                    carry = (a & 0x100) != 0 ? 1 : 0;
+                    a &= 0xff;
+
+                    d = (d << 1) | carry;
+                    carry = (d & 0x100) != 0 ? 1 : 0;
+                    d &= 0xff;
+                } while(--b != 0);
+
+            }
+            c <<= 1;
+            var e = a;
+            hl = (e & 0xff)| ((d << 8) & 0xff00);
+            if(!isMinus)
+            {
+                return hl;
+            }
+            return -hl;
+        }
+
+        public static int ValueToFloat24(float value)
+        {
+            var f24Vals = ValueToFloat24Byte(value);
+            int f24Val =    (f24Vals[0] & 0xff)
+                        | ((f24Vals[1] << 8) & 0xff00)
+                        | ((f24Vals[2] << 16) & 0xff0000);
+            return f24Val;
+        }
+
+        public static int[] ValueToFloat24Byte(float value)
+        {
+            if(value == float.NaN)
+            {
+                return new int[3]{244,244,127};
+            }
+            if(value == 0)
+            {
+                return new int[3]{0,0,0};
+            }
+            int sign = 0;
+            if(value < 0)
+            {
+                sign = 1;
+                value = -value;
+            }
+            if(float.IsInfinity(value))
+            {
+                return new int[3]{0,0,(byte)(127 + (sign<<7))};
+            }
+
+            int exp=0;
+            while(value < 1)
+            {
+                exp--;
+                value += value;
+            }
+            while(value >= 2)
+            {
+                exp++;
+                value /= 2f;
+            }
+            if(exp > 63)
+            {
+                // infinity
+                return new int[3]{0,0,(byte)(127 + (sign<<7))};
+            }
+            if(exp < -62)
+            {
+                // zero
+                return new int[3]{0,0,0};
+            }
+            var result = new List<int>(){ (int)(exp + 63 + (sign << 7)) };
+            value -= 1f;
+            value *= 256;
+            var n = 2;
+            for(int k = 0; k < n-1; k++)
+            {
+                var a = (int)value;
+                value -= a;
+                result.Insert(0,a);
+                value *= 256;
+            }
+            // rounding
+            value += 0.5f;
+            result.Insert(0, (byte)value);
+            int idx = 0;
+            while((idx < n) && (result[idx] == 256))
+            {
+                result[idx] = 0;
+                idx++;
+                result[idx] = 1;
+            }
+            return result.ToArray();
+        }
+        public static int GetIntValue(string valueString)
         {
             int number;
 

--- a/SLANG/SymbolManager.cs
+++ b/SLANG/SymbolManager.cs
@@ -211,15 +211,11 @@ namespace SLANGCompiler.SLANG
                     outputStreamWriter.WriteLine($"{labelName} EQU (__WORK__ + {workOffset})");
                 }
 
-                var isByte = symbol.TypeInfo.GetDataSize() == TypeDataSize.Byte;
-                isByte = isByte && !symbol.TypeInfo.IsIndirect();
-                string dataDefine = isByte ? "db" : "dw";
-
                 if(symbol.TypeInfo.IsArray())
                 {
                     workOffset += symbol.Size;
                 } else {
-                    workOffset += isByte ? 1 : 2;
+                    workOffset += symbol.TypeInfo.GetDataSize().GetDataSize();
                 }
             }
 
@@ -279,6 +275,9 @@ namespace SLANGCompiler.SLANG
                 var labelName = symbol.LabelName;
                 codeRepository.AddCode($"{labelName}:\n");
 
+                var dataSize = symbol.Size;
+
+                var isFloat = symbol.TypeInfo.GetDataSize() == TypeDataSize.Float;
                 var isByte = symbol.TypeInfo.GetDataSize() == TypeDataSize.Byte;
                 isByte = isByte && !symbol.TypeInfo.IsIndirect();
                 string dataDefine = isByte ? "DB" : "DW";
@@ -304,9 +303,22 @@ namespace SLANGCompiler.SLANG
                 } else {
                     if(symbol.InitialValueList == null)
                     {
-                        codeRepository.AddCode($" {dataDefine} 0\n");
+                        if(isFloat)
+                        {
+                            codeRepository.AddCode($" DS 3\n");
+                        } else if(isByte)
+                        {
+                            codeRepository.AddCode($" DS 1\n");
+                        } else {
+                            codeRepository.AddCode($" DS 2\n");
+                        }
                     } else {
-                        codeRepository.AddCode($" {dataDefine} {symbol.InitialValueList[0]}\n");
+                        if(isFloat)
+                        {
+                            errorReporter.Error("not support (float initial value)");
+                        } else {
+                            codeRepository.AddCode($" {dataDefine} {symbol.InitialValueList[0]}\n");
+                        }
                     }
                 }
             }

--- a/SLANG/SymbolTable.cs
+++ b/SLANG/SymbolTable.cs
@@ -146,7 +146,7 @@ namespace SLANGCompiler.SLANG
 
         public bool IsMemoryArray()
         {
-             return Address != null && Address.ConstInfoType == ConstInfoType.Value && Address.Value == 0;
+             return Address != null && Address.ConstInfoType == ConstInfoType.IntValue && Address.Value == 0;
         }
 
         public SymbolTable AddAliasName(string name)

--- a/SLANG/TypeInfo.cs
+++ b/SLANG/TypeInfo.cs
@@ -34,9 +34,29 @@ namespace SLANGCompiler.SLANG
         /// <summary>バイト(1byte)</summary>
         Byte,
         /// <summary>ワード(2bytes)</summary>
-        Word
+        Word,
+        /// <summary>浮動小数点(3bytes)</summary>
+        Float
     }
 
+    public static partial class TypeDataSizeExtend {
+            /// <summary>
+            /// TypeDataSizeの保存に必要なメモリバイト数を返す
+            /// </summary>
+            public static int GetDataSize(this TypeDataSize param)
+            {
+                switch(param)
+                {
+                    case TypeDataSize.Byte:
+                        return 1;
+                    case TypeDataSize.Word:
+                        return 2;
+                    case TypeDataSize.Float:
+                        return 3;
+                }
+                return 2;
+            }
+    }
     /// <summary>
     /// 型情報クラス
     /// </summary>
@@ -109,6 +129,14 @@ namespace SLANGCompiler.SLANG
         public bool IsWordTypeInfo()
         {
             return (InfoClass == TypeInfoClass.Normal && DataSize == TypeDataSize.Word);
+        }
+
+        /// <summary>
+        /// この型が単純変数のFloat型の場合true、そうでない場合falseを返す
+        /// </summary>
+        public bool IsFloatTypeInfo()
+        {
+            return (InfoClass == TypeInfoClass.Normal && DataSize == TypeDataSize.Float);
         }
 
         /// <summary>
@@ -252,6 +280,9 @@ namespace SLANGCompiler.SLANG
             } else if((this.InfoClass == TypeInfoClass.Normal || this.InfoClass == TypeInfoClass.Indirect) && this.DataSize == TypeDataSize.Word)
             {
                 return OperatorType.Word;
+            } else if((this.InfoClass == TypeInfoClass.Normal || this.InfoClass == TypeInfoClass.Indirect) && this.DataSize == TypeDataSize.Float)
+            {
+                return OperatorType.Float;
             } else if(this.InfoClass == TypeInfoClass.Array)
             {
                 if(this.DataSize == TypeDataSize.Byte)
@@ -300,16 +331,26 @@ namespace SLANGCompiler.SLANG
         {
             ByteTypeInfo = CreateTypeInfo(TypeInfoClass.Normal, null, 1, TypeDataSize.Byte);
             WordTypeInfo = CreateTypeInfo(TypeInfoClass.Normal, null, 2, TypeDataSize.Word);
+            FloatTypeInfo = CreateTypeInfo(TypeInfoClass.Normal, null, 3, TypeDataSize.Float);
+
             IndirectByteTypeInfo = CreateTypeInfo(TypeInfoClass.Indirect, null, 1, TypeDataSize.Byte);
             IndirectWordTypeInfo = CreateTypeInfo(TypeInfoClass.Indirect, null, 2, TypeDataSize.Word);
+            IndirectFloatTypeInfo = CreateTypeInfo(TypeInfoClass.Indirect, null, 3, TypeDataSize.Float);
+
             PtrToByte = CreateTypeInfo(TypeInfoClass.Pointer, ByteTypeInfo);
             PtrToWord = CreateTypeInfo(TypeInfoClass.Pointer, WordTypeInfo);
+            PtrToFloat = CreateTypeInfo(TypeInfoClass.Pointer, FloatTypeInfo);
+
             PtrToIndirectByte = CreateTypeInfo(TypeInfoClass.Pointer, IndirectByteTypeInfo);
             PtrToIndirectWord = CreateTypeInfo(TypeInfoClass.Pointer, IndirectWordTypeInfo);
+            PtrToIndirectFloat = CreateTypeInfo(TypeInfoClass.Pointer, IndirectFloatTypeInfo);
+
             PortByte = CreateTypeInfo(TypeInfoClass.PortArray, ByteTypeInfo.Clone(), 1, TypeDataSize.Byte);
             PortWord = CreateTypeInfo(TypeInfoClass.PortArray, WordTypeInfo.Clone(), 2, TypeDataSize.Word);
+
             MemoryByte = CreateTypeInfo(TypeInfoClass.MemoryArray, ByteTypeInfo.Clone(), 1, TypeDataSize.Byte);
             MemoryWord = CreateTypeInfo(TypeInfoClass.MemoryArray, WordTypeInfo.Clone(), 2, TypeDataSize.Word);
+            MemoryFloat = CreateTypeInfo(TypeInfoClass.MemoryArray, WordTypeInfo.Clone(), 3, TypeDataSize.Float);
 
             TempFunc = CreateTypeInfo(TypeInfoClass.TempFunc, WordTypeInfo.Clone(), 2, TypeDataSize.Word);
         }
@@ -323,6 +364,10 @@ namespace SLANGCompiler.SLANG
         /// </summary>
         public static TypeInfo WordTypeInfo { get; private set; }
         /// <summary>
+        /// 単純FLOAT型
+        /// </summary>
+        public static TypeInfo FloatTypeInfo { get; private set; }
+        /// <summary>
         /// 間接変数BYTE型
         /// </summary>
         public static TypeInfo IndirectByteTypeInfo { get; private set; }
@@ -330,6 +375,10 @@ namespace SLANGCompiler.SLANG
         /// 間接変数WORD型
         /// </summary>
         public static TypeInfo IndirectWordTypeInfo { get; private set; }
+        /// <summary>
+        /// 間接変数FLOAT型
+        /// </summary>
+        public static TypeInfo IndirectFloatTypeInfo { get; private set; }
         /// <summary>
         /// BYTEポインタ型
         /// </summary>
@@ -339,6 +388,10 @@ namespace SLANGCompiler.SLANG
         /// </summary>
         public static TypeInfo PtrToWord { get; private set; }
         /// <summary>
+        /// FLOATポインタ型
+        /// </summary>
+        public static TypeInfo PtrToFloat { get; private set; }
+        /// <summary>
         /// BYTE間接変数ポインタ型
         /// </summary>
         public static TypeInfo PtrToIndirectByte { get; private set; }
@@ -346,6 +399,10 @@ namespace SLANGCompiler.SLANG
         /// WORD間接変数ポインタ型
         /// </summary>
         public static TypeInfo PtrToIndirectWord { get; private set; }
+        /// <summary>
+        /// FLOAT間接変数ポインタ型
+        /// </summary>
+        public static TypeInfo PtrToIndirectFloat { get; private set; }
         /// <summary>
         /// I/OポートBYTE配列型
         /// </summary>
@@ -362,6 +419,10 @@ namespace SLANGCompiler.SLANG
         /// メモリWORD配列型
         /// </summary>
         public static TypeInfo MemoryWord { get; private set; }
+        /// <summary>
+        /// メモリFLOAT配列型
+        /// </summary>
+        public static TypeInfo MemoryFloat { get; private set; }
         /// <summary>
         /// 一時定義関数型
         /// </summary>

--- a/examples/FMANDEL.SL
+++ b/examples/FMANDEL.SL
@@ -1,0 +1,38 @@
+//
+// 
+//
+
+VAR X,Y,I,VAL;
+ARRAY FLOAT CA, FLOAT CB, FLOAT FX, FLOAT FY;
+ARRAY FLOAT A, FLOAT B, FLOAT T;
+
+MAIN()
+BEGIN
+    FOR Y=0 TO 24
+    {
+        FOR X=0 TO 78
+        {
+            FX = X - 39;
+            FY = Y - 12;
+            CA = FX * 0.0458;
+            CB = FY * 0.08333;
+            A = CA;
+            B = CB;
+            FOR I=0 TO 15
+            {
+                T = A*A - B*B + CA;
+                B = 2*A*B + CB;
+                A=T;
+                IF (A*A+B*B)>4.0 THEN EXIT;
+            }
+            IF I<=15 {
+                IF I>9 THEN I=I+7;
+                PRINT(CHR$(48+I));
+            } ELSE {
+                PRINT(" ");
+            }
+        }
+        PRINT(/);
+    }
+END;
+

--- a/examples/MANDEL.SL
+++ b/examples/MANDEL.SL
@@ -1,0 +1,61 @@
+//
+// 
+//
+
+#INCLUDE SOROBAN.LIB
+
+VAR X,Y,I,VAL;
+ARRAY BYTE CA[@DBL], BYTE CB[@DBL], BYTE FX[@DBL], BYTE FY[@DBL];
+ARRAY BYTE A[@DBL], BYTE B[@DBL], BYTE T[@DBL];
+ARRAY BYTE CAK[@DBL], BYTE CBK[@DBL], BYTE FV2[@DBL], BYTE FV4[@DBL];
+ARRAY BYTE TMPF[@DBL],TMPF2[@DBL];
+
+MAIN()
+BEGIN
+    @CVSTF(CAK,"0.0458");
+    @CVSTF(CBK,"0.08333");
+    @CVSTF(FV2,"2");
+    @CVSTF(FV4,"4");
+    FOR Y=0 TO 24
+    {
+        FOR X=0 TO 78
+        {
+            @CVITF(FX,X-39);
+            @CVITF(FY,Y-12);
+            @MUL(CA,FX,CAK);    // CA=X*0.0458
+            @MUL(CB,FY,CBK);    // CB=Y*0.08333
+            @MOVE(A,CA);        // A=CA
+            @MOVE(B,CB);        // B=CB
+            FOR I=0 TO 15
+            {
+                // T=A*A-B*B+CA
+                @MUL(T,A,A);        // T=A*A
+                @MUL(TMPF,B,B);     // TMPF=B*B
+                @SUB(T,T,TMPF);     // T=T-TMPF
+                @ADD(T,T,CA);       // T=T+CA
+
+                // B=2*A*B+CB
+                @MUL(TMPF,FV2,A);
+                @MUL(TMPF,TMPF,B);
+                @ADD(B,TMPF,CB);
+
+                // A=T
+                @MOVE(A,T);
+
+                // IF (A*A+B*B)>4 THEN GOTO 200
+                @MUL(TMPF,A,A);
+                @MUL(TMPF2,B,B);
+                @ADD(TMPF,TMPF,TMPF2);
+                IF @CMP(TMPF,FV4)==1 THEN EXIT;
+            }
+            IF I<=15 {
+                IF I>9 THEN I=I+7;
+                PRINT(CHR$(48+I));
+            } ELSE {
+                PRINT(" ");
+            }
+        }
+        PRINT(/);
+    }
+END;
+

--- a/libfloat.yml
+++ b/libfloat.yml
@@ -1,0 +1,1401 @@
+
+mul16:
+  code: |
+    ;This was made by Runer112
+    ;Tested by jacobly
+    ;BC*DE --> DEHL
+    ; ~544.887cc as calculated in jacobly's test
+    ;min: 214cc  (DE = 1)
+    ;max: 667cc
+    ;avg: 544.4507883cc   however, deferring to jacobly's result as mine may have math issues ?
+    ;177 bytes
+    ld a,d
+    ld d,0
+    ld h,b
+    ld l,c
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit14
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit13
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit12
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit11
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit10
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit9
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit8
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit7
+    ld a,e
+    and %11111110
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit6
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit5
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit4
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit3
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit2
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit1
+    add a,a
+    jr c,Mul_BC_DE_DEHL_Bit0
+    rr e
+    ret c
+    ld h,d
+    ld l,e
+    ret
+
+    Mul_BC_DE_DEHL_Bit14:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit13
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit13:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit12
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit12:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit11
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit11:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit10
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit10:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit9
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit9:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit8
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit8:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit7
+    add hl,bc
+    adc a,d
+    Mul_BC_DE_DEHL_Bit7:
+    ld d,a
+    ld a,e
+    and %11111110
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit6
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit6:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit5
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit5:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit4
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit4:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit3
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit3:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit2
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit2:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit1
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit1:
+    add hl,hl
+    adc a,a
+    jr nc,Mul_BC_DE_DEHL_Bit0
+    add hl,bc
+    adc a,0
+    Mul_BC_DE_DEHL_Bit0:
+    add hl,hl
+    adc a,a
+    jr c,Mul_BC_DE_DEHL_FunkyCarry
+    rr e
+    ld e,a
+    ret nc
+    add hl,bc
+    ret nc
+    inc e
+    ret nz
+    inc d
+    ret
+
+    Mul_BC_DE_DEHL_FunkyCarry:
+    inc d
+    rr e
+    ld e,a
+    ret nc
+    add hl,bc
+    ret nc
+    inc e
+    ret
+
+f24sub:
+  calls:
+    - f24add
+  code: |
+    ;AHL - CDE ==> AHL
+    ;Destroys BC,DE
+    ;
+    ld b,a
+    ld a,c
+    xor $80
+    ld c,a
+    ld a,b
+    ; jp f24add
+
+f24add:
+  code: |
+    ;AHL + CDE ==> AHL
+    ;Destroys BC,DE
+    ;
+    ;save A
+    ld b,a
+
+    ;check for special values
+    and $7F
+    #if exists return_CDE
+    jp z,return_CDE
+    #else
+    jr nz,f24add1
+    return_CDE:
+    ld a,c
+    ex de,hl
+    ret
+    f24add1:
+    #endif
+    inc a
+    jp m,f24add_op1_inf_nan
+
+    ld a,c
+    ;check for special values
+    and $7F
+    jp z,return_exp_b
+
+    inc a
+    jp m,return_CDE
+
+
+    ld a,b
+    xor c
+    jp m,f24add_subtract
+    ;we need to add
+
+    call f24add_reorder
+    jr z,f24add_add_same_exp
+    ret nc
+    push bc
+    call rshift_1DE
+    sla b
+    adc hl,de
+    ;if carry is reset, then we are all good :)
+    pop de
+    ld a,d
+    ret nc
+    ;otherwise, we need to increment the sign and see if it overflows to inf
+    and $7F
+    cp $7E
+    ld a,d
+    jr z,f24_return_inf
+    inc a
+
+    ;we also need to shift a 0 down into the HL
+    srl h
+    rr l
+    ret nc
+    inc hl
+    ret
+
+    f24add_add_same_exp:
+    ld a,b
+    and $7F
+    cp $7E
+    ld a,b
+    jr z,f24_return_inf
+    inc a
+    add hl,de
+    rr h
+    rr l
+    ret nc
+    inc l
+    ret nz
+    inc h
+    ret nz
+    inc a
+    ret
+
+    f24_return_inf:
+    or %01111111
+    ld hl,0
+    ret
+
+
+    f24add_subtract:
+    call f24add_reorder
+    jr z,f24add_subtract_same_exp
+    ret nc
+    push bc
+    call rshift_1DE
+    sub c
+    ld c,a
+    ld a,0
+    sbc a,b
+    ld b,a
+    sbc hl,de
+    ;if carry is not set, then we are all good :)
+    pop de
+    ld a,d
+    ret nc
+
+    ;otherwise, the implicit bit is set to 0, so we need to renormalize
+    normalize_D_HLBC:
+    ;D is the sign+exponent
+    ;HLBC is the significand
+    ;returns AHLBC
+    ;make sure HLBC is not 0
+    ld a,h
+    or l
+    or b
+    or c
+    ret z
+
+    ld a,d
+    normalize_D_HLBC_nonzero:
+    ;save the sign
+    add a,a
+    push af
+    rrca
+
+    .f24add3
+    dec a
+    jr z,.f24add2
+    sla c
+    rl b
+    adc hl,hl
+    jp nc,.f24add3
+    ;now round
+    sla c
+    ld bc,0
+    adc hl,bc
+    ;if carry is set, then the implicit bit is 2, and the rest of the exponent is 0
+    ;so we can just increment A and keep HL as 0
+    adc a,b
+    add a,a
+    .f24add2
+    ld d,a
+    pop af
+    ld a,d
+    rra
+    ret
+
+    f24add_subtract_same_exp:
+    ;subtract the significands
+    ld a,b
+    ;  or a
+    sbc hl,de
+
+    ;if zero, then the result is zero, but we'll keep the same sign
+    jr nz,$+5
+    and %10000000
+    ret
+
+    ;if the carry flag is set, then we need to change the sign of the output
+    ;and negate the significand. if reset, then we still need to normalize and whatnot
+    ld bc,0
+    jr nc,normalize_D_HLBC_nonzero
+    xor $80
+    ld d,a
+    xor a
+    sub l
+    ld l,a
+    sbc a,a
+    sub h
+    ld h,a
+    ld a,d
+    jr normalize_D_HLBC_nonzero
+
+    f24add_reorder:
+    xor c
+    rlc c
+    rla
+    ;Want to rearrange so that A-C>=0
+    sub c
+    ret z
+    jr nc,.f24add4
+    neg
+    ;A is the difference in exponents
+    rrc c
+    ld b,c
+    ex de,hl
+    .f24add4
+    ;A is how many bits to shift DE right
+    ;B is the sign+exponent of the result
+    or a
+    rra
+    cp 18
+    ret c
+    return_exp_b:
+    ld a,b
+    ret
+
+    f24add_op1_inf_nan:
+    ld a,h
+    or l
+    jr nz,return_exp_b
+    ;so op1 is +inf or -inf
+    ;If op2 is finite, then just return op1
+    or c
+    jr z,return_exp_b
+    inc a
+    add a,a
+    jr nz,return_exp_b
+
+    ;if op2 is NaN, return NaN
+    ld a,d
+    or e
+    ld a,c
+    jr nz,.f24add5
+
+    ;so |op1| and |op2| are inf
+    ;if they have the same sign, fine, else return NaN
+    cp b
+    ret z
+    .f24add5
+    dec hl
+    ret
+
+    rshift_1DE:
+    ld bc,0
+    scf
+    .f24add6
+    rr d
+    rr e
+    rr b
+    rr c
+    dec a
+    jr nz,.f24add6
+    ret
+
+f24mul:
+  calls:
+    - mul16
+  code: |
+    ;AHL * CDE ==> AHL
+    ;Destroys BC,DE
+    ;
+
+    ;put the output sign in the top bit of A
+    ld b,a
+    ld a,c
+    and $80
+    xor b
+
+    ;check for special values
+    ;NaN*x ==> NaN
+    ;0*fin ==> 0
+    ;0*inf ==> NaN
+    ;inf*fin ==> inf
+    ;inf*inf ==> inf
+
+    ;save A
+    ld b,a
+    and $7F
+    jr z,f24mul_op1_0
+    inc a
+    jp m,f24mul_op1_inf_nan
+
+    ;so the first value is finite
+    ld a,c
+    and $7F
+    ld c,a
+    ret z
+    inc a
+    #if exists return_CDE
+    jp m,return_CDE
+    #else
+    jp p,f24mul_1
+    return_CDE:
+    ld a,c
+    ex de,hl
+    ret
+    f24mul_1:
+    #endif
+
+    ;upper bit of B is the output sign
+    ;first approximation of the exponent is
+    ; (B&7F) + (C&7F) - 63
+    ld a,b
+    and $7F
+    add a,c
+    sub 63
+    jr nc,$+4
+    xor a     ;underflowed, so return 0
+    ret
+
+    cp $7F
+    jr c,f24mul_2
+    f24mul_return_inf:
+    ld a,b
+    or %01111111
+    ld hl,0   ;overflow so return inf
+    ret
+    f24mul_2:
+
+    xor b
+    and $7F
+    xor b
+    f24mul_significand:
+    ;save the exponent
+    push af
+
+    ;now compute (1.HL * 1.DE)
+    ; = (1+.HL)(1+.DE)
+    ; = 1+.HL+.DE+.HL*.DE
+    ld b,h
+    ld c,l
+    push hl
+    push de
+    call mul16
+    ;result is .DEHL
+    ;we can discard HL, but first round
+    xor a
+    sla h
+    ex de,hl
+    pop bc
+    adc hl,bc
+    adc a,0
+    pop bc
+    add hl,bc
+    adc a,0
+    rra
+    ;now 1+A.HL is the significand
+    pop bc    ;B is the exponent
+    ld a,b
+    ret z
+    ccf
+    rr h
+    rr l
+    inc a
+    inc a
+    add a,a
+    jr z,f24mul_return_inf
+    rra
+    dec a
+    ret
+
+    f24mul_op1_0:
+    ld a,c
+    and $7F
+    ret z
+    inc a
+    jp m,f24mul_return_NaN
+    xor a
+    ret
+
+    f24mul_op1_inf_nan:
+    ld a,h
+    or l
+    ld a,b
+    ret nz    ;NaN
+
+    ;inf*0 is NaN
+    ld a,c
+    and $7F
+    jr nz,f24mul_3
+    f24mul_return_NaN:
+    dec a   ;inf*0
+    ld h,a  ;=
+    ld l,a  ;NaN
+    ret
+    f24mul_3:
+    inc a
+    jp m,f24mul_4
+    ld a,b    ;returning inf
+    ret
+    f24mul_4:
+
+    ;op1 is inf
+    ;op2 is is either NaN or inf
+    ; inf*NaN ==> NaN
+    ; inf*inf ==> inf
+    ;so just return op2's significand
+    ld a,c
+    ex de,hl
+    ret
+
+f24mul2:
+  code: |
+    ;AHL * 2.0 ==> AHL
+    ;Destroys B
+    ;
+    ld b,a
+    ;check for special values
+    and $7F
+    jr nz,$+4
+    ld a,b
+    ret
+    inc a
+    ld a,b
+    ret m
+    inc a
+    ret
+
+f24mul3:
+  code: |
+    ;AHL*3 ==> AHL
+    ;0*3 ==> 0
+    ld c,a
+    add a,a
+    ld a,c
+    ret z
+
+    ;inf*3 ==> inf, NaN*3 ==> NaN
+    ld c,a
+    and $7F
+    inc a
+    ld a,c
+    ret m
+
+    inc c
+    ld a,c
+    add a,a
+    add a,2
+    jr nz,$+6
+    ld hl,0
+    ret
+
+    ld d,h
+    ld e,l
+    scf
+    rr h
+    rr l
+    add hl,de
+    ld a,c
+    ret nc
+    srl h
+    rr l
+    inc a
+    ret
+
+i16tof24:
+  calls:
+    - u16tof24
+  code: |
+    ;Inputs:
+    ;   HL holds a 16-bit signed integer, (-32768 to 32767)
+    ;Outputs:
+    ;   Converts to an f24 float in AHL
+    ;   returns z flag set if zero, nz otherwise :)
+
+    bit 7,h
+    jr z,i16tof24_pos
+    xor a
+    sub l
+    ld l,a
+    sbc a,a
+    sub h
+    ld h,a
+    ld b,$BF+16
+    db $11     ;start of `ld de,**`, eats the next two bytes
+
+u16tof24:
+  code: |
+    i16tof24_pos:
+    ld b,$3F+16    ;Initial exponent and sign
+
+    ;Check if HL is 0, if so return AHL == 0x000000
+    ld a,h
+    or l
+    ret z
+
+    ; HL is non-zero
+    ; shift HL left until there is an overflow (the implicit bit)
+    ; meanwhile, decrement B, the exponent each iteration
+    dec b
+    add hl,hl
+    jr nc,$-2
+    ld a,b
+    ret
+
+f24toi16:
+  code: |
+    ;AHL to a 16-bit signed integer
+    ;NaN ==> 0
+    ;+inf ==> 32767
+    ;-inf ==> -32768
+    
+    ;save the sign of the output
+    ld c,a
+    
+    ;Check if the input is 0
+    add a,a
+    jr z,f24toi16_return_0
+    
+    ;check if inf or NaN
+    cp $FE
+    jr nz,f24toi161
+    ld a,h
+    or l
+    jr nz,f24toi16_return_0
+    f24toi16_return_inf:
+    sla c
+    ld hl,32767
+    ret nc
+    inc hl
+    ret
+    f24toi161:
+    
+    ;now if exponent is less than 0, just return 0
+    cp 63*2
+    jr nc,f24toi162
+    f24toi16_return_0:
+    ld hl,0
+    ret
+    f24toi162:
+    
+    ;if the exponent is greater than 14, return +- "inf"
+    rra
+    sub 63
+    cp 15
+    jr nc,f24toi16_return_inf
+    
+    ;all is good!
+    ;A is the exponent
+    ;1+A is the number of bits to read
+    or a
+    ld b,a
+    ld d,0
+    ld a,1
+    jr z,.f24toi163
+    
+    add hl,hl
+    rla
+    rl d
+    djnz $-4
+    .f24toi163
+    sla c
+    ld e,a
+    ex de,hl
+    ret nc
+    xor a
+    sub l
+    ld l,a
+    sbc a,a
+    sub h
+    ld h,a
+    ret
+
+f24cmp:
+  calls:
+    - f24sub
+  code: |
+    ;returns the flags for float AHL minus float CDE
+    ;   AHL >= CDE, nc
+    ;   AHL < CDE,  c
+    ;   AHL == CDE, z (and nc)
+    ;
+    ;Note:
+    ;   This allows some wiggle room in the bottom two bits. For example, if the two
+    ;   exponents are the same and the two significands differ by at most 3, they are
+    ;   considered equal.
+    ;
+    ;Note:
+    ;   NaN is a special case. This routines returns that NaN<x for all x.
+    ;   This gives the weird property NaN<NaN, and when sorting, NaN will be the
+    ;   smallest element.
+    ;
+
+    ;check for inf and NaN
+    ld b,a
+    and $7F
+    inc a
+    jp m,f24cmp_special
+    ld a,b
+
+    ;save the old exponent
+    push af
+    call f24sub
+
+    ;restore the old exponent
+    pop bc
+
+    ; if 0, return equal
+    xor 80h
+    ret z
+    xor 80h
+    ret z
+
+    ;if the difference was only in the bottom two bits, we'll call it good
+    ;check if (B&7F)-(A&7F) >= 15
+    ;check if (B&7F) > 14 + (A&7F)
+    ld c,a    ;new exponent, need to save the sign for later comparison
+    res 7,b
+    and $7F
+    add a,14
+    sub b
+    jr nc,$+4
+    xor a
+    ret
+
+    ;otherwise, not equal, so let's return the sign in c and nz
+    ld a,c
+    return_nz_sign_a:
+    or $7F
+    add a,a
+    ret
+
+    f24cmp_special:
+    ld a,h
+    or l
+    ccf
+    ret nz
+
+    ;so the first op is inf
+
+    ;if second of is finite, return the sign of B in carry and nz
+
+    ld a,c
+    and $7F
+    inc a
+    ld a,b
+    jp p,return_nz_sign_a
+
+    ;second op is either NaN or inf
+    ld a,d
+    or e
+    ret nz
+
+    ; op1 op2 result
+    ; 7F  7F  z, nc
+    ; 7F  FF  nz,nc
+    ; FF  7F  nz,c
+    ; FF  FF  z, nc
+    ld a,c
+    cp b
+    ret
+
+f24neg:
+  code: |
+    ;-AHL ==> AHL
+
+    ;-(+0) ==> +0
+    or a
+    ret z
+
+    ;otherwise, negate
+    xor 80h
+    ret
+
+
+PFLOAT:
+  calls:
+    - f24toa
+    - PMSX
+  code: |
+    LD DE,FSTRBUFF
+    CALL f24toa
+    JP PMSX
+  works:
+    FSTRBUFF: 12
+
+f24toa:
+  calls:
+    - f24mul
+    - formatstr
+    - f24pow10_LUT
+    - f24_common_str
+  code: |
+    char_NEG EQU '-'
+    char_DEC EQU '.'
+
+    ;converts a 24-bit float to a string
+    ;Inputs:
+    ;   AHL is the float to convert
+    ;   DE points to where to write the string
+    ;Output:
+    ;   HL pointing to the string
+    ;Destroys:
+    ;   A,DE,BC
+    ;Notes:
+    ;   Uses up to 12 bytes to store the string
+
+    ld b,a  ; save the exponent
+
+    ; check if the input is 0
+    add a,a
+    jr nz,f24toa_1
+    ex de,hl
+    jr nc,$+5
+    ld (hl),char_NEG
+    inc hl
+    ld (hl),'0'
+    inc hl
+    ld (hl),0
+    dec hl
+    ret nc
+    dec hl
+    ret
+    f24toa_1:
+
+    ;check if the input is inf or NaN
+    push de
+    cp $FE
+    jr nz,f24toa_finite
+    ld a,h
+    or l
+    ld hl,s_NaN
+    jr nz,f24toa_2
+    ld hl,s_NEGinf
+    bit 7,b
+    jr nz,f24toa_2
+    inc hl
+    f24toa_2:
+    ldi
+    ldi
+    ldi
+    ldi
+    ld a,(hl)
+    ld (de),a
+    pop hl
+    ret
+    f24toa_finite:
+
+    ;BHL is the float and it is not a special number
+    ;save the exponent
+
+    ;write a negative sign if needed
+    ld a,b
+    add a,a
+    jr nc,f24toa_3
+    ex de,hl
+    ld (hl),char_NEG
+    inc hl
+    ex de,hl
+    f24toa_3:
+
+    ;save the string pointer
+    push de
+
+    ;save the significand
+    push hl
+
+    ;Get an estimate of the power of 10
+    ;multiply A/2 by 77
+
+    ld l,a
+    ld h,0
+    rrca
+    ld e,a
+    ld d,h
+
+    add hl,hl ;4
+    add hl,hl ;8
+    add hl,de ;9
+    add hl,hl ;18
+    add hl,de ;19
+    add hl,hl ;38
+    add hl,hl ;76
+    add hl,de ;77
+
+    ;now HL is approximately (exp+63)*log10(2)*256
+
+    ;first, save H, the power-of-10 guess
+    ;also restore the significand
+    ld e,h
+    ex (sp),hl
+
+    ;now multiply by the appropriate power-of-10 to get our input in the [1,10]-ish
+    ;range. Unlike the higher-precision floats, it is actually smaller to store the
+    ;whole table. This will also be slightly more accurate and also faster.
+    push hl
+    ld hl,f24pow10_LUT
+    add hl,de
+    sla e
+    add hl,de
+    ld e,(hl)
+    inc hl
+    ld d,(hl)
+    inc hl
+    ld c,(hl)
+    ld a,b
+    and $7F
+    pop hl
+    call f24mul
+
+    cp 63
+    jr nc,f24toa_4
+    ;decrement the power of 10 and multiply by 10
+    pop de
+    dec d
+    push de
+    ld c,$42
+    ld de,$4000
+    call f24mul
+    f24toa_4:
+
+    ;now AHL is a float on [1,20]
+    ;let's convert it to an 8.16 unsigned fixed-point number
+    sub 63
+    ld b,a
+    ld a,1
+    jr z,f24toa_5
+    add hl,hl
+    rla
+    djnz $-2
+    f24toa_5:
+
+    ;for rounding porpoises, add 3 to A:HL
+    ld bc,3
+    add hl,bc
+    adc a,b
+
+    pop bc    ;power-of-10 is in B
+    pop de    ;where to write the output
+
+
+    cp 10
+    jr nc,f24toa_6
+    add a,'0'
+    ld (de),a
+    inc de
+    ;get a second digit
+    push bc
+    call f24toa_sub
+    jr f24toa_write_digits
+    f24toa_6:
+    _:
+    inc b
+    ;save the power-of-10 exponent
+    push bc
+
+    ;for rounding purposes, add another 30 to HL
+    ld bc,30
+    add hl,bc
+    adc a,b
+
+    ;the first digit is either a 1 or a 2
+    ex de,hl
+    ld (hl),'1'
+    sub 20
+    jr c,$+4
+    inc (hl)
+    db $01
+    add a,10
+    inc hl
+    ex de,hl
+    add a,'0'
+    ld (de),a
+    inc de
+    f24toa_write_digits:
+    ;get the next three digits
+    call f24toa_sub
+    call f24toa_sub
+    call f24toa_sub
+    xor a
+    ld (de),a
+
+    ; need to determine what to do with the power-of-10 exponent
+    pop af
+
+    pop hl  ; pointer to the string
+    push hl
+    sub 19
+    ld e,a
+    add a,a
+    sbc a,a
+    ld d,a
+    call formatstr
+    pop hl
+    ret
+    ;
+    f24toa_sub:
+    ;now need to multiply 0.HL by 10 and add '0'
+    xor a
+    ld b,h
+    ld c,l
+    add hl,hl
+    rla
+
+    add hl,hl
+    rla
+
+    add hl,bc
+    adc a,'0'/2
+
+    add hl,hl
+    rla
+
+    ld (de),a
+    inc de
+    ret
+
+formatstr:
+  code: |
+    ; This routine for taking a base-10 exponent and a string of digits and (without
+    ; a decimal) and inserting a decimal, any leading zeros, stripping trailing
+    ; zeros, and appending an exponent if needed.
+
+    ; Define the absolute maximum number of digits in the result string.
+    ; If FORMAT_LEN is bigger than this value, then it will be reduced.
+    MAX_FORMAT_LEN EQU 7
+
+    ; This is the max number of digits in the output.
+    ; If EXTERNAL_FORMAT_LEN is used and it is 0, then this will be used.
+    FORMAT_LEN EQU 5
+
+    ; Define the largest negative exponent to use engineering format
+    ; If EXTERNAL_FORMAT_MIN_ENGINEERING is used and is 0 or larger than FORMAT_LEN,
+    ; then this will be used.
+    FORMAT_MIN_ENGINEERING EQU -3
+    ; causes exponent of -5 to be enginierring
+
+    ; For formatting, we need to define these three characters
+    ; "Enginieering e" for values like "1.23456e10"
+    TOK_ENG EQU 'e'
+
+    ; Negative sign
+    TOK_NEG  EQU '-'
+
+    ; Decimal point
+    TOK_DECIMAL EQU '.'
+
+    ;Inputs:
+    ;   HL points to the null-terminated string of digits
+    ;   DE is the signed exponent.
+    ;Outputs:
+    ;   The string has leading and trailing zeros stripped, a decimal is placed
+    ;   (if needed), and an exponent field is appended (if needed).
+    ;Destroys:
+    ;   HL, DE, BC, AF
+    ;Notes:
+    ;   This routine operates in-place. It assumes that there is enough space
+    ;   allocated for the string. At most MAX_FORMAT_LEN+10 bytes is needed,
+    ;   assuming the exponent can be up to 5 digits long.
+    ;
+    ; Skip over the negative sign, if any
+    ld a,(hl)
+    cp TOK_NEG
+    jr nz,$+3
+    inc hl
+    push de ; save the exponent
+    push hl
+
+    ;Strip leading zeros
+    ld d,h
+    ld e,l
+    ld a,'0'
+    cp (hl)                           ;These two lines can be commented-out to save three
+    jr nz,formatstr_no_leading_zeros  ;bytes at the expense of redundant processing.
+    formatstr_strip_leading_zeros:
+    cpi
+    jr z,formatstr_strip_leading_zeros
+    dec hl
+
+    ; HL points to the first non-'0' digit
+    ; DE points to the first digit
+    ; Copy bytes from HL to DE until 0x00 is reached at HL or FORMAT_LEN digits are copied
+    ld a,FORMAT_LEN
+    ld c,a
+
+    xor a
+    ld b,a
+    formatstr_copy_digits:
+    cp (hl)
+    ldi
+    jp po,formatstr_1
+    jr nz,formatstr_copy_digits
+    formatstr_1:
+    dec hl
+    ld (hl),0
+
+    formatstr_no_leading_zeros:
+    ; there are no more leading zeros
+    ; Truncate the number of digits if necessary based on FORMAT_LEN
+
+    call formatstr_remove_trailing_zeros
+    pop hl  ; points to the first digit
+    pop de  ; exponent
+
+    ; Make sure the first digit isn't 0x00
+    ld a,(hl)
+    or a
+    jr nz,formatstr_2
+    ld (hl),'0'
+    inc hl
+    ld (hl),a
+    ret
+    formatstr_2:
+
+    call formatstr_check_eng
+    jr c,formatstr_eng
+    inc de
+    bit 7,d
+    jr nz,formatstr_neg_exp
+    ; Otherwise, we need to insert a decimal after DE digits (D is 0, though)
+    ld b,d
+    ld c,e
+    xor a
+    cp e
+    jr z,formatstr_insert_decimal
+    cpir
+    ; If we have reached a 0x00, we may need to pad with zeros
+    jr z,formatstr_pad_right
+    ; otherwise, let's insert the decimal
+    formatstr_insert_decimal:
+    ld a,(hl)
+    or a
+    ret z
+    ld a,TOK_DECIMAL
+    formatstr_insert_decimal_loop:
+    ld c,(hl) ; back up digit
+    ld (hl),a
+    inc hl
+    ld a,c
+    or a
+    jr nz,formatstr_insert_decimal_loop
+    ld (hl),a
+    ret
+
+    formatstr_neg_exp:
+    ; Need to pad -DE 0s to the left
+    xor a
+    ld c,a
+    cpir
+    ld b,a
+    sub c
+    ld c,a
+    ;HL-1 is where to start reading bytes
+    ;HL-DE is where to start writing bytes
+    xor a
+    ld d,a
+    sub e     ; A is the number of 0s to write
+    ld e,a
+    ex de,hl
+    add hl,de
+    ex de,hl
+    dec hl
+    ; DE points to where to write the last byte
+    ; HL points to where to read it from
+    ; BC is the number of bytes to copy (it will be non-zero)
+    ; A is the number of zeros to insert
+    lddr
+    ;now from DE backwards, write A '0's
+    ex de,hl
+    ld b,a
+    ld (hl),'0'
+    dec hl
+    djnz $-3
+    ; finally, write a '.'
+    ld (hl),TOK_DECIMAL
+    ret
+
+    formatstr_pad_right:
+    ; append BC+1 0s
+    dec hl
+    inc bc
+    formatstr_3:
+    ld (hl),'0'
+    cpi
+    jp pe,formatstr_3
+    ld (hl),0
+    ret
+
+    formatstr_eng:
+    ; need to insert a decimal after the first digit
+    inc hl
+    call formatstr_insert_decimal
+    ld (hl),TOK_ENG
+    inc hl
+    bit 7,d
+    jr z,formatstr_exp_to_str
+    ld (hl),TOK_NEG
+    inc hl
+    xor a
+    sub e
+    ld e,a
+    sbc a,a
+    sub d
+    ld d,a
+    formatstr_exp_to_str:
+    ex de,hl
+    ld a,'0'-1
+    ld bc,-10000
+    formatstr_4:
+    inc a
+    add hl,bc
+    jr c,formatstr_4
+    cp '0'
+    jr z,$+4
+    ld (de),a
+    inc de
+
+    ld a,'9'+1
+    ld bc,1000
+    formatstr_5:
+    dec a
+    add hl,bc
+    jr nc,formatstr_5
+    cp '0'
+    jr z,$+4
+    ld (de),a
+    inc de
+
+    ld a,'0'-1
+    ld bc,-100
+    formatstr_6:
+    inc a
+    add hl,bc
+    jr c,formatstr_6
+    cp '0'
+    jr z,$+4
+    ld (de),a
+    inc de
+
+    ld b,10
+    ld a,l
+    formatstr_7:
+    add a,10
+    dec b
+    jr nc,formatstr_7
+    ex de,hl
+    jr z,formatstr_eng_last_digit
+    set 4,b
+    set 5,b
+    ld (hl),b
+    inc hl
+    formatstr_eng_last_digit:
+    add a,'0'
+    ld (hl),a
+    inc hl
+    ld (hl),0
+    ret
+
+    formatstr_remove_trailing_zeros:
+    ; first, seek the end of the string
+    xor a
+    ld c,a
+    ld b,a
+    cpir
+    dec hl
+    ld a,'0'
+    formatstr_8:
+    dec hl
+    cp (hl)
+    jr z,formatstr_8
+    inc hl
+    ld (hl),0
+    ret
+
+    formatstr_check_eng:
+    ; Return carry flag set if engineering format is required, else nc
+    ;
+    ; If the exponent is greater than FORMAT_MAX_ENGINEERING, then use enginieering
+    ; notation. Note that FORMAT_MAX_ENGINEERING < 256, so check that D = -1 or 0
+    ld a,d
+    inc a
+    jr z,formatstr_check_eng_neg
+    add a,254
+    ret c   ;the exponent is too big in magnitude, engineering format is required.
+    ; The exponent is positive and less than 256
+
+    ld a,FORMAT_LEN
+    cp e
+    ret
+
+    formatstr_check_eng_neg:
+    ;The exponent is negative and greater than or equal to -256
+
+    ld a,FORMAT_MIN_ENGINEERING
+    cp e
+    ccf
+    ret
+
+
+f24pow10_LUT:
+  code: |
+    db $8E,$15,$7E  ;1e19
+    db $17,$BC,$7A  ;1e18
+    db $45,$63,$77  ;1e17
+    db $38,$1C,$74  ;1e16
+    db $BF,$C6,$70  ;1e15
+    db $CC,$6B,$6D  ;1e14
+    db $0A,$23,$6A  ;1e13
+    db $A9,$D1,$66  ;1e12
+    db $87,$74,$63  ;1e11
+    db $06,$2A,$60  ;1e10
+    db $D6,$DC,$5C  ;1e9
+    db $78,$7D,$59  ;1e8
+    db $2D,$31,$56  ;1e7
+    db $48,$E8,$52  ;1e6
+    db $A0,$86,$4F  ;1e5
+    db $80,$38,$4C  ;1e4
+    db $00,$F4,$48  ;1e3
+    db $00,$90,$45  ;1e2
+    f24const_10:
+    db $00,$40,$42  ;1e1
+    db $00,$00,$3F  ;1e0
+    db $9A,$99,$3B  ;1e-1
+    db $AE,$47,$38  ;1e-2
+    db $25,$06,$35  ;1e-3
+    db $6E,$A3,$31  ;1e-4
+    db $8B,$4F,$2E  ;1e-5
+    db $6F,$0C,$2B  ;1e-6
+    db $7F,$AD,$27  ;1e-7
+    db $99,$57,$24  ;1e-8
+    db $E1,$12,$21  ;1e-9
+    db $CE,$B7,$1D  ;1e-10
+    db $D8,$5F,$1A  ;1e-11
+    db $7A,$19,$17  ;1e-12
+    db $5C,$C2,$13  ;1e-13
+    db $4A,$68,$10  ;1e-14
+    db $3B,$20,$0D  ;1e-15
+    db $2B,$CD,$09  ;1e-16
+    db $EF,$70,$06  ;1e-17
+    db $26,$27,$03  ;1e-18
+
+
+f24_common_str:
+  code: |
+    s_neginf:
+    str_neginf:
+    db char_NEG
+    s_inf:
+    str_inf:
+    db "inf",0
+    s_NaN:
+    str_NaN:
+    db "NaN",0
+    str_Zero:
+    db "0", 0

--- a/lsx.env
+++ b/lsx.env
@@ -1,6 +1,7 @@
 default_org:	"$100"
 libraries:
   - runtime.yml
+  - libfloat.yml
   - liblsx_base.yml
   - liblsx_input.yml
   - liblsx_print.yml

--- a/msx2.env
+++ b/msx2.env
@@ -1,6 +1,7 @@
 default_org:	"$100"
 libraries:
   - runtime.yml
+  - libfloat.yml
   - liblsx_base.yml
   - liblsx_input.yml
   - liblsx_print.yml

--- a/sos.env
+++ b/sos.env
@@ -1,6 +1,7 @@
 default_org:	"$3000"
 libraries:
   - runtime.yml
+  - libfloat.yml
   - libsos_base.yml
   - libsos_input.yml
   - libsos_print.yml


### PR DESCRIPTION
* BYTE、WORDに加え、FLOAT型を追加しました
* 24bit浮動小数点なので精度はそれなりです(-32768～32767)
* 四則演算と単純な変数への代入のみサポートしており、関数への引数渡しなどはほぼ未チェックです
* 配列なども未チェックです
* FLOAT未対応の演算などを使うとエラーが出るのはまだいい方で、何も出さずに変な演算をする事があります
* 暗黙でキャストします(FLOATとWORD間での代入に対応。BYTEは怪しいです)
* 文字列表示関数 FL$() を追加しました。FLOAT型の値を渡す事で表示出来ます
* 三角関数などはまだありません
* FLOAT型はこちらのf24型を利用させていただいています→ https://github.com/Zeda/z80float
* mainにマージしないかもしれません(言語的な全対応を保証出来そうにないため)