### PR TITLE
TILELIB: TILE_ATTR アドレス + TileInit テキスト初期値の修正

### DIFF
--- a/include/TILELIB.LIB
+++ b/include/TILELIB.LIB
@@ -40,8 +40,8 @@ MACHINE TILE_INVALIDATE(0): TileInvalidate;
 #ASM
 
 ; --- 定数 ---
-TILE_TVRAM	EQU	$3000	; テキスト VRAM (I/O)
-TILE_ATTR	EQU	$2800	; アトリビュート VRAM (I/O)
+TILE_TVRAM	EQU	$3000	; テキスト VRAM (I/O, $3000-$37FF)
+TILE_ATTR	EQU	$2000	; アトリビュート VRAM (I/O, $2000-$27FF)
 TILE_ATTR_PCG7	EQU	$27	; PCG 有効 + カラー 7
 TILE_WIDTH	EQU	40	; 画面横文字数
 TILE_HEIGHT	EQU	25	; 画面縦文字数
@@ -52,7 +52,7 @@ TILE_MAPWIDTH	EQU	20	; 横スーパーチップ数 (20×2=40 文字)
 ; TileInit — テキスト VRAM/アトリビュート初期化 (両ページ)
 ; ============================================================
 TileInit:
-	; アトリビュート $2800-$2FFF を $27 で埋める (両ページ分)
+	; アトリビュート $2000-$27FF を $27 で埋める (両ページ分)
 	ld bc,TILE_ATTR
 	ld d,TILE_ATTR_PCG7
 	ld hl,$0800
@@ -65,11 +65,17 @@ TileInit:
 	or l
 	jr nz,.attr_loop
 
-	; テキスト VRAM $3000-$37FF を 0 で埋める (両ページ分)
+	; テキスト VRAM $3000-$37FF を空白 ($20) で埋める (両ページ分)。
+	; attribute が PCG=1 の状態で char code $00 を置くと「定義済み PCG
+	; glyph 0 (= PCGDEF で最初に定義したタイル)」がそこに表示されてしまう。
+	; 特に TILE_SET_SIZE の表示範囲外は TileFillMap が描かないため
+	; そのままタイル 0 が残る (turbo/turboZ の CRTC では画面下端に露出)。
+	; $20 を入れておけば未定義 PCG glyph (通常 0 初期化) = ブランクとして扱われ、
+	; CTRL0C のテキストクリア値とも整合する。
 	ld bc,TILE_TVRAM
 	ld hl,$0800
 .text_loop:
-	xor a
+	ld a,$20
 	out (c),a
 	inc bc
 	dec hl


### PR DESCRIPTION
## Summary

- **TILE_ATTR を \$2800 → \$2000 に修正**: X1 アトリビュート VRAM は仕様上 \$2000-\$27FF が正。\$2800 はミラーアドレスで結果的に同じ VRAM を叩いていたので動作していたが、仕様 / 保守性のため正規アドレスに揃える。
- **TileInit のテキスト VRAM 初期値を \$00 → \$20 に修正**: attribute が PCG=1 の状態で text VRAM に \$00 を置くと「PCG glyph 0 (= PCGDEF で最初に定義したタイル)」が表示される。TILE_SET_SIZE の範囲外は TileFillMap が描かないため、そこにタイル 0 が残り X1 turbo / turboZ の CRTC で画面下端にゴミとして露出する問題があった。

## Background

- \$2800 問題は PR #139 の UILIB / TILELIB 一式追加時に気づいていなかった既存の命名ミス。機能的影響はないがドキュメントと食い違う
- \$00 問題は X1 turbo / turboZ の環境でのみ可視化される回帰。plain X1 では CRTC 表示幅 / タイミングにより隠れていたが、turbo 系では画面下端に出る。手動で \`\$3000-\$37FF\` を \$20 埋めする workaround で直ることが確認できたので、TileInit 自体を修正

## Test plan

- [x] TILETEST / TILSPRTEST のアセンブルが通る
- [x] X1 turbo / turboZ 環境で画面下端のゴミが消えることを実機確認 (報告済)
- [x] plain X1 でも動作変わらないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)