### PR TITLE
ITOF/UTOF エイリアス追加

### DIFF
--- a/runtime/libfloat.asm
+++ b/runtime/libfloat.asm
@@ -621,6 +621,7 @@ ret
 
 
 ; @name i16tof24
+; @alias ITOF
 ; @result_type float
 ; @calls u16tof24
 ;Inputs:
@@ -642,6 +643,7 @@ db $11     ;start of `ld de,**`, eats the next two bytes
 
 
 ; @name u16tof24
+; @alias UTOF
 ; @result_type float
 i16tof24_pos:
 ld b,$3F+16    ;Initial exponent and sign


### PR DESCRIPTION
## Summary
- \`i16tof24\` に \`ITOF\` エイリアス、\`u16tof24\` に \`UTOF\` エイリアスを追加
- \`FSQRT(ITOF(X))\` のような書き方が可能に

## 背景
コンパイラの二項演算(+,*等)では整数→FLOAT自動変換 (\`i16tof24\` 挿入) が効くが、
関数呼び出しの引数には自動変換が入らない。そのため \`FSQRT(X)\` と WORD変数を
直接渡すと壊れる。明示的な変換関数を使いやすい名前でエイリアスとして提供する。

## Test plan
- [x] dotnet test 全93テスト合格
- [x] \`FSQRT(ITOF(X))\` / \`FSQRT(UTOF(50000))\` がコンパイル＆アセンブル成功
- [x] 生成コードで \`CALL i16tof24\` / \`CALL u16tof24\` が正しく出力される

🤖 Generated with [Claude Code](https://claude.com/claude-code)