### PR TITLE
v0.20.1 リリース

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # 更新履歴
 
+## Version 0.20.1
+- CASE文のカンマ区切り値（`6,7,8: body`）でbodyコードが重複生成される問題を修正
+- FLOAT対応の強化
+  - CONST定数式でFLOAT演算に対応（`CONST DEG2RAD = 3.14 / 180.0`）
+  - ランタイム関数（FCOS, FSIN等）の戻り値型をFLOATとして正しく追跡
+  - FL$()関数のPRINT出力に対応
+  - FLOAT定数の即値ロード最適化（constant pool廃止、LD DE,imm / LD C,imm 方式）
+  - FLOAT二項演算の直接レジスタロード最適化（halfDirectOps/reverseHalfDirectOps対応）
+  - FLOAT比較演算の融合ジャンプ対応（fusedCompareJumps）
+- x1環境の改善
+  - _TXADRをLSX-Dodgers 1.62cの$EE8Eと共有化（GETLIN後のカーソル位置同期）
+  - 改行時のスクロール処理をLSX-DodgersのBDOSに委譲（24行スクロール対応）
+  - WIDTH(40/80)切替時にLSX-Dodgersのワーク変数を同期
+
 ## Version 0.20.0
 - 新コンパイラ(slangc)への移行
   - IR(中間表現)ベースのコンパイラに全面書き換え（Parser → SemanticAnalyzer → IrGenerator → CodeGenerator）

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SLANG-compiler
-SLANG Compiler (Z80) 0.20.0
+SLANG Compiler (Z80) 0.20.1
 
 # 概要
 
@@ -14,7 +14,7 @@ SLANG Compiler (Z80) 0.20.0
 # 使い方
 
 ```
-SLANG Compiler v0.20.0
+SLANG Compiler v0.20.1
 Usage: slangc [options] <input.sl>
 
 Options:

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -8,7 +8,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.20.0";
+    const string Version = "0.20.1";
 
     static int Main(string[] args)
     {


### PR DESCRIPTION
## Summary
v0.20.1 リリース準備。バージョン番号更新とCHANGELOG追加。

## v0.20.1 の主な変更点
- CASE文カンマ区切り値のコード重複を解消
- FLOAT CONST定数式対応、ランタイム関数戻り値型追跡、FL$()対応
- FLOAT二項演算の即値ロード・直接レジスタロード最適化
- FLOAT比較演算の融合ジャンプ対応
- x1環境: _TXADR共有化、スクロール対応、WIDTH切替時ワーク同期

🤖 Generated with [Claude Code](https://claude.com/claude-code)