### PR TITLE
ビルド用Makefile追加

### DIFF
--- a/env/Makefile
+++ b/env/Makefile
@@ -1,0 +1,122 @@
+# ファイル名拡張子の設定
+SRC_EXT = .sl
+ASM_EXT = .asm
+BIN_EXT = .bin
+
+# 環境名を指定
+ENV ?= lsx
+SLANGENV=$(ENV)
+
+# ファイル名（拡張子なし）を指定
+TARGET ?= examples/STARS
+
+# S-OS用の実行アドレスとロードアドレス
+RUNADR = 3000
+LOADADR = 3000
+
+# ツールのコマンド名
+SLANGCOMPILER = bin/SLANGcompiler
+ASM = tools/AILZ80ASM
+NDC = tools/ndc
+HUDISK = tools/HuDisk
+
+OUTPROG = $(dir $(TARGET))PROG.bin
+
+# エミュレータのコマンド名とディスクイメージファイル名を環境に応じて設定
+ifeq ($(ENV), lsx)
+  EMU = C:\emu\X1\X1.exe
+  # EMU = wine ~/emu/X1/X1.exe
+  DISK_IMAGE = images/LSXPROG.D88
+  BIN_EXT_ENV = .com
+else ifeq ($(ENV), x1)
+  EMU = C:\emu\X1\X1.exe
+  # EMU = wine ~/emu/X1/X1.exe
+  DISK_IMAGE = images/LSXPROG.D88
+  BIN_EXT_ENV = .com
+else ifeq ($(ENV), sos)
+  EMU = C:\emu\X1\X1.exe
+  # EMU = wine ~/emu/X1/X1.exe
+  DISK_IMAGE = images/SOSPROG.D88
+  BIN_EXT_ENV = $(BIN_EXT)
+else ifeq ($(ENV), msxrom)
+  EMU = C:\emu\MSX\openmsx\openmsx.exe
+  # EMU = /Applications/openMSX.app/Contents/MacOS/openmsx
+  BIN_EXT_ENV = $(BIN_EXT)
+  EMUOPT = -cart
+  DISK_IMAGE = $(OUTPROG)
+else ifeq ($(ENV), msx2)
+  EMU = C:\emu\MSX\openmsx\openmsx.exe
+  # EMU = /Applications/openMSX.app/Contents/MacOS/openmsx
+  DISK_IMAGE = images/dosformsx.dsk
+  BIN_EXT_ENV = .com
+  EMUOPT = -diska
+else ifeq ($(ENV), cpm)
+  SLANGENV=lsx
+  EMU = tools/cpm.exe
+  # EMU = wine ./tools/cpm.exe
+  DISK_IMAGE = $(OUTPROG)
+endif
+
+IMGPROG = $(basename $(OUTPROG))$(BIN_EXT_ENV)
+
+# リネーム関数
+define rename_func
+ifeq ($(OS),Windows_NT)
+  move /Y $(1) $(2)
+else
+  mv $(1) $(2)
+endif
+endef
+
+all: run
+
+# ソースコードのコンパイル
+$(TARGET)$(ASM_EXT): $(TARGET)$(SRC_EXT)
+	$(SLANGCOMPILER) $< -E $(SLANGENV)
+
+# アセンブリコードのアセンブル
+$(OUTPROG): $(TARGET)$(ASM_EXT)
+	$(ASM) $< -f -o $@
+
+# ディスクイメージにバイナリファイルを格納
+ifeq ($(ENV), cpm)
+disk_image: $(OUTPROG)
+else ifeq ($(ENV), msxrom)
+disk_image: $(OUTPROG)
+else ifeq ($(ENV), sos)
+disk_image: $(IMGPROG)
+	$(HUDISK) -d $(DISK_IMAGE) PROG.bin
+	$(HUDISK) -a $(DISK_IMAGE) $(IMGPROG) -r $(LOADADR) -g $(RUNADR)
+else ifeq ($(ENV), msx2)
+disk_image: $(IMGPROG)
+	- $(NDC) D $(DISK_IMAGE) 0 PROG$(BIN_EXT_ENV)
+	$(NDC) P $(DISK_IMAGE) 0 $(IMGPROG)
+else
+disk_image: $(IMGPROG)
+	- $(NDC) D $(DISK_IMAGE) 0 PROG$(BIN_EXT_ENV)
+	$(NDC) P $(DISK_IMAGE) 0 $(IMGPROG)
+endif
+
+# バイナリファイルの拡張子を環境に応じて変更(必要に応じて)
+ifneq ($(BIN_EXT), $(BIN_EXT_ENV))
+$(basename $(OUTPROG))$(BIN_EXT_ENV): $(OUTPROG)
+ifeq ($(OS),Windows_NT)
+	move $< $@
+else
+	mv $< $@
+endif
+endif
+
+# エミュレータでの実行
+run: disk_image
+	$(EMU) $(EMUOPT) $(DISK_IMAGE)
+
+# クリーンアップ
+clean:
+ifeq ($(OS),Windows_NT)
+	del /Q /F $(subst /,\,$(TARGET)$(ASM_EXT)) $(subst /,\,$(TARGET)$(BIN_EXT)) $(subst /,\,$(dir $(TARGET))PROG.bin) $(subst /,\,$(dir $(TARGET))PROG.com)
+else
+	rm -f $(TARGET)$(ASM_EXT) $(TARGET)$(BIN_EXT) $(TARGET)$(BIN_EXT_ENV) $(subst /,\,$(dir $(TARGET))PROG.bin) $(subst /,\,$(dir $(TARGET))PROG.com)
+endif
+
+.PHONY: all run clean

--- a/setupenv.bat
+++ b/setupenv.bat
@@ -78,6 +78,16 @@ REM どうしたものか……
 REM curl https://github.com/tablacus/LSX-Dodgers/releases/download/1.55/ldsys155.zip -OL
 REM unzip ldsys155.zip
 
+REM 似非DOS for MSXをダウンロード
+curl https://github.com/tablacus/dosformsx/releases/download/0.16/dosformsx_016.zip -OL
+unzip -xo dosformsx_016.zip
+REM AUTOEXEC.BATを追加
+%TOOLPATH%NDC P dosformsx.dsk 0 ..\env\LSX-Dodgers\AUTOEXEC.BAT
+copy dosformsx.dsk ..\images\
+DEL dosformsx.dsk
+DEL dos2formsx.dsk
+DEL dosformsx_016.zip
+
 cd ..
 rmdir temp /q
 

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -122,6 +122,16 @@ rm SWXCV110.zip
 # curl https://github.com/tablacus/LSX-Dodgers/releases/download/1.55/ldsys155.zip -OL
 # unzip ldsys155.zip
 
+# 似非DOS for MSXをダウンロード
+curl https://github.com/tablacus/dosformsx/releases/download/0.16/dosformsx_016.zip -OL
+unzip -xo dosformsx_016.zip
+# AUTOEXEC.BATを追加
+$TOOLPATH/ndc P dosformsx.dsk 0 ../env/LSX-Dodgers/AUTOEXEC.BAT
+cp dosformsx.dsk ../images/
+rm dosformsx.dsk
+rm dos2formsx.dsk
+rm dosformsx_016.zip
+
 cd ..
 rm -rf temp
 


### PR DESCRIPTION
* MSX2ディスク環境を実行可能にしました
* make TARGET=examples/FMANDEL ENV=msx2  といった感じで、TARGETに拡張子抜きのファイル名、ENVに環境名を指定します(msx2以外、環境名としてlsx、x1、sos、msxrom、cpmの指定が可能です)
* setupenv.bat/.shも更新しており、Gakuさんの似非DOS for MSXのディスクイメージを取得しています。makeでmsx2環境のものを動かす場合は、事前にsetupenvでディスクイメージファイルを取得しておいてください。