### PR TITLE
VGS-Zeroの更新を反映

### DIFF
--- a/include/VGS0.SL
+++ b/include/VGS0.SL
@@ -190,3 +190,21 @@ VAR BYTE namtbl_attr[][32-1];
         str++;
     }
 }
+
+vgs0_dma_ram(prg, ofs, sz, dst)
+{
+#ASM
+    ; prg
+    LD  A,(IY+104)
+    ; ofs
+    LD  C,(IY+106)
+    LD  B,(IY+107)
+    ; sz
+    LD  E,(IY+108)
+    LD  D,(IY+109)
+    ; dst
+    LD  L,(IY+110)
+    LD  H,(IY+111)
+    OUT (0xC1), A
+#END
+}

--- a/lib/libdef/libvgs0_base.yml
+++ b/lib/libdef/libvgs0_base.yml
@@ -75,6 +75,12 @@ vgs0_bank3_switch:
     out ($B3), a
     ret
 
+vgs0_rambank_switch:
+  code: |
+    ld a,l
+    out ($B4), a
+    ret
+
 vgs0_bank0_get:
   code: |
     in a, ($B0)
@@ -99,6 +105,13 @@ vgs0_bank2_get:
 vgs0_bank3_get:
   code: |
     in a, ($B3)
+    ld l, a
+    ld h,0
+    ret
+
+vgs0_rambank_get:
+  code: |
+    in a, ($B4)
     ld l, a
     ld h,0
     ret


### PR DESCRIPTION
* 現時点ではVersion 1.10.0まで対応済
* マージについてはもうしばらく保留(VGS-Zero側のバージョンアップが落ち着くまで待つ)