### PR TITLE
v0.21.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
   - `VAR FLOAT FP[]; FP = &BUF[0]; FP[i] = 1.5;` の形で外部メモリを FLOAT 配列として扱える
   - ×3 スケーリング計算の共通ヘルパーで間接変数 3 経路 (load/AddressOf/store) を統一
 - CP/M 実行環境を RunCPM (MIT) に切り替え
-  - `make run ENV=cpm|lsx` の CP/M エミュレータを Homebrew 版 `cpm` から RunCPM に変更
+  - `make run ENV=cpm|lsx` の CP/M エミュレータを従来の `cpm` 実行環境から RunCPM に変更
   - macOS (arm64/x64) / Linux (x64) / Windows (x64) 4 プラットフォーム分のプリビルド RunCPM バイナリを同梱
   - SUBMIT/EXIT を使った自動終了方式で stdin リダイレクトに依存せず全 OS で動作
   - 配布 zip (Makefile.dist + publish.sh) でも RunCPM 一式を同梱して即実行可能に

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # 更新履歴
 
+## Version 0.21.0
+- ユーザー定義関数の FLOAT 引数・戻り値に対応
+  - 宣言構文: `FX:FLOAT(FLOAT X) BEGIN RETURN X * X; END;`
+  - 整数引数→FLOAT 引数の自動変換 (`i16tof24` 挿入)
+  - WORD 戻り値との混在を型エラーで検出 (`Cannot pass FLOAT`/`Cannot return FLOAT`)
+  - MACHINE 関数は戻り値型指定を拒否 (現状サポート外のため)
+- ARRAY FLOAT に対応
+  - ロード/ストアで 3 バイト単位の mantissa+exponent を正しく扱う
+  - グローバル/ローカル/static の全経路、定数/動的インデックス両対応
+  - `ARRAY FLOAT FA[3] = {1.5, 2.5, 3.5};` の初期値付き宣言をサポート
+    - 整数リテラルは FLOAT に自動変換 (`{1, 2, 3}` → 1.0, 2.0, 3.0)
+    - CONST 参照と FLOAT 定数式 (`{PI, PI/2.0}`) も評価可能
+  - 配列要素への代入で整数→FLOAT の自動変換が動作
+- FLOAT を指す間接変数 (PointerType) に対応
+  - `VAR FLOAT FP[]; FP = &BUF[0]; FP[i] = 1.5;` の形で外部メモリを FLOAT 配列として扱える
+  - ×3 スケーリング計算の共通ヘルパーで間接変数 3 経路 (load/AddressOf/store) を統一
+- CP/M 実行環境を RunCPM (MIT) に切り替え
+  - `make run ENV=cpm|lsx` の CP/M エミュレータを Homebrew 版 `cpm` から RunCPM に変更
+  - macOS (arm64/x64) / Linux (x64) / Windows (x64) 4 プラットフォーム分のプリビルド RunCPM バイナリを同梱
+  - SUBMIT/EXIT を使った自動終了方式で stdin リダイレクトに依存せず全 OS で動作
+  - 配布 zip (Makefile.dist + publish.sh) でも RunCPM 一式を同梱して即実行可能に
+- Makefile のクロスプラットフォーム対応強化
+  - ツールパスを OS 別に `tools/AILZ80ASM` / `tools\AILZ80ASM.exe` で直接参照 (PATH 依存を排除)
+  - `make clean` / 進捗表示 (`ls -la` vs `dir`) / ファイル移動 (`mv` vs `move`) を OS 別に分岐
+  - Windows で bat に渡す引数のパス区切りを `\` に自動変換
+  - `runcpm.bat` を ASCII + CRLF に統一
+
 ## Version 0.20.2
 - CASE文の冗長なexprVal初回評価を削除（生成コードのサイズ縮小、JS版コンパイラとの整合性向上）
 - x1環境で SGL ライブラリ（libx1_sgl_lsx）が使用可能に

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SLANG-compiler
-SLANG Compiler (Z80) 0.20.2
+SLANG Compiler (Z80) 0.21.0
 
 # 概要
 
@@ -14,7 +14,7 @@ SLANG Compiler (Z80) 0.20.2
 # 使い方
 
 ```
-SLANG Compiler v0.20.2
+SLANG Compiler v0.21.0
 Usage: slangc [options] <input.sl>
 
 Options:
@@ -280,11 +280,13 @@ make TARGET=examples/STARS ENV=x1 run
 | pc88mk2sr | PC-8801mkIISR |
 | vgs0 | VGS-Zero |
 | zxn | ZX Spectrum Next |
-| cpm | CP/Mエミュレータ |
+| cpm | CP/Mエミュレータ (RunCPM 同梱) |
 
 ### エミュレータの設定
 
-`Makefile`内のEMU変数を環境に合わせて編集してください。
+`Makefile` 内の `EMU` 変数を環境に合わせて編集してください。
+ただし `ENV=cpm` および `ENV=lsx` は `tools/runcpm/` 以下に同梱された
+RunCPM (MIT) を自動的に使うため、特別な設定は不要です。
 
 ### ディスクイメージの準備
 

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -134,10 +134,22 @@ VAR HENSUU, ABC;
 
 ### 間接変数（変数としても配列としても使える）
 ```
-VAR BYTE POINT[], %KANSETU[];
+VAR BYTE POINT[], %KANSETU[], FLOAT FP[];
 ```
 間接変数の値をアドレスとしてメモリをアクセスする。
-型省略時はWORD。
+型省略時はWORD。FLOAT 指定時はアクセス単位が 3 バイトになり、
+整数値の代入では自動的に `i16tof24` 変換が挿入される (クロスコンパイラ版拡張)。
+
+```
+VAR FLOAT FP[];
+ARRAY FLOAT BUF[5];
+MAIN() BEGIN
+  FP = &BUF[0];
+  FP[0] = 1.5;
+  FP[1] = 7;            (* 整数→FLOAT 自動変換 *)
+  PRINT(FL$(FP[0]));
+END;
+```
 
 ### アドレス指定
 ```
@@ -162,10 +174,11 @@ VAR F[][15];
 
 ### 基本
 ```
-ARRAY BYTE ABUF[5], WORD C[3];
+ARRAY BYTE ABUF[5], WORD C[3], FLOAT FA[3];
 ```
 **定数式+1個分** の配列が確保される（`ARRAY BYTE BUFF[10]` → BUFF[0]～BUFF[10] の11個）。
 添字省略時は0とみなされ、1個分確保。型省略時はWORD。
+FLOAT 配列は 1 要素あたり 3 バイト (mantissa 2byte + exponent 1byte) を確保する。
 
 ### 二次元配列
 ```
@@ -183,6 +196,17 @@ ARRAY ABC[]:$C000;     // 添字省略可
 ARRAY BYTE DT[4]={0, 1, 2, 3, 4};
 ```
 初期値が足りない場合は0で埋められる。多すぎる場合はエラー。
+
+### FLOAT 配列の初期化 (クロスコンパイラ版拡張)
+```
+CONST PI = 3.14;
+ARRAY FLOAT FA[3] = {1.5, 2.5, 3.5};
+ARRAY FLOAT FB[3] = {1, 2, 3};           (* 整数→FLOAT 自動変換 *)
+ARRAY FLOAT FC[2] = {PI, PI / 2.0};      (* CONST 参照 + FLOAT 定数式 *)
+```
+要素は全て FLOAT (3バイト) として展開される。足りない分は 0.0 で埋められる。
+`%` (BYTE/WORD キャスト) を FLOAT 配列のトップレベル要素に書くのは禁止
+(混在を防ぐため。式の内部に含まれる形 (`(%5) + 1.0` 等) は許容)。
 
 ---
 

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -8,7 +8,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.20.2";
+    const string Version = "0.21.0";
 
     static int Main(string[] args)
     {

--- a/tools/runcpm/README.md
+++ b/tools/runcpm/README.md
@@ -26,10 +26,25 @@ used by `make run ENV=cpm|lsx`. They:
 
 1. Prepare a staging directory under the user's temp folder
 2. Copy the target `.COM` into `A/0/<NAME>.COM`
-3. Write the .COM's basename into `AUTOEXEC.TXT`
-4. Launch the platform-appropriate RunCPM binary
-5. Pipe `EXIT` into stdin so RunCPM shuts down after the program returns
-6. Filter RunCPM's boot banner from stdout
+3. Copy `cpm/SUBMIT.COM` and `cpm/EXIT.COM` into `A/0/`
+4. Write a 2-line `A/0/BOOT.SUB` containing `<NAME>` then `EXIT` (CR/LF)
+5. Write `SUBMIT BOOT` into `AUTOEXEC.TXT`
+6. Launch the platform-appropriate RunCPM binary
+7. The CCP runs `SUBMIT BOOT` (from AUTOEXEC), which expands `BOOT.SUB`
+   into `$$$.SUB`. The CCP then executes the program and finally `EXIT`,
+   which terminates RunCPM
+8. Filter RunCPM's boot banner from stdout
+
+Using SUBMIT/EXIT avoids relying on stdin redirection, which is
+unreliable on Windows (RunCPM's Windows console build doesn't read
+stdin via console pipe).
+
+## Bundled CP/M utilities
+
+`cpm/EXIT.COM` and `cpm/SUBMIT.COM` are taken from RunCPM's official
+master disk image (`A0.ZIP`). Both are CP/M standard utilities (DRI
+compatible). They are bundled here so the wrappers above can be
+self-contained without requiring the user to download the master disk.
 
 ## Source and license
 


### PR DESCRIPTION
## 概要

v0.20.2 以降にマージされた以下の機能群をまとめて v0.21.0 としてリリース。

## 含まれる PR

- **#131**: ユーザー定義関数の FLOAT 引数・戻り値対応 (`FX:FLOAT(FLOAT X) ...`)
- **#132**: ARRAY FLOAT のロード/ストア (3バイト要素サイズの正しい伝播)
- **#133**: ARRAY FLOAT 初期値付き宣言 (`ARRAY FLOAT FA[3] = {1.5, 2.5, 3.5};`)
- **#134**: FLOAT を指す間接変数 (`VAR FLOAT FP[]`)
- **#135**: CP/M 実行環境を RunCPM に切り替え (4 プラットフォーム対応)

## このブランチでの変更

- `src/SLANGCompiler.CLI/Program.cs`: Version `0.20.2` → `0.21.0`
- `README.md`: バージョン表記を 0.21.0 に + ENV=cpm が RunCPM 同梱の旨を注記
- `CHANGELOG.md`: v0.21.0 エントリを追加
- `docs/SLANG-spec.md`:
  - 配列宣言に FLOAT 要素サイズ (3 バイト) の説明と例
  - FLOAT 配列の初期化セクション新設 (整数→FLOAT 自動変換 / CONST 参照 / CastExpr 制限)
  - 間接変数に `VAR FLOAT FP[]` の例と FLOAT ポインタ用法を追記

## Test plan

- [x] `dotnet test` 全 126 件パス
- [x] Windows 実機で `make run ENV=cpm` が RunCPM 経由で自動終了動作 (PR #135)
- [ ] マージ後に tag `v0.21.0` を作成 + 4 プラットフォーム分の zip を GitHub release に添付