### PR TITLE
S-OS turbo版でPSGドライバが正常に動作するよう対応＋α

### DIFF
--- a/extlib/psgdriverx1.asm
+++ b/extlib/psgdriverx1.asm
@@ -115,7 +115,7 @@ SOUNDDRV_INIT:
     ; 割り込み先アドレスが格納されている場合はturboである
     LD DE,(NAME_SPACE_DEFAULT._ISRADR)
     LD A,E
-    OR E
+    OR D
     JR NZ,PSG_TURBO
 
     ; 非turboなので普通にやる

--- a/extlib/psgdriverx1.asm
+++ b/extlib/psgdriverx1.asm
@@ -53,7 +53,16 @@ SOUNDDRV_INIT:
     PUSH IX
     PUSH IY
 
+
+    PUSH HL
 	CALL GICINI		                ; GICINI	PSGの初期化
+    POP HL
+
+    ; L = MODE
+    ;   0 = NON INTERRUPT 1 = USE CTC
+    LD A,L
+    OR A
+    JP Z,NOCTC
 
     DI
 

--- a/extlib/psgdriverx1.asm
+++ b/extlib/psgdriverx1.asm
@@ -104,11 +104,48 @@ SOUNDDRV_INIT:
     INC HL
     LD      B,(HL)
     LD      (CTC3BACKUP),BC
-    LD      BC,SOUNDDRV_EXEC
     DEC HL
+
+#IF NAME_SPACE_DEFAULT.OS_TYPE == 0
+    LD      BC,SOUNDDRV_EXEC
     LD      (HL),C
     INC HL
     LD      (HL),B
+#ELIF NAME_SPACE_DEFAULT.OS_TYPE == 1
+    ; 割り込み先アドレスが格納されている場合はturboである
+    LD DE,(NAME_SPACE_DEFAULT._ISRADR)
+    LD A,E
+    OR E
+    JR NZ,PSG_TURBO
+
+    ; 非turboなので普通にやる
+    LD      BC,SOUNDDRV_EXEC
+    LD      (HL),C
+    INC HL
+    LD      (HL),B
+
+    JR CTCCHECKEND
+
+PSG_TURBO:
+    ; S-OS turboである
+    ;   0000 - 7FFFがBIOS ROMである可能性があるので一度8000H-FFFFHに一時ハンドラを置き、
+    ;   そこから本来のアドレスに飛んでやる(飛んだ先からはRETで返る必要がある)
+    ; ただし必ず8000H以降のアドレスにサウンドドライバがある場合は、
+    ; ↑の通常の処理で良い(その方が速いはずなので臨機応変に対応の事……)
+    LD (HL),E
+    INC HL
+    LD (HL),D
+
+    ; 汎用割り込み処理のジャンプ先にSOUNDDRV_EXECのアドレスを入れてやる
+    LD DE,SOUNDDRV_EXEC
+    LD HL,(NAME_SPACE_DEFAULT._ISRHANDLER)
+    LD (HL),E
+    INC HL
+    LD (HL),D
+
+    LD A,$C9        ; RETIをRETに書き換える
+    LD (SOUNDDRV_EXEC_END),A
+#ENDIF
 
     JR CTCCHECKEND
 NOCTC:
@@ -473,6 +510,7 @@ SOUNDDRV_RESUME_EXIT:
 ; DRIVER EXECUTE
 ; ====================================================================================================
 SOUNDDRV_EXEC:
+    DI
     PUSH AF
     PUSH HL
     PUSH DE
@@ -512,9 +550,12 @@ SOUNDDRV_EXIT:
     POP DE
     POP HL
     POP AF
+
     EI
+SOUNDDRV_EXEC_END:
+    ; RETになる可能性がある(S-OS turbo版)
     RETI
-;    RET
+
 ;    JP SOUNDDRV_H_TIMI_BACKUP
 #ENDLIB
 

--- a/libsos_base.yml
+++ b/libsos_base.yml
@@ -62,6 +62,12 @@ SLANGINIT:
     LD	BC,01FA0H
     CALL	CHKCTC
 
+    ; CTCが無い場合はCTC関連の初期化はしない
+    LD BC,(_CTC)
+    LD A,C
+    OR B
+    JP Z,SETCTCADREND
+
     ; #VER
     ; Hレジスタ
     ; 機種別情報を元に割り込みベクタアドレスを決める
@@ -80,15 +86,73 @@ SLANGINIT:
     ; normal X1 S-OS or 筑紫版
     LD HL,0058H
     LD (_CTCVEC),HL
+
+    ; ここが0だとS-OS turbo以外であるという事(0000H-7FFFHが常にメインRAMの想定で良いはず)
+    LD HL,0
+    LD (_ISRADR),HL
+
     JR SETCTCADREND
 
     CTCX1TURBO:
     ; X1turbo
     LD HL,F830H
     LD (_CTCVEC),HL
-    SETCTCADREND:
 
+    ; turbo用パッチ
+    LD A,010H
+    LD ($F850),A
+
+    ; MEMAXにturbo用の割り込み処理を転送してやる
+    LD HL,(sMEMAX)
+    LD BC,ISR_ENTRY_END - ISR_ENTRY
+    OR A
+    SBC HL,BC
+    PUSH HL
+    DEC HL
+    ; 割り込み処理ぶんMEMAXを減らす
+    LD (sMEMAX),HL
+    INC HL
+    EX DE,HL
+    LD HL,ISR_ENTRY
+    LD BC,ISR_ENTRY_END - ISR_ENTRY
+    LDIR
+
+    ; アドレスを書きかえてやる
+    POP HL
+    PUSH HL
+    ; 先頭アドレスを保存
+    LD (_ISRADR),HL
+    OR A
+    LD BC,7
+    ADD HL,BC ; 新しいISR_SAFEのアドレス
+    EX DE,HL
+    POP HL
+    ; HL = 転送したISR_ENTRYの先頭(割り込み先)
+    INC HL
+    INC HL
+    LD (HL),E  ; LD HL,ISR_SAFEのISR_SAFEのところを正しいアドレスにしてやる
+    INC HL
+    LD (HL),D
+    LD BC,9
+    ADD HL,BC
+    ; HL = JP 0の、0の位置
+    LD (_ISRHANDLER),HL ; _ISRHANDLERに入ったアドレスに割り込み先アドレスを書くとイイ
+
+    SETCTCADREND:
     RET
+
+    ; 割り込みの一時ハンドラ
+    ISR_ENTRY:
+    PUSH HL
+    ISR_SAFE_ADDR:
+    LD HL,ISR_SAFE
+    JP 0xf847
+    ISR_SAFE:
+    LD A,1Eh
+    OUT (0x00),A
+    ISR_HANDLER_ADDR:
+    JP 0    ; 割り込み処理の飛び先(0000H-FFFFHどこでもいい)
+    ISR_ENTRY_END:
 
     CHKCTC:
     PUSH	BC
@@ -140,6 +204,7 @@ SOSCALLS:
     sHLHEX  EQU 1FB2H
     sKBFAD  EQU 1F76H
 
+    sMEMAX  EQU 1F6AH
     sFILE   EQU 1FA3H
     sDSK    EQU 1F5DH
     sFATPOS EQU 1F5EH
@@ -156,6 +221,8 @@ SOSCALLS:
     AT_WIDTH: 1
     _CTC: 2
     _CTCVEC: 2
+    _ISRADR: 2
+    _ISRHANDLER: 2
 
 BEEP:
   code: |

--- a/libx1_base.yml
+++ b/libx1_base.yml
@@ -1,0 +1,54 @@
+
+VSYNC_CHECK:
+  code: |
+    LD A,1AH
+    IN A,(01H)
+
+    LD HL,LASTVSYNCFLAG
+    XOR (HL)
+    RET P
+    XOR (HL)
+    LD (HL),A
+    RET M
+    ; LD HL,VSYNCCOUNTER
+    INC HL
+    INC (HL)
+
+    JP !VSYNC_PROC
+  works:
+    LASTVSYNCFLAG: 1
+    VSYNCCOUNTER: 1
+
+VSYNC:
+  calls:
+    - VSYNC_CHECK
+  code: |
+    ; HL = WAIT COUNT
+    VSYNC_LOOP:
+    LD A,(VSYNCCOUNTER)
+    CP L
+    JP NC,VSYNC_OVER
+    PUSH HL
+    CALL VSYNC_CHECK
+    POP HL
+    JP VSYNC_LOOP
+
+    VSYNC_OVER:
+    XOR A
+    LD (VSYNCCOUNTER),A
+
+    RET
+
+VSYNC1:
+  code: |
+    ; VSYNC
+    LD BC,$1a01
+    .LP1
+    DB $ED,$70  ; IN F,(C)
+    JP P,.LP1
+    DI
+    .LP2
+    DB $ED,$70
+    JP M,.LP2
+    EI
+    RET

--- a/libx1_psg.yml
+++ b/libx1_psg.yml
@@ -55,17 +55,3 @@ PSG_END:
   lib_name: PSGLIB
   extlib: psgdriverx1.asm:PSG_END
 
-VSYNC:
-  code: |
-    ; VSYNC
-    LD BC,$1a01
-    .LP1
-    DB $ED,$70  ; IN F,(C)
-    JP P,.LP1
-    DI
-    .LP2
-    DB $ED,$70
-    JP M,.LP2
-    EI
-    RET
-

--- a/lsx.env
+++ b/lsx.env
@@ -8,4 +8,5 @@ libraries:
   - liblsx_input.yml
   - liblsx_print.yml
   - liblsx_file.yml
+  - libx1_base.yml
   - libx1_psg.yml

--- a/sos.env
+++ b/sos.env
@@ -11,4 +11,5 @@ libraries:
   - libsos_pcg.yml
   - libmag.yml
   - libm8a.yml
+  - libx1_base.yml
   - libx1_psg.yml

--- a/x1.env
+++ b/x1.env
@@ -5,6 +5,7 @@ libraries:
   - runtime.yml
   - libfloat.yml
   - liblsx_base.yml
+  - libx1_base.yml
   - liblsx_input.yml
   - libx1_print.yml
   - liblsx_file.yml
@@ -12,4 +13,3 @@ libraries:
   - libmag.yml
   - libm8a.yml
   - libx1_psg.yml
-  


### PR DESCRIPTION
* 場合により0000H - 7FFFHがメインのRAMではない可能性があったので、その範囲にPSGドライバがあると変な事になっていた(っぽい)
* そこで、一時割り込み処理を8000H-FFFFHのどこか(MEMAXの手前)に置いてからメモリを戻し、本来の割り込み先に飛ぶように対応
* 色々ややこしいので、S-OS turbo版を使わずに、turboでもX1高速版を使いつつBIOSに触らないようにする、というのがいい気はします(あるいは割り込み先が8000H以降になるよう工夫する)