### PR TITLE
間接変数のポインタの演算がおかしいのを修正

### DIFF
--- a/SLANG/SLANG.Parser.Symbol.cs
+++ b/SLANG/SLANG.Parser.Symbol.cs
@@ -249,20 +249,20 @@ namespace SLANGCompiler.SLANG
                         arrayTree = tree;
                         var baseType = typeInfo;
 
-                        // 間接変数の配列の場合はDataSizeは常にWORDになる(ポインタ配列なので)
-                        TypeDataSize dataSize;
-                        if(isIndirect)
-                        {
-                            dataSize = TypeDataSize.Word;
-                        } else {
-                            dataSize = typeInfo.GetDataSize();
-                        }
                         bool indirectCheck = false;
                         // isArrayがfalseでtree.ArraySizeが0の場合は強制的に間接変数
                         // Sizeが入っている場合は型としてはArrayにする
                         if(!isArray && tree.ArraySize == 0)
                         {
                             indirectCheck = true;
+                        }
+                        // 間接変数自身必ずWORDになる
+                        TypeDataSize dataSize;
+                        if(indirectCheck)
+                        {
+                            dataSize = TypeDataSize.Word;
+                        } else {
+                            dataSize = typeInfo.GetDataSize();
                         }
                         // var tp = new TypeInfo((isArray || arrayCount > 1) ? TypeInfoClass.Array : TypeInfoClass.Indirect, tree.ArraySize + 1, dataSize, typeInfo);
                         var tp = new TypeInfo(!indirectCheck ? TypeInfoClass.Array : TypeInfoClass.Indirect, tree.ArraySize + 1, dataSize, typeInfo);


### PR DESCRIPTION
* BYTEの間接変数のアドレスを加算する時アドレスがBYTE扱いになっていました