### PR TITLE
FLOAT比較演算の融合ジャンプ対応

### DIFF
--- a/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
+++ b/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
@@ -1195,10 +1195,21 @@ public class CodeGenerator
                 continue;
             }
 
-            // FLOAT reverseHalfDirectOps: src2がAHLに残っている、src1をCDEに直接ロード（可換演算のみ: Add/Mul）
+            // FLOAT reverseHalfDirectOps: src2がAHLに残っている、src1をCDEに直接ロード（可換演算のみ: Add/Mul/CmpEq/CmpNeq）
             if (reverseHalfDirectOps.Contains(i) && inst.DataSize == 3)
             {
                 var s1Inst = insts[tempDef[inst.Src1.TempIndex]];
+
+                // 融合比較ジャンプ: CmpXx + JumpIfZero/NonZero → 直接条件ジャンプ
+                if (fusedCompareJumps.TryGetValue(i, out int frJumpIdx))
+                {
+                    var jumpInst = insts[frJumpIdx];
+                    bool jumpOnTrue = jumpInst.Op == IrOp.JumpIfNonZero;
+                    EmitFloatSrc2ToCDE(s1Inst);
+                    EmitFusedCompareJump(inst, jumpInst.Dest.Name!, jumpOnTrue);
+                    continue;
+                }
+
                 EmitFloatSrc2ToCDE(s1Inst);
                 EmitBinaryDirect(inst);
                 if (inst.Dest.Kind == IrOperandKind.Temp && NeedsPushAfter(insts, i, inst.Dest.TempIndex))

--- a/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
+++ b/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
@@ -1177,6 +1177,17 @@ public class CodeGenerator
             if (halfDirectOps.Contains(i) && inst.DataSize == 3)
             {
                 var s2Inst = insts[tempDef[inst.Src2.TempIndex]];
+
+                // 融合比較ジャンプ: CmpXx + JumpIfZero/NonZero → 直接条件ジャンプ
+                if (fusedCompareJumps.TryGetValue(i, out int fhJumpIdx))
+                {
+                    var jumpInst = insts[fhJumpIdx];
+                    bool jumpOnTrue = jumpInst.Op == IrOp.JumpIfNonZero;
+                    EmitFloatSrc2ToCDE(s2Inst);
+                    EmitFusedCompareJump(inst, jumpInst.Dest.Name!, jumpOnTrue);
+                    continue;
+                }
+
                 EmitFloatSrc2ToCDE(s2Inst);
                 EmitBinaryDirect(inst);
                 if (inst.Dest.Kind == IrOperandKind.Temp && NeedsPushAfter(insts, i, inst.Dest.TempIndex))
@@ -1780,27 +1791,48 @@ public class CodeGenerator
                 _e.Instruction("LD", "HL,$0000"); _e.Instruction("JR", "NZ,$+3"); _e.Instruction("INC", "HL");
                 break;
             case IrOp.CmpNeq:
-                _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                if (isFloat) { CallRuntime("f24cmp"); }
+                else { _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE"); }
                 _e.Instruction("LD", "HL,$0000"); _e.Instruction("JR", "Z,$+3"); _e.Instruction("INC", "HL");
                 break;
             case IrOp.CmpLt:
-                // src1 < src2 → src1-src2: C=true → JR NC(false)でスキップ
-                _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                // src1 < src2 → C=true
+                if (isFloat) { CallRuntime("f24cmp"); }
+                else { _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE"); }
                 _e.Instruction("LD", "HL,$0000"); _e.Instruction("JR", "NC,$+3"); _e.Instruction("INC", "HL");
                 break;
             case IrOp.CmpGe:
-                // src1 >= src2 → src1-src2: NC=true → JR C(false)でスキップ
-                _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                // src1 >= src2 → NC=true
+                if (isFloat) { CallRuntime("f24cmp"); }
+                else { _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE"); }
                 _e.Instruction("LD", "HL,$0000"); _e.Instruction("JR", "C,$+3"); _e.Instruction("INC", "HL");
                 break;
             case IrOp.CmpGt:
-                // src1 > src2 → src2-src1: C=true → JR NC(false)でスキップ
-                _e.Instruction("EX", "DE,HL"); _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                // src1 > src2 → swap and use C
+                if (isFloat)
+                {
+                    _e.Instruction("EX", "DE,HL");
+                    _e.Instruction("LD", "B,A"); _e.Instruction("LD", "A,C"); _e.Instruction("LD", "C,B");
+                    CallRuntime("f24cmp");
+                }
+                else
+                {
+                    _e.Instruction("EX", "DE,HL"); _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                }
                 _e.Instruction("LD", "HL,$0000"); _e.Instruction("JR", "NC,$+3"); _e.Instruction("INC", "HL");
                 break;
             case IrOp.CmpLe:
-                // src1 <= src2 → src2 - src1: carryならsrc1>src2(false)
-                _e.Instruction("EX", "DE,HL"); _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                // src1 <= src2 → swap and check C
+                if (isFloat)
+                {
+                    _e.Instruction("EX", "DE,HL");
+                    _e.Instruction("LD", "B,A"); _e.Instruction("LD", "A,C"); _e.Instruction("LD", "C,B");
+                    CallRuntime("f24cmp");
+                }
+                else
+                {
+                    _e.Instruction("EX", "DE,HL"); _e.Instruction("OR", "A"); _e.Instruction("SBC", "HL,DE");
+                }
                 _e.Instruction("LD", "HL,$0000"); _e.Instruction("JR", "C,$+3"); _e.Instruction("INC", "HL");
                 break;
 

--- a/tests/SLANGCompiler.Tests/IntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/IntegrationTests.cs
@@ -222,4 +222,103 @@ SUB() BEGIN PRINT(""X""); END;
         Assert.Contains("_V_ARI:", asm);
         Assert.DoesNotContain("__INIT_TEMPLATE", asm);
     }
+
+    // ---- FLOAT比較演算テスト ----
+
+    [Fact]
+    public void Float_CmpGt_HalfDirect_UsesFusedJump()
+    {
+        // halfDirectOps FLOAT: f24add結果(AHL) > 定数(CDE) → fusedCompareJump
+        // IF (A*A+B*B) > 4.0 パターン（FMANDEL.SLで問題になったケース）
+        var asm = CompileWithCli(@"
+            VAR FLOAT A, FLOAT B;
+            MAIN() {
+                A = 0.6875; B = 0.5;
+                IF (A*A+B*B) > 4.0 THEN PRINT(""GT"");
+            }");
+        // f24cmpが使われること（整数SBCではなく）
+        Assert.Contains("f24cmp", asm);
+        // 融合ジャンプ: JP C/JP Z パターンが出ること（0/1変換のLD HL,$0000ではなく）
+        Assert.DoesNotContain("JR\tNC,$+3", asm);
+    }
+
+    [Fact]
+    public void Float_CmpGt_Variable_UsesFusedJump()
+    {
+        // 一般パス: FLOAT変数 > FLOAT定数 → EmitCompareGt経由でf24cmp
+        var asm = CompileWithCli(@"
+            VAR FLOAT A;
+            MAIN() {
+                A = 3.0;
+                IF A > 2.0 THEN PRINT(""GT"");
+            }");
+        Assert.Contains("f24cmp", asm);
+    }
+
+    [Fact]
+    public void Float_CmpEq_ReverseHalfDirect_UsesFusedJump()
+    {
+        // reverseHalfDirectOps FLOAT: 定数(simple) == f24演算結果(complex)
+        // SLANGでは == が等値比較
+        var asm = CompileWithCli(@"
+            VAR FLOAT X;
+            MAIN() {
+                X = 0.0;
+                IF 1.0 == FCOS(X) THEN PRINT(""EQ"");
+            }");
+        Assert.Contains("f24cmp", asm);
+    }
+
+    [Fact]
+    public void Float_CmpNeq_ReverseHalfDirect_UsesFusedJump()
+    {
+        // reverseHalfDirectOps FLOAT: 定数 <> f24演算結果
+        var asm = CompileWithCli(@"
+            VAR FLOAT X;
+            MAIN() {
+                X = 0.0;
+                IF 0.0 <> FCOS(X) THEN PRINT(""NEQ"");
+            }");
+        Assert.Contains("f24cmp", asm);
+    }
+
+    [Fact]
+    public void Float_LoadFloatConst_ImmediateLoad()
+    {
+        // FLOAT定数がconstant poolではなく即値ロードされること
+        var asm = CompileWithCli(@"
+            VAR FLOAT A;
+            MAIN() { A = 1.5; }");
+        // LoadFloatConst: LD HL,$xxxx; LD A,$xx で即値ロード
+        Assert.DoesNotContain("_FC0:", asm);  // constant poolラベルがないこと
+    }
+
+    [Fact]
+    public void Float_ConstExpr_Compiles()
+    {
+        // CONST FLOAT式（定数同士の演算）が正常コンパイルされること
+        var asm = CompileWithCli(@"
+            CONST DEG2RAD = 3.1415926 / 180.0;
+            VAR FLOAT R;
+            MAIN() { R = DEG2RAD; }");
+        Assert.DoesNotContain("error", asm.ToLower());
+    }
+
+    [Fact]
+    public void Float_HalfDirect_Arithmetic()
+    {
+        // halfDirectOps FLOAT: f24関数結果 * FLOAT定数 → PUSH/POP不要
+        var asm = CompileWithCli(@"
+            VAR FLOAT A;
+            MAIN() {
+                A = 0.5;
+                A = FCOS(A) * 9.0;
+            }");
+        // FCOS後にPUSH AF/PUSH HLがないこと（halfDirectで直接CDE→f24mul）
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        var fcosIdx = mainSection.IndexOf("CALL\tFCOS");
+        Assert.True(fcosIdx >= 0, "CALL FCOS not found");
+        var afterFcos = mainSection.Substring(fcosIdx, 80);
+        Assert.DoesNotContain("PUSH\tAF", afterFcos);
+    }
 }


### PR DESCRIPTION
## Summary
- halfDirectOps FLOATパスでfusedCompareJumpsが未処理だったバグを修正
- EmitBinaryDirectのCmpNeq/CmpLt/CmpGe/CmpGt/CmpLeにFLOAT対応(f24cmp)を追加

## 問題
`(A*A+B*B) > 4.0` のようなFLOAT比較が常にtrueと評価されていた。

**原因**: halfDirectOps FLOATパスで`EmitBinaryDirect`を呼ぶ際、
`fusedCompareJumps`で後続の`JumpIfZero`がskipされているにも関わらず、
`EmitBinaryDirect`が0/1変換コードを出力→JumpIfZero不在→常にフォールスルー

## Test plan
- [x] dotnet test 全85テスト合格
- [x] FMANDEL.SL (マンデルブロ集合) が正しく描画されることをcpmエミュで確認
- [x] FTEST2.SL / FTEST3.SL 正常動作
- [x] SLANGTEST.SL / BILLIARD.SL 正常コンパイル

🤖 Generated with [Claude Code](https://claude.com/claude-code)