### PR TITLE
外部シンボルを格納アドレス指定により指定可能にしました

### DIFF
--- a/SLANG/SLANG.Language.grammar.y
+++ b/SLANG/SLANG.Language.grammar.y
@@ -514,7 +514,7 @@ float_spec
 
 declarator2
        : IDENTIFIER { $$ = Tree.CreateDeclIdentifier(DeclNode.Id, $1); }
-       | declarator2 COLON expr { $$ = $1.UpdateIdentifier(createExprString($3)); } // Address
+       | declarator2 COLON expr { $$ = $1.UpdateIdentifier(createExprString($3, true)); } // Address
        | declarator2 AB_OPEN B_CLOSE { $$ = Tree.CreateArray($1, null);  } // Array or Indirect
        | declarator2 AB_OPEN expr B_CLOSE { $$ = Tree.CreateArray($1, $3);  } // Array(with size)
        ;
@@ -527,7 +527,7 @@ func_head_decl
 
 func_declarator
        : IDENTIFIER { $$ = Tree.CreateDeclIdentifier(DeclNode.Id, $1); }
-       | func_declarator COLON expr { $$ = $1.UpdateIdentifier(createExprString($3)); }
+       | func_declarator COLON expr { $$ = $1.UpdateIdentifier(createExprString($3, true)); }
        | func_declarator P_OPEN P_CLOSE { $$ = Tree.CreateFuncDecl($1, null ); }
        | func_declarator P_OPEN expr P_CLOSE { $$ = Tree.CreateFuncDecl($1, $3 ); }
        ;


### PR DESCRIPTION
* ARRAY EXTARR[]:EXTERNALLABEL; のようにする事で、変数EXTARRを経由して、EXTERNALLABELという外部のラベルを参照出来ます。

つまり

```
ARRAY EXTARR[]:EXTERNALLABEL;

MAIN()
BEGIN
   PCG_DEF(65, EXTARR);
END;

#ASM
EXTERNALLABEL:
  DB 1,2,3
#END
```
のように、ラベル名(EXTERNALLABEL)を変数(EXTARR)として使えるようになります(もちろんEXTERNALLABELラベルを含むソースはSLANGソースに含めず、別途アセンブル時に混ぜても構いません)