### PR TITLE
v0.20.2 リリース

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # 更新履歴
 
+## Version 0.20.2
+- CASE文の冗長なexprVal初回評価を削除（生成コードのサイズ縮小、JS版コンパイラとの整合性向上）
+- x1環境で SGL ライブラリ（libx1_sgl_lsx）が使用可能に
+  - LSX-Dodgers のシステム領域と衝突する固定アドレス依存を排除
+  - VRAM_ADRS_TBL/BITLINE_BUFFER を @works に統合
+  - BitLine の OR-trick を AND+ADD 方式に置換（64箇所）
+- @works_align を絶対アドレスでアライン保証
+  - EQU 仮想ベース方式 (`__WORK_ALIGNED_<N>__`) で実現
+  - __WORK__ 自体は動かさず、WORK 指定の意味を壊さない
+  - @works_align は 2 の冪のみ受け付け（不正値はエラー）
+- FLOAT 周辺のバグ修正
+  - `f24add` の指数差ちょうど18ビット時の誤分岐を修正（FCOS(3.1447)=0.31201 等の異常値を解消）
+  - FLOAT 単項マイナスが整数演算として展開されていたバグを修正（`-T` で f24 値が破壊されていた）
+  - `@alias` と `@name` 両方使用時に関数本体が重複出力される問題を修正
+- ITOF/UTOF エイリアス追加（i16tof24/u16tof24 を呼びやすく）
+
 ## Version 0.20.1
 - CASE文のカンマ区切り値（`6,7,8: body`）でbodyコードが重複生成される問題を修正
 - FLOAT対応の強化

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SLANG-compiler
-SLANG Compiler (Z80) 0.20.1
+SLANG Compiler (Z80) 0.20.2
 
 # 概要
 
@@ -14,7 +14,7 @@ SLANG Compiler (Z80) 0.20.1
 # 使い方
 
 ```
-SLANG Compiler v0.20.1
+SLANG Compiler v0.20.2
 Usage: slangc [options] <input.sl>
 
 Options:

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -8,7 +8,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.20.1";
+    const string Version = "0.20.2";
 
     static int Main(string[] args)
     {


### PR DESCRIPTION
## Summary
v0.20.2 リリース準備。バージョン番号更新と CHANGELOG 追加。

## v0.20.2 の主な変更点
- CASE 文の冗長な exprVal 初回評価削除 (#126)
- x1 環境用 SGL ライブラリ + @works_align 絶対アライン修正 (#127)
- ITOF/UTOF エイリアス追加 (#128)
- FLOAT 周辺の3つのバグ修正 (FCOS/単項マイナス/エイリアス重複) (#129)

🤖 Generated with [Claude Code](https://claude.com/claude-code)