### PR TITLE
ARRAY FLOAT 初期値付き宣言サポート

### DIFF
--- a/src/SLANGCompiler.Core/IR/IrGenerator.cs
+++ b/src/SLANGCompiler.Core/IR/IrGenerator.cs
@@ -377,6 +377,9 @@ public class IrGenerator : IAstVisitor<IrOperand>
                     var constEval = new ConstEvaluator(_globalSymbols);
                     foreach (var expr in node.InitialCode)
                     {
+                        // トップレベル要素として CastExpr (%X 等) を置くのは禁止。
+                        // BYTE/WORD 要素混在の意図を防ぐためで、式の内部に含まれる
+                        // CastExpr は EvaluateFloat が再帰的に評価するため許容される。
                         if (expr is CastExpr)
                         {
                             _diagnostics?.Error("Cast expression not allowed in FLOAT array initializer", expr.Span);

--- a/src/SLANGCompiler.Core/IR/IrGenerator.cs
+++ b/src/SLANGCompiler.Core/IR/IrGenerator.cs
@@ -370,62 +370,90 @@ public class IrGenerator : IAstVisitor<IrOperand>
             if (node.InitialCode != null)
             {
                 initItems = new List<InitItem>();
-                foreach (var expr in node.InitialCode)
+
+                if (node.Size == DataSize.Float)
                 {
-                    var initExpr = expr;
-                    int itemSize = 1; // 配列初期値はデフォルトBYTE（%付きでWORD）
-                    if (initExpr is CastExpr cast)
+                    // FLOAT配列専用パス: 全要素3バイトf24で展開
+                    var constEval = new ConstEvaluator(_globalSymbols);
+                    foreach (var expr in node.InitialCode)
                     {
-                        initExpr = cast.Operand;
-                        itemSize = cast.TargetSize == DataSize.Byte ? 1 : cast.TargetSize == DataSize.Float ? 3 : 2;
-                    }
-
-                    // 定数式の評価を試みる（BinaryExpr, CONST参照なども含む）
-                    var constEval = _globalSymbols != null ? new ConstEvaluator(_globalSymbols) : null;
-                    var constVal = constEval?.Evaluate(initExpr);
-                    if (initExpr is IntegerLiteral ilit)
-                        constVal = (int)ilit.Value; // IntegerLiteralは直接使用
-
-                    if (constVal.HasValue)
-                    {
-                        int v = constVal.Value;
-                        if (itemSize == 1)
-                            initItems.Add(InitItem.Byte((byte)(v & 0xFF)));
-                        else if (itemSize == 3)
+                        if (expr is CastExpr)
                         {
-                            initItems.Add(InitItem.Byte((byte)(v & 0xFF)));
-                            initItems.Add(InitItem.Byte((byte)((v >> 8) & 0xFF)));
-                            initItems.Add(InitItem.Byte((byte)((v >> 16) & 0xFF)));
+                            _diagnostics?.Error("Cast expression not allowed in FLOAT array initializer", expr.Span);
+                            continue;
+                        }
+                        double? val = constEval.EvaluateFloat(expr);
+                        if (!val.HasValue)
+                        {
+                            _diagnostics?.Error("FLOAT array initializer must be a constant expression", expr.Span);
+                            continue;
+                        }
+                        var bytes = LabelUtils.ConvertToF24(val.Value);
+                        initItems.Add(InitItem.Byte(bytes[0]));
+                        initItems.Add(InitItem.Byte(bytes[1]));
+                        initItems.Add(InitItem.Byte(bytes[2]));
+                    }
+                }
+                else
+                {
+                    foreach (var expr in node.InitialCode)
+                    {
+                        var initExpr = expr;
+                        int itemSize = 1; // 配列初期値はデフォルトBYTE（%付きでWORD）
+                        if (initExpr is CastExpr cast)
+                        {
+                            initExpr = cast.Operand;
+                            itemSize = cast.TargetSize == DataSize.Byte ? 1 : cast.TargetSize == DataSize.Float ? 3 : 2;
+                        }
+
+                        // 定数式の評価を試みる（BinaryExpr, CONST参照なども含む）
+                        var constEval = _globalSymbols != null ? new ConstEvaluator(_globalSymbols) : null;
+                        var constVal = constEval?.Evaluate(initExpr);
+                        if (initExpr is IntegerLiteral ilit)
+                            constVal = (int)ilit.Value; // IntegerLiteralは直接使用
+
+                        if (constVal.HasValue)
+                        {
+                            int v = constVal.Value;
+                            if (itemSize == 1)
+                                initItems.Add(InitItem.Byte((byte)(v & 0xFF)));
+                            else if (itemSize == 3)
+                            {
+                                initItems.Add(InitItem.Byte((byte)(v & 0xFF)));
+                                initItems.Add(InitItem.Byte((byte)((v >> 8) & 0xFF)));
+                                initItems.Add(InitItem.Byte((byte)((v >> 16) & 0xFF)));
+                            }
+                            else
+                            {
+                                initItems.Add(InitItem.Byte((byte)(v & 0xFF)));
+                                initItems.Add(InitItem.Byte((byte)((v >> 8) & 0xFF)));
+                            }
+                        }
+                        else if (initExpr is StringLiteral slit)
+                        {
+                            var sjisBytes = StringEncoder.ToShiftJisBytes(slit.Value, _diagnostics);
+                            foreach (var b in sjisBytes)
+                                initItems.Add(InitItem.Byte(b));
                         }
                         else
                         {
-                            initItems.Add(InitItem.Byte((byte)(v & 0xFF)));
-                            initItems.Add(InitItem.Byte((byte)((v >> 8) & 0xFF)));
-                        }
-                    }
-                    else if (initExpr is StringLiteral slit)
-                    {
-                        var sjisBytes = StringEncoder.ToShiftJisBytes(slit.Value, _diagnostics);
-                        foreach (var b in sjisBytes)
-                            initItems.Add(InitItem.Byte(b));
-                    }
-                    else
-                    {
-                        // 非定数式: ExprToAsmStringでアセンブラ式に変換
-                        var asmResult = LabelUtils.ExprToAsmString(initExpr, _globalSymbols, _diagnostics);
-                        if (asmResult.HasValue && itemSize == 2)
-                        {
-                            initItems.Add(InitItem.Word(asmResult.Value.Expr));
-                            foreach (var dep in asmResult.Value.Deps)
-                                _module.AddressSymbolDeps.Add(dep);
-                        }
-                        else if (itemSize == 1)
-                        {
-                            _diagnostics?.Error("Non-constant BYTE expression in CODE block not supported",
-                                initExpr.Span);
+                            // 非定数式: ExprToAsmStringでアセンブラ式に変換
+                            var asmResult = LabelUtils.ExprToAsmString(initExpr, _globalSymbols, _diagnostics);
+                            if (asmResult.HasValue && itemSize == 2)
+                            {
+                                initItems.Add(InitItem.Word(asmResult.Value.Expr));
+                                foreach (var dep in asmResult.Value.Deps)
+                                    _module.AddressSymbolDeps.Add(dep);
+                            }
+                            else if (itemSize == 1)
+                            {
+                                _diagnostics?.Error("Non-constant BYTE expression in CODE block not supported",
+                                    initExpr.Span);
+                            }
                         }
                     }
                 }
+
                 // totalSizeに満たない場合は0で埋める
                 int currentSize = initItems.Sum(i => i.ByteSize);
                 while (currentSize < totalSize)

--- a/src/SLANGCompiler.Core/SLANGCompiler.Core.csproj
+++ b/src/SLANGCompiler.Core/SLANGCompiler.Core.csproj
@@ -9,4 +9,7 @@
     <PackageReference Include="YamlDotNet" Version="12.0.2" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
   </ItemGroup>
+  <ItemGroup>
+    <InternalsVisibleTo Include="SLANGCompiler.Tests" />
+  </ItemGroup>
 </Project>

--- a/tests/SLANGCompiler.Tests/IntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/IntegrationTests.cs
@@ -659,12 +659,25 @@ SUB() BEGIN PRINT(""X""); END;
     }
 
     [Fact]
-    public void FloatArrayInit_CastExpr_Error()
+    public void FloatArrayInit_TopLevelCastExpr_Error()
     {
-        // T5b: FLOAT 配列に CastExpr (%X 等) は禁止
+        // T5b: トップレベル要素として CastExpr (%X 等) を置くのは禁止
+        // (BYTE/WORD 要素混在の意図を防ぐため)
         var stderr = CompileExpectError(@"
             ARRAY FLOAT FA[1] = {%5};
             MAIN() BEGIN END;");
         Assert.Contains("Cast expression not allowed in FLOAT array initializer", stderr);
+    }
+
+    [Fact]
+    public void FloatArrayInit_CastInsideExpression_OK()
+    {
+        // T5c: 式の内部に CastExpr が含まれていても、結果が定数式として
+        // double 評価できれば許容する (混在禁止はトップレベル要素のみが対象)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT FA[1] = {(%5) + 1.0};
+            MAIN() BEGIN END;");
+        var expected = ExpectedFloatBytes(6.0);
+        Assert.Contains($"DB\t{expected}", asm);
     }
 }

--- a/tests/SLANGCompiler.Tests/IntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/IntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Xunit;
+using SLANGCompiler;
 
 namespace SLANGCompiler.Tests;
 
@@ -576,5 +577,94 @@ SUB() BEGIN PRINT(""X""); END;
         Assert.Matches(@"LD\s+\(_V_FOO_SA\+2\),A", fooSection);
         Assert.Matches(@"LD\s+\(_V_FOO_SA\+3\),HL", fooSection);
         Assert.Matches(@"LD\s+\(_V_FOO_SA\+3\+2\),A", fooSection);
+    }
+
+    // ==== ARRAY FLOAT 初期値付き宣言 ====
+
+    /// <summary>FLOAT 値の f24 バイト列を DB 出力期待文字列 "$XX,$YY,..." に変換</summary>
+    private static string ExpectedFloatBytes(params double[] values)
+    {
+        var allBytes = values.SelectMany(v => LabelUtils.ConvertToF24(v));
+        return string.Join(",", allBytes.Select(b => $"${b:X2}"));
+    }
+
+    [Fact]
+    public void FloatArrayInit_WordArrayRegression_NoChange()
+    {
+        // T0: 既存 BYTE/WORD CODE ブロック初期値が変わらないこと
+        // 1,2,3 は BYTE で 1byte ずつ、%4/%5 は WORD で 2byte ずつ ($04,$00 / $05,$00)
+        var asm = CompileWithCli(@"
+            ARRAY ARI[5] = {1, 2, 3, %4, %5};
+            MAIN() BEGIN END;");
+        Assert.Contains("DB\t$01,$02,$03,$04,$00,$05,$00", asm);
+    }
+
+    [Fact]
+    public void FloatArrayInit_FloatLiterals()
+    {
+        // T1: グローバル ARRAY FLOAT に FloatLiteral 初期値
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT FA[3] = {1.5, 2.5, 3.5};
+            MAIN() BEGIN END;");
+        var expected = ExpectedFloatBytes(1.5, 2.5, 3.5);
+        Assert.Contains($"DB\t{expected}", asm);
+    }
+
+    [Fact]
+    public void FloatArrayInit_IntegerToFloat_AutoConversion()
+    {
+        // T2: IntegerLiteral が FLOAT に自動変換される
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT FA[3] = {1, 2, 3};
+            MAIN() BEGIN END;");
+        var expected = ExpectedFloatBytes(1.0, 2.0, 3.0);
+        Assert.Contains($"DB\t{expected}", asm);
+    }
+
+    [Fact]
+    public void FloatArrayInit_ConstAndExpression()
+    {
+        // T3: CONST 参照と FLOAT 定数式 (CONST に型指定構文は無いので CONST PI = 3.14)
+        var asm = CompileWithCli(@"
+            CONST PI = 3.14;
+            ARRAY FLOAT FA[2] = {PI, PI / 2.0};
+            MAIN() BEGIN END;");
+        var expected = ExpectedFloatBytes(3.14, 3.14 / 2.0);
+        Assert.Contains($"DB\t{expected}", asm);
+    }
+
+    [Fact]
+    public void FloatArrayInit_PartialInit_ZeroPadding()
+    {
+        // T4: 要素数不足分は 0.0 で埋める (3 バイトの 0 = $00,$00,$00)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT FA[5] = {1.5, 2.5};
+            MAIN() BEGIN END;");
+        // 5 要素 (dim=6) × 3 = 18 バイト。1.5 と 2.5 で 6 バイト + 残り 12 バイトの 0
+        var head = ExpectedFloatBytes(1.5, 2.5);
+        // 残り 12 バイト分の 0 が続く
+        var zeros = string.Join(",", Enumerable.Repeat("$00", 12));
+        Assert.Contains($"DB\t{head},{zeros}", asm);
+    }
+
+    [Fact]
+    public void FloatArrayInit_NonConstantExpr_Error()
+    {
+        // T5: 非定数式 (定義済み変数の参照等) はエラー
+        var stderr = CompileExpectError(@"
+            VAR X;
+            ARRAY FLOAT FA[1] = {X};
+            MAIN() BEGIN END;");
+        Assert.Contains("FLOAT array initializer must be a constant expression", stderr);
+    }
+
+    [Fact]
+    public void FloatArrayInit_CastExpr_Error()
+    {
+        // T5b: FLOAT 配列に CastExpr (%X 等) は禁止
+        var stderr = CompileExpectError(@"
+            ARRAY FLOAT FA[1] = {%5};
+            MAIN() BEGIN END;");
+        Assert.Contains("Cast expression not allowed in FLOAT array initializer", stderr);
     }
 }


### PR DESCRIPTION
## 背景

PR #132 で ARRAY FLOAT のロード/ストアは対応したが、**初期値付き宣言** (`ARRAY FLOAT FA[3] = {1.5, 2.5, 3.5};`) は意図的にスコープ外とした。再調査の結果、必要な部品 (`LabelUtils.ConvertToF24` / `ConstEvaluator.EvaluateFloat` / 既存 ByteRun 機構) が全て揃っており、限定的な修正で対応可能と判明したので追加実装。

## 修正内容

### `IrGenerator.VisitArrayDecl`
`node.Size == DataSize.Float` 専用パスを追加:
- `ConstEvaluator.EvaluateFloat()` で要素式を `double` として評価 (FloatLiteral / IntegerLiteral / CONST 参照 / Unary/Binary 全対応)
- `LabelUtils.ConvertToF24(double)` で 3 バイト f24 表現に変換
- `InitItem.Byte` を 3 つ並べる → 既存 `EmitInitialItems` の ByteRun 機構が自然に `DB $L,$H,$A` で展開
- 整数リテラル → FLOAT 自動変換 (`{1, 2, 3}` → 1.0, 2.0, 3.0)
- CONST + FLOAT 定数式 (`{PI, PI / 2.0}`) も評価可能
- 部分初期値の残りは `0.0` (3 バイトの 0) で埋める (既存 0 埋めロジックが totalSize=バイト数で動くのでそのまま機能)
- CastExpr (`%X`) と非定数式は明示エラー化

既存パス (BYTE/WORD/CODE ブロック) は分岐の else 側に移動するだけで内容は完全に同一 → regression なし。

### `SLANGCompiler.Core.csproj`
- `InternalsVisibleTo Include="SLANGCompiler.Tests"` を追加 (テスト側で `LabelUtils.ConvertToF24` を呼んで期待バイト列を組み立てるため。f24 表現の将来変更に追従可能)

## スコープ外 (将来対応)

- **ローカル `ARRAY FLOAT` の初期値**: 現状 SLANG 全体としてローカル配列の初期値構文は未対応のため
- **FLOAT 配列に CastExpr で BYTE/WORD 要素を混在**: `{1.5, %2, 3.0}` のような混合
- **FLOAT を指す PointerType 経由のアクセス**: 別 PR で対応

## Test plan

- [x] `dotnet test` 全 116 件 (既存 109 + 新規 7) パス
- [x] RunCPM 実機で T1-T4 全ケース期待値どおり出力
  - T1: `{1.5, 2.5, 3.5}` → `1.5 2.5 3.5`
  - T2: `{1, 2, 3}` → `1 2 3` (i16→f24 自動変換)
  - T3: `CONST PI = 3.1415926; {PI, PI/2.0, PI*2.0}` → `3.1416 1.5708 6.2832`
  - T4: `ARRAY FLOAT GD[5] = {1.5, 2.5}` → `1.5 2.5 0 0 0 0` (部分初期値 + 0 埋め)
- [x] エラーケース 2 種 (非定数式、CastExpr) もテストで明示