### PR TITLE
output-debug-symbolをつけると_(関数名/変数名)_というシンボルを定義するよう対応

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -34,6 +34,9 @@ namespace SLANGCompiler
             [Option("source-comment", Required = false, HelpText = "Include source code as comments.")]
             public bool SourceComment { get; set; }
 
+            [Option("output-debug-symbol", Required = false, HelpText = "Output original symbol name for debug.")]
+            public bool OutputDebugSymbol { get; set; }
+
             [Value(0, Required = true, MetaName = "input files")]
             public IEnumerable<string> Files { get; set; }
         }
@@ -148,6 +151,7 @@ namespace SLANGCompiler
             parser.SetOriginalSymbolUse(opt.UseOriginalSymbol);
             parser.SetCaseSensitiveSymbol(opt.CaseSensitive);
             parser.SetSourceComment(opt.SourceComment);
+            parser.SetOutputDebugSymbol(opt.OutputDebugSymbol);
 
             // 環境名を設定する(設定されていない場合はLSX-Dodgers環境をデフォルトとする)
             string envName = opt.EnvironmentName;

--- a/SLANG/SLANG.Parser.Function.cs
+++ b/SLANG/SLANG.Parser.Function.cs
@@ -111,6 +111,7 @@ namespace SLANGCompiler.SLANG
             localSymbolTableManager = new SymbolTableManager(this);
             localSymbolTableManager.UseOriginalSymbol = symbolTableManager.UseOriginalSymbol;
             localSymbolTableManager.CaseSensitive = symbolTableManager.CaseSensitive;
+            localSymbolTableManager.OutputOriginalSymbol = symbolTableManager.OutputOriginalSymbol;
             funcNumber++;
 
             // 関数のパラメータがくっついているTreeを探す
@@ -212,6 +213,10 @@ namespace SLANGCompiler.SLANG
         private void genfunclabel(SymbolTable symbol)
         {
             var funcLabel = symbol.LabelName;
+            if(symbolTableManager.OutputOriginalSymbol && symbol.OriginalName != funcLabel)
+            {
+                gencode($"_{symbol.NormalizeOriginalName}_ EQU {funcLabel}\n");
+            }
             gencode($"{funcLabel}:\n");
 
             // 一応処理中ですよ、という事で標準出力にも出してみる
@@ -226,7 +231,8 @@ namespace SLANGCompiler.SLANG
             {
                 if(p.SymbolClass == SymbolClass.Global)
                 {
-                    p.LabelHeader = "F" + funcNumber;
+                    // p.LabelHeader = "F" + funcNumber;
+                    p.LabelHeader = currentFunction.NormalizeOriginalName;
                     continue;
                 }
                 p.Address = new ConstInfo(offset);

--- a/SLANG/SLANG.Parser.Symbol.cs
+++ b/SLANG/SLANG.Parser.Symbol.cs
@@ -113,6 +113,15 @@ namespace SLANGCompiler.SLANG
         }
 
         /// <summary>
+        /// シンボルテーブルについてソースコードで使われた変数名、関数名をデバッグ用に定義する( VAL という変数が _VAL_ としてシンボル定義される)
+        /// </summary>
+        public void SetOutputDebugSymbol(bool outputOriginal)
+        {
+            symbolTableManager.OutputOriginalSymbol = outputOriginal;
+            localSymbolTableManager.OutputOriginalSymbol = outputOriginal;
+        }
+
+        /// <summary>
         /// シンボルテーブルとCONSTテーブルについて大文字小文字の区別をする場合はtrue、しない場合はfalseを指定する
         /// </summary>
         public void SetCaseSensitiveSymbol(bool caseSensitive)

--- a/SLANG/SymbolTable.cs
+++ b/SLANG/SymbolTable.cs
@@ -50,6 +50,28 @@ namespace SLANGCompiler.SLANG
             }
         }
 
+        public string OriginalName {
+            get
+            {
+                if(!string.IsNullOrEmpty(LabelHeader))
+                {
+                    // 関数内で定義された変数
+                    return $"{LabelHeader}_{normalizeName}";
+                } else {
+                    // グローバル変数
+                    return normalizeName;
+                }
+            }
+        }
+
+        public string NormalizeOriginalName
+        {
+            get
+            {
+                return OriginalName.Replace('^', '_').Replace('@', '_');
+            }
+        }
+
         /// <summary>
         /// アセンブラソース内で使ってはいけない文字を置き換えて、利用可能な名前に変換する
         /// </summary>


### PR DESCRIPTION
* AILZ80ASMが出力するsymファイルをX1エミュレータで読み込む事で変数アドレスをダンプしたり出来ます
* (takedaさんのデバッガで)
* N PROG.sym
* L
* 等としてから、例えば D _I_ とすると、グローバル変数「I」のアドレスからダンプ出来る
* _FNC_I_ だと、関数FNCで定義されたIを示す
* この関連で一部シンボル命名ルールが変わっているので注意(例えば関数内変数の内部名称が _F0_SYM123 などだったのが _(関数名)_SYM123 になっている)
* 上記の関数名の「@」「^」は「_」に置換されます(なので場合によっては重複するので注意してください)