### PR TITLE
ARRAY FLOAT 対応 (3バイト要素サイズの正しい伝播)

### DIFF
--- a/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
+++ b/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
@@ -2718,12 +2718,22 @@ public class CodeGenerator
 
     private void EmitIndirLoad(IrInstruction inst)
     {
-        // HL = *HL
+        // HL = *HL (dataSize=1: byte, =2: word, =3: float f24→AHL)
         bool isByte = inst.DataSize == 1;
+        bool isFloat = inst.DataSize == 3;
         if (isByte)
         {
             _e.Instruction("LD", "L,(HL)");
             _e.Instruction("LD", "H,$00");
+        }
+        else if (isFloat)
+        {
+            _e.Instruction("LD", "E,(HL)");
+            _e.Instruction("INC", "HL");
+            _e.Instruction("LD", "D,(HL)");
+            _e.Instruction("INC", "HL");
+            _e.Instruction("LD", "A,(HL)");
+            _e.Instruction("EX", "DE,HL");
         }
         else
         {
@@ -2737,9 +2747,11 @@ public class CodeGenerator
     private void EmitIndirStore(IrInstruction inst)
     {
         // HL=addr (最後に評価された値), スタック上にvalue
-        // POP DE(=value) → *(HL) = DE
+        // dataSize=3: PUSH AF + PUSH HL の順で積まれている → POP DE, POP AF の順で復元
         bool isByte = inst.DataSize == 1;
+        bool isFloat = inst.DataSize == 3;
         _e.Instruction("POP", "DE");
+        if (isFloat) _e.Instruction("POP", "AF");
         if (isByte)
         {
             _e.Instruction("LD", "(HL),E");
@@ -2749,6 +2761,11 @@ public class CodeGenerator
             _e.Instruction("LD", "(HL),E");
             _e.Instruction("INC", "HL");
             _e.Instruction("LD", "(HL),D");
+            if (isFloat)
+            {
+                _e.Instruction("INC", "HL");
+                _e.Instruction("LD", "(HL),A");
+            }
         }
     }
 

--- a/src/SLANGCompiler.Core/IR/IrGenerator.cs
+++ b/src/SLANGCompiler.Core/IR/IrGenerator.cs
@@ -57,7 +57,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
         if (_localVars?.TryGetValue(name, out var li) == true)
         {
             int varDs = li.ByteSize;
-            int elemSz = li.Kind == VarKind.Scalar ? varDs : (li.IsByte ? 1 : 2);
+            int elemSz = li.Kind == VarKind.Scalar ? varDs : li.ElemSize;
             return new VarInfo { IsResolved = true, Kind = li.Kind, ElemSize = elemSz, VarDataSize = varDs, Local = li };
         }
         // 2. 関数内static変数
@@ -73,14 +73,19 @@ public class IrGenerator : IAstVisitor<IrOperand>
         var sym = _globalSymbols?.Resolve(name);
         if (sym != null)
         {
-            bool isByte = sym.Type is ArrayType at ? at.ElementType == SlangType.Byte
-                        : sym.Type is PointerType pt ? pt.ElementType == SlangType.Byte
-                        : false;
             VarKind kind = sym.Type is PointerType && !sym.IsArrayDecl ? VarKind.Pointer
                          : sym.Type is ArrayType || sym.IsArrayDecl     ? VarKind.Array
                          :                                                 VarKind.Scalar;
             int varDs = sym.Type?.ByteSize ?? 2;
-            int elemSz = kind == VarKind.Scalar ? varDs : (isByte ? 1 : 2);
+            int elemSz;
+            if (kind == VarKind.Scalar)
+                elemSz = varDs;
+            else if (sym.Type is ArrayType at)
+                elemSz = at.ElementType.ByteSize;  // BYTE=1 / WORD=2 / FLOAT=3
+            else if (sym.Type is PointerType pt)
+                elemSz = (pt.ElementType == SlangType.Byte ? 1 : 2);  // 既存維持 (FLOAT ポインタは別スコープ)
+            else
+                elemSz = 2;
             return new VarInfo { IsResolved = true, Kind = kind, ElemSize = elemSz, VarDataSize = varDs, GlobalSym = sym };
         }
         // 4. 未解決
@@ -98,7 +103,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
 
     private enum VarKind { Scalar, Array, Pointer }
 
-    private record LocalVarInfo(int Offset, int ByteSize, VarKind Kind = VarKind.Scalar, bool IsByte = false, List<int>? Dims = null)
+    private record LocalVarInfo(int Offset, int ByteSize, VarKind Kind = VarKind.Scalar, bool IsByte = false, List<int>? Dims = null, int ElemSize = 2)
     {
         public bool IsArray => Kind == VarKind.Array;
         public bool IsPointer => Kind == VarKind.Pointer;
@@ -109,7 +114,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
     {
         public bool IsResolved { get; init; }
         public VarKind Kind { get; init; }
-        /// <summary>Array/Pointerでは要素幅(1 or 2)、ScalarではVarDataSizeと同値。</summary>
+        /// <summary>Array/Pointerでは要素幅(1, 2 or 3)、ScalarではVarDataSizeと同値。</summary>
         public int ElemSize { get; init; }
         /// <summary>変数自体のサイズ (1/2/3)。</summary>
         public int VarDataSize { get; init; }
@@ -313,7 +318,12 @@ public class IrGenerator : IAstVisitor<IrOperand>
 
     public IrOperand VisitArrayDecl(ArrayDecl node)
     {
-        int elemSize = node.Size == DataSize.Byte ? 1 : 2;
+        int elemSize = node.Size switch
+        {
+            DataSize.Byte => 1,
+            DataSize.Float => 3,
+            _ => 2,
+        };
         bool isByte = node.Size == DataSize.Byte;
 
         // 次元情報を計算
@@ -434,7 +444,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 _staticVarLabels![node.Name] = label;
                 bool isPointerType = dims.All(d => d == 0);
                 _staticVarSizes![node.Name] = 2; // 配列/ポインタ変数は常にWORD
-                _staticElemSizes![node.Name] = isByte ? 1 : 2;
+                _staticElemSizes![node.Name] = elemSize;
                 _staticVarKinds![node.Name] = isPointerType ? VarKind.Pointer : VarKind.Array;
             }
 
@@ -462,7 +472,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
             _localOffset += allocSize;
             int offset = 0x70 - _localOffset;
             var kind = isPointerVar ? VarKind.Pointer : VarKind.Array;
-            _localVars![node.Name] = new LocalVarInfo(offset, allocSize, Kind: kind, IsByte: isByte, Dims: dims);
+            _localVars![node.Name] = new LocalVarInfo(offset, allocSize, Kind: kind, IsByte: isByte, Dims: dims, ElemSize: elemSize);
         }
         return IrOperand.None;
     }
@@ -1745,15 +1755,15 @@ public class IrGenerator : IAstVisitor<IrOperand>
         bool isLocalArray = arrInfo != null && arrInfo.Kind == VarKind.Array && arrInfo.Dims != null;
         if (isLocalArray)
         {
-            strides = ComputeStridesFromDims(arrInfo!.Dims!, arrInfo.IsByte ? 1 : 2, node.Indices.Count);
-            isArrayByte = arrInfo.IsByte;
+            strides = ComputeStridesFromDims(arrInfo!.Dims!, arrInfo.ElemSize, node.Indices.Count);
+            isArrayByte = arrInfo.ElemSize == 1;
         }
         else
         {
             strides = ComputeStrides(arraySym, node.Indices.Count, arrayName);
         }
 
-        int elemSize = isArrayByte ? 1 : 2;
+        int elemSize = vi.ElemSize;
 
         // 部分配列参照: 指定インデックス数 < 配列の次元数 → アドレスを返す
         int arrayRank = 0;
@@ -1774,6 +1784,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 if (loadValue)
                 {
                     Emit(IrOp.LoadLocal, result, IrOperand.Imm(directOffset.Value), dataSize: elemSize);
+                    if (elemSize == 3) _tempDataSize[result.TempIndex] = 3;
                 }
                 else
                 {
@@ -1795,7 +1806,10 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 string label = ResolveAsmLabel(arrayName);
                 string sym = globalOffset.Value == 0 ? label : $"{label}+{globalOffset.Value}";
                 if (loadValue)
+                {
                     Emit(IrOp.LoadVar, result, IrOperand.Sym(sym), dataSize: elemSize);
+                    if (elemSize == 3) _tempDataSize[result.TempIndex] = 3;
+                }
                 else
                     Emit(IrOp.LoadAddr, result, IrOperand.Sym(sym));
                 return result;
@@ -1852,6 +1866,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
         {
             var result = IrOperand.Temp(AllocTemp());
             Emit(IrOp.IndirLoad, result, addr, dataSize: elemSize);
+            if (elemSize == 3) _tempDataSize[result.TempIndex] = 3;
             return result;
         }
         return addr; // アドレスのみ
@@ -2234,6 +2249,8 @@ public class IrGenerator : IAstVisitor<IrOperand>
             else
             {
                 // 通常配列のストア（多次元対応）
+                // 要素サイズに応じた型変換 (int→float の i16tof24 等を挟む)
+                value = EmitTypeConversion(value, stVi.ElemSize);
                 bool storeIsByte = stVi.Kind == VarKind.Array && stVi.ElemSize == 1;
 
                 // 多次元ストライド計算（定数最適化でも使用）
@@ -2242,8 +2259,8 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 bool isLocalStoreArray = stArrLi != null && stArrLi.Kind == VarKind.Array && stArrLi.Dims != null;
                 if (isLocalStoreArray)
                 {
-                    strides = ComputeStridesFromDims(stArrLi!.Dims!, stArrLi.IsByte ? 1 : 2, arr.Indices.Count);
-                    storeIsByte = stArrLi.IsByte;
+                    strides = ComputeStridesFromDims(stArrLi!.Dims!, stArrLi.ElemSize, arr.Indices.Count);
+                    storeIsByte = stArrLi.ElemSize == 1;
                 }
                 else
                 {
@@ -2254,7 +2271,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 bool localStoreHandled = false;
                 if (isLocalStoreArray)
                 {
-                    int elemSize = stArrLi!.IsByte ? 1 : 2;
+                    int elemSize = stArrLi!.ElemSize;
                     var directOffset = TryComputeLocalArrayOffset(stArrLi, arr.Indices, strides, elemSize);
                     if (directOffset.HasValue)
                     {
@@ -2266,7 +2283,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 // グローバル/static配列の定数インデックス最適化: label+offset 直接ストア
                 if (!localStoreHandled && !isLocalStoreArray && arrayName != null && stVi.Kind == VarKind.Array)
                 {
-                    int gElemSize = storeIsByte ? 1 : 2;
+                    int gElemSize = stVi.ElemSize;
                     var globalOffset = TryComputeConstArrayOffset(arr.Indices, strides);
                     if (globalOffset.HasValue)
                     {
@@ -2326,7 +2343,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
                 }
 
                 // 最終アドレスに値を書き込み
-                Emit(IrOp.IndirStore, addr, value, dataSize: storeIsByte ? 1 : 2);
+                Emit(IrOp.IndirStore, addr, value, dataSize: stVi.ElemSize);
 
                 } // end else (non-const index path)
             }

--- a/tests/SLANGCompiler.Tests/IntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/IntegrationTests.cs
@@ -453,4 +453,128 @@ SUB() BEGIN PRINT(""X""); END;
             MAIN() BEGIN END;");
         Assert.Contains("MACHINE functions", stderr);
     }
+
+    // ==== FLOAT 配列 ====
+
+    [Fact]
+    public void FloatArray_WordByteRegression_NoChange()
+    {
+        // T0: WORD/BYTE 配列は変化しないこと (2バイト/1バイト格納のまま)
+        var asm = CompileWithCli(@"
+            ARRAY WORD WA[3];
+            ARRAY BYTE BA[3];
+            MAIN() BEGIN WA[0] = 100; BA[0] = 7; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // WORD: LD HL,$0064; LD (_V_WA),HL
+        Assert.Contains("LD\t(_V_WA),HL", mainSection);
+        Assert.DoesNotContain("(_V_WA+2)", mainSection);
+        // BYTE: LD A,$07; LD (_V_BA),A
+        Assert.Contains("(_V_BA)", mainSection);
+    }
+
+    [Fact]
+    public void FloatArray_GlobalConstIndex_Store()
+    {
+        // T1: グローバル FLOAT 配列への定数インデックス代入 = 3バイト格納 (HL+A)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT GA[3];
+            MAIN() BEGIN GA[0] = 1.5; GA[1] = 2.5; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // GA[0]: _V_GA に mantissa と exponent
+        Assert.Contains("LD\t(_V_GA),HL", mainSection);
+        Assert.Contains("LD\t(_V_GA+2),A", mainSection);
+        // GA[1]: _V_GA+3 (FLOAT ストライド 3)
+        Assert.Contains("LD\t(_V_GA+3),HL", mainSection);
+        Assert.Contains("LD\t(_V_GA+3+2),A", mainSection);
+    }
+
+    [Fact]
+    public void FloatArray_GlobalConstIndex_Load()
+    {
+        // T2: グローバル FLOAT 配列からの定数インデックス読み込み (HL+A 両方)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT GA[3];
+            VAR FLOAT R;
+            MAIN() BEGIN R = GA[1]; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        Assert.Contains("LD\tHL,(_V_GA+3)", mainSection);
+        Assert.Contains("LD\tA,(_V_GA+3+2)", mainSection);
+    }
+
+    [Fact]
+    public void FloatArray_GlobalDynamicIndex_Store()
+    {
+        // T3: 動的インデックスでの代入 = IndirStore dataSize=3
+        //     PUSH AF + PUSH HL → POP DE + POP AF → LD (HL),E / INC HL / LD (HL),D / INC HL / LD (HL),A
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT GA[5];
+            VAR I;
+            MAIN() BEGIN FOR I = 0 TO 4 BEGIN GA[I] = I + 0.5; END; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // 動的 IndirStore path で POP AF と INC HL + LD (HL),A が出現
+        Assert.Contains("POP\tAF", mainSection);
+        Assert.Contains("LD\t(HL),A", mainSection);
+    }
+
+    [Fact]
+    public void FloatArray_GlobalDynamicIndex_Load()
+    {
+        // T4: 動的インデックスでの読み込み = IndirLoad dataSize=3
+        //     LD E,(HL) / INC HL / LD D,(HL) / INC HL / LD A,(HL) / EX DE,HL
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT GA[5];
+            VAR FLOAT R;
+            VAR I;
+            MAIN() BEGIN R = GA[I]; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // 3バイト読み込みパターン
+        Assert.Contains("LD\tE,(HL)", mainSection);
+        Assert.Contains("LD\tD,(HL)", mainSection);
+        Assert.Contains("LD\tA,(HL)", mainSection);
+    }
+
+    [Fact]
+    public void FloatArray_LocalConstIndex_Store()
+    {
+        // T5: ローカル FLOAT 配列への定数インデックス代入
+        var asm = CompileWithCli(@"
+            FOO() BEGIN VAR I; ARRAY FLOAT LA[3]; LA[1] = 3.5; END;
+            MAIN() BEGIN FOO(); END;");
+        // IY+offset への 3バイト格納 (mantissa+exponent)
+        var fooSection = asm.Substring(asm.IndexOf("FOO:"));
+        fooSection = fooSection.Substring(0, fooSection.IndexOf("_FOO_EXIT"));
+        // ローカル FLOAT 配列: LD (IY+off),L / LD (IY+off+1),H / LD (IY+off+2),A
+        Assert.Matches(@"LD\s+\(IY\+\$[0-9A-F]+\),L", fooSection);
+        Assert.Matches(@"LD\s+\(IY\+\$[0-9A-F]+\),H", fooSection);
+        Assert.Matches(@"LD\s+\(IY\+\$[0-9A-F]+\),A", fooSection);
+    }
+
+    [Fact]
+    public void FloatArray_IntToFloat_AutoConversion()
+    {
+        // T9: 整数→FLOAT 配列への代入で i16tof24 が挿入されること
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT GA[3];
+            MAIN() BEGIN GA[0] = 7; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        Assert.Contains("CALL\ti16tof24", mainSection);
+        Assert.Contains("LD\t(_V_GA),HL", mainSection);
+        Assert.Contains("LD\t(_V_GA+2),A", mainSection);
+    }
+
+    [Fact]
+    public void FloatArray_StaticArray_Store()
+    {
+        // T12: 関数内 static ARRAY FLOAT (BEGIN 前宣言) のストア
+        var asm = CompileWithCli(@"
+            FOO() ARRAY FLOAT SA[3]; BEGIN SA[0] = 1.5; SA[1] = 2.5; END;
+            MAIN() BEGIN FOO(); END;");
+        // 関数内 static は __FOO_SA のようなラベル。3バイト格納が 2 要素分出る
+        var fooSection = asm.Substring(asm.IndexOf("FOO:"));
+        fooSection = fooSection.Substring(0, fooSection.IndexOf("_FOO_EXIT"));
+        Assert.Matches(@"LD\s+\(_V_FOO_SA\),HL", fooSection);
+        Assert.Matches(@"LD\s+\(_V_FOO_SA\+2\),A", fooSection);
+        Assert.Matches(@"LD\s+\(_V_FOO_SA\+3\),HL", fooSection);
+        Assert.Matches(@"LD\s+\(_V_FOO_SA\+3\+2\),A", fooSection);
+    }
 }


### PR DESCRIPTION
## 背景

`ARRAY FLOAT FA[N]; FA[i] = 1.5;` はパース・セマンティック解析は通るが、IR 生成段階で要素サイズが BYTE=1 / WORD=2 にハードコードされており、FLOAT (3バイト = mantissa + exponent) のロード/ストアが exponent (A) を捨ててサイレントに壊れていた。

## 修正内容

### `IrGenerator`
- `LocalVarInfo` に `ElemSize` フィールドを追加 (default 2)
- `VisitArrayDecl` で `node.Size == DataSize.Float` を 3 として伝播 (ローカル/グローバル/static の全経路)
- `ResolveVarInfo` のグローバル配列分岐で `ArrayType.ElementType.ByteSize` を直接参照 (PointerType 分岐は既存挙動を維持)
- `ComputeArrayAccess` (load) と `EmitStore` (store) で `IsByte ? 1 : 2` を `vi.ElemSize` / `arrInfo.ElemSize` に置換 (定数インデックス最適化と動的インデックス IndirLoad/IndirStore の全パス)
- `EmitStore` の `ArrayAccessExpr` 分岐で `EmitTypeConversion(value, ElemSize)` を挿入し、`FA[0] = 7` で `i16tof24` が自動挿入されるように
- 配列ロード結果 temp を `_tempDataSize` に登録 (FLOAT 値が後続の関数引数等で整数扱いされるのを防止)

### `CodeGenerator`
- `EmitIndirLoad` / `EmitIndirStore` の dataSize=3 (FLOAT) 経路を追加
  - **Load**: `LD E,(HL); INC HL; LD D,(HL); INC HL; LD A,(HL); EX DE,HL`
  - **Store**: `POP DE; POP AF; LD (HL),E; INC HL; LD (HL),D; INC HL; LD (HL),A`

### 設計原則

`ElemSize` を「要素サイズの唯一の真実」とし、配列アクセス系では `IsByte` を読まない。`IsByte` フィールド自体は他経路 (BYTE スカラ変数の FOR/代入等) で使われているためフィールドとして残置。

## スコープ外 (将来対応)

- 初期値付き宣言 `ARRAY FLOAT FA[3] = [1.5, 2.5, 3.5];`
  (FloatLiteral → f24 エンコード機構が未実装のため)
- FLOAT を指す PointerType 経由のアクセス
  (`ComputeArrayAccess` 内の間接変数経路は触らず)

## Test plan

- [x] `dotnet test` 全 109 件 (既存 101 + 新規 8) パス
- [x] RunCPM 実機で global/local/static × const/dynamic × load/store の全 12 ケース期待値どおり出力
  - T0: WORD/BYTE 配列 regression なし
  - T1-T2: グローバル定数インデックス store/load (`GA[0]=1.5; GA[1]=2.5;`)
  - T3-T4: グローバル動的インデックス store/load (`FOR I: GA[I]=I*0.5; GA[3]==1.5`)
  - T5-T6: ローカル定数インデックス store/load
  - T7-T8: ローカル動的インデックス store/load
  - T9: 整数→FLOAT 自動変換 (`GA[0]=7` → `i16tof24`)
  - T10: FLOAT 関数戻り値の配列代入 (`GA[1]=FX(2.5)` → 6.25)
  - T11: 配列要素を関数引数 (`FX(GA[0])` → 49)
  - T12: static ARRAY FLOAT (関数内 BEGIN 前宣言)