### PR TITLE
変数定義時のアドレス指定内の「^」の左をAILZ80ASMのネームスペースとして扱うよう対応

### DIFF
--- a/SLANG/Tree.cs
+++ b/SLANG/Tree.cs
@@ -272,6 +272,8 @@ namespace SLANGCompiler.SLANG
         {
             if(address != null)
             {
+                // 特殊仕様。シンボル内の ^ は .に変換する(これによりAILZ80ASMのnamespaceに対応する)
+                address = address.Replace("^",".");
                 this.Address = new ConstInfo(address, false);
             }
             if(initialValue != null)


### PR DESCRIPTION
*         WORD    _ZAHYO[255][2]:MAGIC^OBJ_BUF;    的な話です(ややこしい)