### PR TITLE
シフト式の左右の値がWORDにキャストされない問題を修正

### DIFF
--- a/SLANG/SLANG.Parser.Expr.cs
+++ b/SLANG/SLANG.Parser.Expr.cs
@@ -978,7 +978,7 @@ namespace SLANGCompiler.SLANG
                 return left;
             }
             var opType = OperatorType.Word;
-            return makeNode2(opcode, opType, opType.ToType(),  left, right );
+            return makeNode2(opcode, opType, opType.ToType(), coerce(left, opType), coerce(right, opType) );
         }
 
         // カンマ式を作る


### PR DESCRIPTION
```
VAR WORD WORDVAL1;
VAR BYTE BYTEVAL1;

MAIN()
{
    BYTEVAL1  = 123;
    WORDVAL1 = BYTEVAL1 >> 1;
}
```
上記のようなコードでビットシフト時にBYTEVAL1の上位に0が入らず、不定な値が入ったままWORDVAL1に入ってしまっていたのを修正しました。