### PR TITLE
FLOAT周辺の3つのバグを修正 (FCOS/単項マイナス/エイリアス重複出力)

### DIFF
--- a/runtime/libfloat.asm
+++ b/runtime/libfloat.asm
@@ -376,6 +376,8 @@ cp 18
 ret c
 return_exp_b:
 ld a,b
+or a       ; ZフラグをクリアしてC=0にする (差>=18時に
+           ; jr z,f24add_subtract_same_exp 等の誤発火を防ぐ)
 ret
 
 f24add_op1_inf_nan:

--- a/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
+++ b/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
@@ -2436,6 +2436,12 @@ public class CodeGenerator
 
     private void EmitNeg(IrInstruction inst)
     {
+        if (inst.DataSize == 3)
+        {
+            // FLOAT (f24): 符号ビット (Aレジスタの bit7) を反転
+            _e.Instruction("XOR", "$80");
+            return;
+        }
         // HL = -HL
         _e.Instruction("LD", "A,H");
         _e.Instruction("CPL");

--- a/src/SLANGCompiler.Core/IR/IrGenerator.cs
+++ b/src/SLANGCompiler.Core/IR/IrGenerator.cs
@@ -1443,9 +1443,17 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 return dest;
             }
         }
+        // FLOAT即値の単項マイナスは符号反転して定数化
+        if (node.Op == UnaryOp.Negate && node.Operand is FloatLiteral fLit)
+        {
+            return EmitLoadFloatConst(-fLit.Value);
+        }
 
         var operand = node.Operand.Accept(this);
         if (node.Op == UnaryOp.Plus) return operand;
+
+        int operandDs = operand.Kind == IrOperandKind.Temp
+            && _tempDataSize.TryGetValue(operand.TempIndex, out int ods) ? ods : 2;
 
         var dest2 = IrOperand.Temp(AllocTemp());
         var op = node.Op switch
@@ -1455,7 +1463,10 @@ public class IrGenerator : IAstVisitor<IrOperand>
             UnaryOp.Cpl => IrOp.Not,
             _ => IrOp.Nop,
         };
-        Emit(op, dest2, operand);
+        // FLOATの単項マイナスは f24 符号ビットを反転 (DataSize=3 で識別)
+        int destDs = (op == IrOp.Neg && operandDs == 3) ? 3 : 2;
+        Emit(op, dest2, operand, dataSize: destDs);
+        if (destDs == 3) _tempDataSize[dest2.TempIndex] = 3;
         return dest2;
     }
 

--- a/src/SLANGCompiler.Core/Runtime/RuntimeLibrary.cs
+++ b/src/SLANGCompiler.Core/Runtime/RuntimeLibrary.cs
@@ -180,6 +180,11 @@ public class RuntimeManager
 
         if (_functions.TryGetValue(name, out var func))
         {
+            // エイリアス経由で呼ばれた場合に正規名(@name)も visited に記録して二重追加を防ぐ
+            if (!string.Equals(name, func.Name, StringComparison.OrdinalIgnoreCase)
+                && !visited.Add(func.Name))
+                return;
+
             foreach (var dep in func.Dependencies)
             {
                 CollectDependencies(dep, visited, result);


### PR DESCRIPTION
## 概要

z80floatベースのf24実装と SLANG コードジェネレータに見つかった3つのバグを修正します。RunCPM + AILZ80ASM での実機(エミュレータ)動作確認済み。

## 修正内容

### 1. `f24add`: 指数差ちょうど18ビット時の同指数加算誤分岐 (z80float上流由来)

`runtime/libfloat.asm` の `f24add_reorder` 内、`cp 18; ret c` で **差がちょうど18のとき Z=1** が立ち、呼び出し元の `jr z,f24add_subtract_same_exp` (および `jr z,f24add_add_same_exp`) が誤って発火していました。

結果として `cos多項式` の最終ステップ `+1.0` で `0.999... + 微小値` のはずが `-0.31201` などの全く違う値を返し、**`FCOS(3.1447)` 等が `0.31201` を返す** 報告のあった現象が発生していました。

`return_exp_b:` で `or a` を実行して Z をクリアする1命令の修正です。

### 2. SLANG: FLOAT に対する単項マイナスが整数演算として展開

`VAR FLOAT T; -T` を書くと `EmitNeg` が16bit整数として `CPL+INC HL` していたため、f24 値が完全に破壊されていました (`-0.49949` が `134` になる等)。

- `IrGenerator.VisitUnaryExpr`: operand の DataSize を見て `IR.Neg` に伝搬。FloatLiteral の単項マイナスは定数畳み込み。
- `CodeGenerator.EmitNeg`: DataSize=3 のとき `XOR A,$80` (f24 符号ビット反転)に分岐。

### 3. `RuntimeManager`: `@alias` と `@name` の両方使用で関数本体が重複出力

`ITOF` (alias) と `i16tof24` (name) のように同じ `RuntimeFunction` を別名でマークすると、`CollectDependencies` の visited が **名前単位** だったため同じ関数が `result` に2回追加され、ASM 出力でラベル重複アセンブルエラーになっていました。

正規名 (`func.Name`) も visited に登録して二重追加を防止します。

## バグ調査の決め手

`runtime/libfloat.asm` の `FCOS` 内部に `dbg_print` 呼び出しを多数挿入して f24 多項式の各ステップの値を実機で観測:

```
P1 (×2π)        : 3.1638e-3   ✓
P2 ((×2π)²)     : 1.001e-5    ✓
P3 (-x²×c1)     : -1.3657e-8  ✓
P4 (+ c2)       : 0.041661    ✓
P5 (× -x²)      : -4.1702e-7  ✓
P6 (+ 0.5)      : 0.5         ✓
P7 (× -x²)      : -5.0049e-6  ✓
P8 (+ 1.0)      : -.31201     ✗ ← ここで破綻!
```

`+1.0` で破綻したことから `f24add` の指数差18の境界条件にたどり着きました。

## テスト

- 既存93テスト全 pass
- RunCPM (Z80 CP/M エミュレータ) で実機検証:

| 入力 | 修正前 | 修正後 |
|---|---|---|
| FCOS(3.144)  | -1       | -1 |
| FCOS(3.1445) | .084304  | -1 |
| FCOS(3.1446) | .15781   | -1 |
| FCOS(3.1447) | **.31201** | **-1** |
| FCOS(3.1448) | .39273   | -1 |
| FCOS(3.1449) | .47586   | -1 |
| FCOS(3.145)  | .5614    | -1 |
| FCOS(3.146)  | -.99999  | -.99999 |

その他 FCOS(0)=1, FCOS(0.5)=0.87759, FCOS(1.0)=0.54029, FSIN(1.5708)=1 など全て正常。

## Test plan

- [x] 既存ユニットテスト (93件) 全パス
- [x] 実機エミュレータ (RunCPM) で FCOS バグ再現範囲全て修正確認
- [x] FLOAT 単項マイナスが f24 として正常動作
- [x] @alias 使用関数 (ITOF/UTOF) で重複ラベルエラー解消

https://claude.ai/code/session_01WT1as6N1AovUa5vHa9Bs4c