### PR TITLE
Fix byte size indirect variable

### DIFF
--- a/SLANG/SLANG.Parser.CodeGen.cs
+++ b/SLANG/SLANG.Parser.CodeGen.cs
@@ -511,12 +511,17 @@ namespace SLANGCompiler.SLANG
             Expr left = expr.Left;
             Expr right = expr.Right;
 
-
+            // 変更した＃＃＃＃＃＃
+            bool isByte = expr.OpType == OperatorType.Byte;
+            bool isWord = expr.OpType == OperatorType.Word;
+            bool isFloat = expr.OpType == OperatorType.Float;
+            /*
             // BYTE or WORD or FLOAT
             TypeDataSize assignType = left.TypeInfo.GetDataSize();
             bool isByte = left.TypeInfo.GetDataSize() == TypeDataSize.Byte;
             bool isWord = left.TypeInfo.GetDataSize() == TypeDataSize.Word;
             bool isFloat = left.TypeInfo.GetDataSize() == TypeDataSize.Float;
+            */
 
             if(left.Opcode == Opcode.PortAccess)
             {
@@ -1606,7 +1611,12 @@ namespace SLANGCompiler.SLANG
                 {
                     // IYからのオフセットで得る
                     var ofs = symbol.Address.Value + expr.Left.SymbolOffset;
-                    if(symbol.TypeInfo.GetDataSize()== TypeDataSize.Byte)
+                    if (typeInfo.InfoClass == TypeInfoClass.Pointer)         // 追加(強引？) ＃＃＃＃＃＃
+                    {                                                               // 追加 ＃＃＃＃＃＃
+                        gencode($" LD L,(IY+{ofs})\n");                             // 追加 ＃＃＃＃＃＃
+                        gencode($" LD H,(IY+{ofs + 1})\n");                         // 追加 ＃＃＃＃＃＃
+                    } else                                                          // 追加 ＃＃＃＃＃＃
+                    if (symbol.TypeInfo.GetDataSize()== TypeDataSize.Byte)
                     {
                         gencode($" LD L,(IY+{ofs})\n");
                     } else if(typeInfo.GetDataSize() == TypeDataSize.Word)

--- a/SLANG/SLANG.Parser.Expr.cs
+++ b/SLANG/SLANG.Parser.Expr.cs
@@ -316,7 +316,8 @@ namespace SLANGCompiler.SLANG
                 e.Symbol = table;
                 e.SymbolOffset = 0;
                 return e;
-            } else {
+            }
+            else {
                 // 単純変数または間接変数
                 e = makeNode1(Opcode.Adr, OperatorType.Pointer, typeInfo.MakePointer(), null);
                 e.Symbol = table;
@@ -549,6 +550,9 @@ namespace SLANGCompiler.SLANG
                             return makeNode1(Opcode.WtoB, OperatorType.Byte, TypeInfo.ByteTypeInfo, a);
                         case OperatorType.Bool:
                             return deBool(a, OperatorType.Byte);
+                        case OperatorType.Pointer:
+                            bug("coerce1p");
+                            break;
                         default:
                             bug("coerce1");
                             break;
@@ -1228,8 +1232,14 @@ namespace SLANGCompiler.SLANG
                 Error($"l-value required ( {left.Opcode} )");
                 return null;
             }
-            if((ltype.IsNumeric() || ltype.IsPointer()) && (rtype.IsNumeric() || rtype.IsPointer()))
+            if (ltype.IsIndirect() && (rtype.IsNumeric() || rtype.IsPointer()))
             {
+                // 追加した＃＃＃＃＃
+                return makeNode2(Opcode.Assign, OperatorType.Word, ltype, left, coerce(right, OperatorType.Word));
+            }
+            if ((ltype.IsNumeric() || ltype.IsPointer()) && (rtype.IsNumeric() || rtype.IsPointer()))
+            {
+                // ここがが問題？間接変数への代入処理 ＃＃＃＃＃
                 return makeNode2(Opcode.Assign, ltype.ToOptype(), ltype, left, coerce(right, ltype.ToOptype()) );
             }
             Error("=: type mismatch " + ltype + "\n:" + rtype);

--- a/SLANG/SymbolManager.cs
+++ b/SLANG/SymbolManager.cs
@@ -233,10 +233,14 @@ namespace SLANGCompiler.SLANG
                     outputStreamWriter.WriteLine($"{labelName} EQU ({prefix}__WORK__ + {workOffset})");
                 }
 
-                if(symbol.TypeInfo.IsArray())
+                if (symbol.TypeInfo.IsArray())
                 {
                     workOffset += symbol.Size;
-                } else {
+                } else if (symbol.TypeInfo.IsPointer() || symbol.TypeInfo.IsIndirect())     // 追加 ＃＃＃＃＃＃
+                { // 追加 ＃＃＃＃＃＃
+                    workOffset += 2;                // 間接変数の場合，型によらず2バイト必要 ＃＃＃＃＃＃
+                } // 追加 ＃＃＃＃＃＃
+                else {
                     workOffset += symbol.TypeInfo.GetDataSize().GetDataSize();
                 }
             }

--- a/SLANGTEST.SL
+++ b/SLANGTEST.SL
@@ -27,6 +27,9 @@ ARRAY ARI[32]={
 };
 VAR IVV=14;
 
+// BYTE型間接変数
+VAR BYTE IVALB[];
+
 (* テスト番号 *)
 VAR TNUM;
 
@@ -399,6 +402,12 @@ LABEL1:
       }
     }
 #END
+
+    // BYTE型間接変数のアドレスを設定できるか、正しくアクセスできるか
+    FOR VAL=0 TO 31 ARB[VAL] = VAL + 1;
+    IVALB = ARB;    // オリジナルS-OS版ではokだが0.8.3ではコンパイルエラー(bug:coerce1)
+    IF IVALB[3] == 4 THEN PRINT(TNUM,"OK",/) ELSE PRINT(TNUM,"NG",/);
+    TNUM++;
 
     PRINT("INPUT 'START'\n");
     GETL(AARB);


### PR DESCRIPTION
BYTE型の間接変数(VAR BYTE P[] など)に関する不具合を見つけましたのでご連絡します。
BYTE型の間接変数自体のサイズ(C言語風に書けばsizeof(BYTE*))は2バイトになりますが内部的に1バイトとして扱われており，これに起因して以下の問題が生じています。

- 代入の左辺がBYTE型の間接変数の場合，WORD型の値(アドレス)を代入するとコンパイルエラーになる
　例：
    ARRAY BYTE ARB[32];
    VAR BYTE P[ ];
    P=ARB;        // ← ここでbug:coerce1 (オリジナルのS-OS版SLANGではコンパイルできる)

- BYTE型の間接変数がメモリ上で1バイトのサイズで確保される
- BYTE型の間接変数に対する[ ]演算子のアドレス計算が1バイトで行われるため正しく参照できない

一応，改変して動作しましたのでpull requestとして送付しますが，ソースを完全に理解できておらず改変部が他の型に悪影響を及ぼしている可能性がありますので，正しい修正を施していただければ幸いです。

以上