### PR TITLE
FLOAT を指す間接変数 (PointerType) 対応

### DIFF
--- a/src/SLANGCompiler.Core/IR/IrGenerator.cs
+++ b/src/SLANGCompiler.Core/IR/IrGenerator.cs
@@ -83,7 +83,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
             else if (sym.Type is ArrayType at)
                 elemSz = at.ElementType.ByteSize;  // BYTE=1 / WORD=2 / FLOAT=3
             else if (sym.Type is PointerType pt)
-                elemSz = (pt.ElementType == SlangType.Byte ? 1 : 2);  // 既存維持 (FLOAT ポインタは別スコープ)
+                elemSz = pt.ElementType.ByteSize;  // BYTE=1 / WORD=2 / FLOAT=3
             else
                 elemSz = 2;
             return new VarInfo { IsResolved = true, Kind = kind, ElemSize = elemSz, VarDataSize = varDs, GlobalSym = sym };
@@ -126,6 +126,25 @@ public class IrGenerator : IAstVisitor<IrOperand>
 
     // 各tempのデータサイズを追跡（FLOAT判定用）
     private readonly Dictionary<int, int> _tempDataSize = new();
+
+    /// <summary>idx を要素サイズ倍に拡大した temp を返す (間接変数経路の共通化)。
+    /// elemSize=1 はそのまま、=2 は ADD HL,HL、それ以外は LoadConst+Mul。</summary>
+    private IrOperand ScaleIndexByElemSize(IrOperand idx, int elemSize)
+    {
+        if (elemSize == 1) return idx;
+        var scaled = IrOperand.Temp(AllocTemp());
+        if (elemSize == 2)
+        {
+            Emit(IrOp.Add, scaled, idx, idx);
+        }
+        else
+        {
+            var c = IrOperand.Temp(AllocTemp());
+            Emit(IrOp.LoadConst, c, IrOperand.Imm(elemSize));
+            Emit(IrOp.Mul, scaled, idx, c);
+        }
+        return scaled;
+    }
 
     public IrModule Generate(CompilationUnit unit)
     {
@@ -1741,23 +1760,15 @@ public class IrGenerator : IAstVisitor<IrOperand>
             var idx = node.Indices[0].Accept(this);
 
             // base + idx * elemSize のアドレスを計算
-            int elemSize = isIndirectByte ? 1 : 2;
-            IrOperand scaledIdx;
-            if (elemSize == 1)
-            {
-                scaledIdx = idx;
-            }
-            else
-            {
-                scaledIdx = IrOperand.Temp(AllocTemp());
-                Emit(IrOp.Add, scaledIdx, idx, idx); // ×2
-            }
+            int elemSize = arrVi.ElemSize;
+            IrOperand scaledIdx = ScaleIndexByElemSize(idx, elemSize);
             var addr = IrOperand.Temp(AllocTemp());
             Emit(IrOp.Add, addr, baseAddr, scaledIdx);
 
             // アドレスから値を読む
             var dest = IrOperand.Temp(AllocTemp());
             Emit(IrOp.IndirLoad, dest, addr, dataSize: elemSize);
+            if (elemSize == 3) _tempDataSize[dest.TempIndex] = 3;
             return dest;
         }
         else
@@ -1967,15 +1978,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
             {
                 var baseAddr = arr.Array.Accept(this); // ポインタ値
                 var idx = arr.Indices[0].Accept(this);
-                int eSize = addrVi.ElemSize;
-                IrOperand scaledIdx;
-                if (eSize == 1)
-                    scaledIdx = idx;
-                else
-                {
-                    scaledIdx = IrOperand.Temp(AllocTemp());
-                    Emit(IrOp.Add, scaledIdx, idx, idx);
-                }
+                IrOperand scaledIdx = ScaleIndexByElemSize(idx, addrVi.ElemSize);
                 var addr = IrOperand.Temp(AllocTemp());
                 Emit(IrOp.Add, addr, baseAddr, scaledIdx);
                 return addr; // アドレスのみ（IndirLoadなし）
@@ -2256,6 +2259,9 @@ public class IrGenerator : IAstVisitor<IrOperand>
             else if (isIndirect)
             {
                 // 間接変数ストア: *(base + idx * elemSize) = value
+                int elemSize = stVi.ElemSize;
+                value = EmitTypeConversion(value, elemSize);
+
                 var baseAddr = IrOperand.Temp(AllocTemp());
                 if (stVi.Local != null)
                     Emit(IrOp.LoadLocal, baseAddr, IrOperand.Imm(stVi.Local.Offset));
@@ -2263,16 +2269,7 @@ public class IrGenerator : IAstVisitor<IrOperand>
                     Emit(IrOp.LoadVar, baseAddr, IrOperand.Sym(ResolveAsmLabel(arrayName!)));
 
                 var idx = arr.Indices[0].Accept(this);
-                int elemSize = stVi.ElemSize;
-
-                IrOperand scaledIdx;
-                if (elemSize == 1)
-                    scaledIdx = idx;
-                else
-                {
-                    scaledIdx = IrOperand.Temp(AllocTemp());
-                    Emit(IrOp.Add, scaledIdx, idx, idx);
-                }
+                IrOperand scaledIdx = ScaleIndexByElemSize(idx, elemSize);
                 var addr = IrOperand.Temp(AllocTemp());
                 Emit(IrOp.Add, addr, baseAddr, scaledIdx);
                 Emit(IrOp.IndirStore, addr, value, dataSize: elemSize);

--- a/tests/SLANGCompiler.Tests/IntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/IntegrationTests.cs
@@ -680,4 +680,147 @@ SUB() BEGIN PRINT(""X""); END;
         var expected = ExpectedFloatBytes(6.0);
         Assert.Contains($"DB\t{expected}", asm);
     }
+
+    // ==== FLOAT を指す PointerType (間接変数) ====
+
+    [Fact]
+    public void FloatPointer_BytePointerRegression_NoChange()
+    {
+        // T0: 既存の BYTE 間接変数 (VAR BYTE BP[]) の動的ストアが変わらない
+        var asm = CompileWithCli(@"
+            ARRAY BYTE BBUF[5];
+            VAR BYTE BP[];
+            VAR I;
+            MAIN() BEGIN BP = &BBUF[0]; FOR I = 0 TO 4 BP[I] = I + 100; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // ScaleIndexByElemSize で elemSize=1 はそのまま (×なし) → idx 加算のみ
+        // BYTE pointer の場合 ×3 化されないことの間接確認
+        Assert.DoesNotContain("CALL\tMULHLDE", mainSection); // ×N runtime call が出ない
+    }
+
+    [Fact]
+    public void FloatPointer_GlobalConstIndex_Store()
+    {
+        // T1: グローバル FLOAT pointer 定数 idx ストア → IndirStore dataSize=3
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[3];
+            VAR FLOAT FP[];
+            MAIN() BEGIN FP = &BUF[0]; FP[0] = 1.5; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // FP の値 (ポインタ) をロードしてアドレス計算に使う + 3バイトストア
+        Assert.Contains("(_V_FP)", mainSection); // FP の中身参照 (HL でも DE でも)
+        Assert.Contains("LD\t(HL),A", mainSection); // exponent も書く = dataSize=3
+    }
+
+    [Fact]
+    public void FloatPointer_GlobalConstIndex_Load()
+    {
+        // T2: グローバル FLOAT pointer 定数 idx ロード → IndirLoad dataSize=3
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[3];
+            VAR FLOAT FP[];
+            VAR FLOAT R;
+            MAIN() BEGIN FP = &BUF[0]; R = FP[0]; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // 3 バイトロード: LD A,(HL) で exponent も読む
+        Assert.Contains("LD\tA,(HL)", mainSection);
+    }
+
+    [Fact]
+    public void FloatPointer_GlobalDynamicIndex_Store()
+    {
+        // T3: 動的 idx → idx × 3 スケーリング (LoadConst $03 + Mul、最適形は ADD HL,HL + ADD HL,DE)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[5];
+            VAR FLOAT FP[];
+            VAR I;
+            MAIN() BEGIN FP = &BUF[0]; FOR I = 0 TO 4 FP[I] = I * 0.5; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // ×3 が ADD HL,HL + ADD HL,DE に展開されるか、LD DE,$0003 + MULHLDE のどちらか
+        bool hasOptimized = mainSection.Contains("ADD\tHL,HL") && mainSection.Contains("ADD\tHL,DE");
+        bool hasGeneric = mainSection.Contains("LD\tDE,$0003") && mainSection.Contains("CALL\tMULHLDE");
+        Assert.True(hasOptimized || hasGeneric, "×3 scaling not found");
+        Assert.Contains("LD\t(HL),A", mainSection); // FLOAT 3バイト書き
+    }
+
+    [Fact]
+    public void FloatPointer_GlobalDynamicIndex_Load()
+    {
+        // T4: 動的 idx ロード
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[5];
+            VAR FLOAT FP[];
+            VAR FLOAT R;
+            VAR I;
+            MAIN() BEGIN FP = &BUF[0]; R = FP[I]; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        Assert.Contains("LD\tA,(HL)", mainSection);
+    }
+
+    [Fact]
+    public void FloatPointer_IntToFloat_AutoConversion()
+    {
+        // T5: FP[0] = 7 で i16tof24 が挿入される (EmitTypeConversion 追加の確認)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[3];
+            VAR FLOAT FP[];
+            MAIN() BEGIN FP = &BUF[0]; FP[0] = 7; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        Assert.Contains("CALL\ti16tof24", mainSection);
+    }
+
+    [Fact]
+    public void FloatPointer_AddressOf()
+    {
+        // T6: &FP[1] で base + 1*3 のアドレス計算 (定数畳み込みで 3 になる)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[3];
+            VAR FLOAT FP[];
+            VAR R;
+            MAIN() BEGIN FP = &BUF[0]; R = &FP[1]; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // 1*3 が定数畳み込みされて LD HL,$0003 + ADD HL,(_V_FP) が出る
+        Assert.Contains("LD\tHL,$0003", mainSection);
+        Assert.Contains("(_V_FP)", mainSection);
+    }
+
+    [Fact]
+    public void FloatPointer_Local_LoadStore()
+    {
+        // T7: 関数内 static 間接変数 (BEGIN 前 VAR FLOAT LP[]) でロード/ストア
+        var asm = CompileWithCli(@"
+            FOO()
+              VAR FLOAT LP[];
+              ARRAY FLOAT LBUF[3];
+            BEGIN
+              LP = &LBUF[0];
+              LP[0] = 11.5;
+            END;
+            MAIN() BEGIN FOO(); END;");
+        var fooSection = asm.Substring(asm.IndexOf("FOO:"));
+        fooSection = fooSection.Substring(0, fooSection.IndexOf("_FOO_EXIT"));
+        // 関数内 static は __FOO_LP のラベル + 3バイト書き
+        Assert.Contains("(_V_FOO_LP)", fooSection);
+        Assert.Contains("LD\t(HL),A", fooSection);
+    }
+
+    [Fact]
+    public void FloatPointer_LoadResult_NoTypeConversion()
+    {
+        // T8: ロード結果を FLOAT 変数に代入する際、i16tof24 が挿入されない
+        // (= _tempDataSize 登録が機能している証拠)
+        var asm = CompileWithCli(@"
+            ARRAY FLOAT BUF[3];
+            VAR FLOAT FP[];
+            VAR FLOAT R;
+            MAIN() BEGIN FP = &BUF[0]; R = FP[0]; END;");
+        var mainSection = asm.Substring(asm.IndexOf("MAIN:"));
+        // R = FP[0] のロードは既に FLOAT (3byte) なので i16tof24 は不要
+        // BUT: FP = &BUF[0] や FP[0] = ... の他の整数式で i16tof24 が出ることはある
+        // ここでは "ロード→代入" の前後で余分な i16tof24 が無いことを部分的に確認
+        // → R 代入前後に i16tof24 が無いことを正確にチェックするのは難しいため、
+        //   全 mainSection で i16tof24 が 1 回も出ないことを Assert する
+        //   (このプログラムには整数→FLOAT 変換が必要な箇所がないため)
+        Assert.DoesNotContain("CALL\ti16tof24", mainSection);
+    }
 }


### PR DESCRIPTION
## 背景

PR #132 (`ARRAY FLOAT` のロード/ストア) と PR #133 (初期値付き宣言) を経て、FLOAT 関連の残りスコープ外項目は **FLOAT を指す PointerType (間接変数) のロード/ストア** のみだった。SLANG では `VAR FLOAT FP[];` (VAR キーワード + 空ブラケット) で間接変数を宣言できるが、PR #132 では `ResolveVarInfo` の PointerType 分岐を意図的に `pt.ElementType == SlangType.Byte ? 1 : 2` のまま温存しており、FLOAT pointer を宣言しても elemSize=2 として WORD ストアされてしまっていた。

## 修正内容

### `IrGenerator`

#### 共通ヘルパー (新規)
- `ScaleIndexByElemSize(idx, elemSize)`: 間接変数経路 3 箇所で重複していた `idx × elemSize` のスケーリング処理を共通化
  - elemSize=1: そのまま、=2: `ADD HL,HL`、その他: `LoadConst + Mul` (CodeGenerator の最適化で `1*3` 等は定数畳み込みされる)

#### 4 箇所の修正
- **`ResolveVarInfo:86`**: PointerType 分岐を `pt.ElementType.ByteSize` に真値化 (BYTE=1 / WORD=2 / FLOAT=3)
- **`VisitArrayAccessExpr` 間接変数 load**: `elemSize = arrVi.ElemSize` 化 + スケーリングをヘルパーに置換 + **`_tempDataSize[dest.TempIndex] = 3` 登録** を追加 (FLOAT 値が後続の関数引数等で WORD 扱いされるのを防止)
- **`VisitAddressOfExpr` 間接変数 addr**: スケーリングをヘルパーに置換
- **`EmitStore` 間接変数 store**: スケーリングをヘルパーに置換 + **`EmitTypeConversion(value, elemSize)` を冒頭に追加** (整数→FLOAT 自動変換)

### CodeGenerator は変更不要
PR #132 で `IndirLoad` / `IndirStore` の dataSize=3 対応済み。

## スコープ外 (将来対応)

- 関数引数として `POINTER FLOAT` を渡すケース (動作確認のみ)
- 多次元 PointerType (`VAR FLOAT FP[][];` 等)

## Test plan

- [x] `dotnet test` 全 126 件 (既存 117 + 新規 9) パス
- [x] RunCPM 実機で 5 ケース (T1-T8 相当) 全部期待値どおり出力
  - T1/T2: `FP[0]=1.5 FP[1]=2.5` (定数 idx ストア/ロード)
  - T3/T4: `FP[3]=1.5` (動的 idx ループ → 定数 idx 読み出し、`I * 0.5` 自動変換)
  - T5: `FP[0]=7` (整数→FLOAT 自動変換、`i16tof24` 挿入)
  - T8: `R = FP[0]` で R=7 (FLOAT 変数代入で `i16tof24` が挿入されない、= `_tempDataSize` 登録が機能している証拠)
  - T7: 関数内 static 間接変数 `LP[0]=11.5 LP[2]=22.5`
- [x] BYTE/WORD pointer regression なし (`FloatPointer_BytePointerRegression_NoChange` で確認)