### PR TITLE
PR-B2: 全ファイル間関数 cross-reference の prelink 二段アセンブル

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased (v0.23.0 候補)
 
+- `slangbuild` に prelink 二段アセンブル機構を追加 (PR-B2) — main / overlay 間で **任意の SLANG 関数の相互呼び出し** をサポート
+  - cross-reference 検出時に自動的に prelink モードへ (Pass 1: 各 target を dummy imports でアセンブル → Pass 2: 全 target の Exports セクションから ExportedFunctionTable 構築 → Pass 3: combined imports で本番アセンブル)
+  - サポート範囲: main → overlay 関数 / overlay → main 関数 / overlay → overlay 関数 (関数シンボルのみ)
+  - **仕様**: 解決するのはアドレスだけ。swap 制御・呼び先 overlay のロード状態確認は ユーザー責任 (低レベル言語の責務分担)
+  - compiler 側 (`CodeGenerator`) で各 ASM に `; === Exported User Functions ===` (= 自分が定義する関数) + `; === User Function References ===` (= 自分が呼ぶ他ファイル関数) の 2 セクションを出力
+  - driver 側に `AsmSectionParser` / `ExportedFunctionTable` / `PrelinkPlan` 新設。`-nsa` は prelink Pass 1/3 のみ付与 (既存単段フローには影響なし)
+  - PR-A バグ修正: `Preprocessor` が `#END` を「stray」として skip してしまい、`#MODULE` 内 `#END` が Parser に届いていなかった問題を解消 (これにより 2 つ以上の `#MODULE` が正しく個別 overlay として認識される)
+  - PR-A バグ修正: `#MODULE` ネスト禁止 (= `#END` 不足検出も兼ねた parse エラー)
+  - 失敗時は `--keep-asm` 指定なしでも中間 ASM を残す (AILZ80ASM のエラー行追跡用、PR-B 既存)
+  - 新規テスト: `AsmSectionParserTests` (4) + `ExportedFunctionTableTests` (4) + `PrelinkPlanTests` (5) + `BuildIntegrationTests` 拡張 (4 件 prelink E2E + -o 相対パス回帰 2 件、合計 17 件追加)
 - 二段アセンブル toolchain `slangbuild` を新ドライバとして追加 (PR-B)
   - `src/SLANGCompiler.Build/` を新規 .NET 8 プロジェクトとして追加。`slangc` は改修せず、`slangbuild` が orchestration (slangc → AILZ80ASM main → AILZ80ASM overlay) を担う GCC 的責務分離
   - **二段フロー**: main を `-sm minimal-equ` でアセンブルして `.sym` を生成 → 各 overlay について overlay ASM 内の `; EXTERN` リストと main.sym の交集合だけを抽出した `<overlay>.imports.asm` (filtered EQU) を作成 → `imports.asm + overlay.ASM` を AILZ80ASM に投入。raw main.sym をそのまま渡すと compiler 内部ラベル衝突が起きるため必ず filter する

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -861,3 +861,53 @@ slangbuild <input.SL> [options]
 - 未解決ラベル (overlay の `; EXTERN` リストにあるが main.sym にない) は
   `--verbose` 時に warning として表示。AILZ80ASM 側で「未定義シンボル」
   エラーで止まる
+
+### 全ファイル間関数 cross-reference 解決 (v0.23 PR-B2)
+
+PR-B2 で `slangbuild` を拡張し、`main / overlay 0 / overlay 1 / ...` の
+任意の組み合わせ間で **SLANG 関数を相互呼び出し** できるようにする
+(prelink 二段アセンブル方式)。
+
+#### サポート範囲 (関数シンボルのみ)
+
+- main → overlay 関数
+- overlay → overlay 関数
+- overlay → main 関数
+
+#### 仕様 (= ユーザー責任)
+
+- 解決するのは **アドレスだけ**。呼び先 overlay が実行時にメモリにロード
+  されている保証は driver / runtime には無い
+- 同一 ORG を共有する overlay 間 call は未定義動作になりうる
+- swap タイミング / 呼び出し可否はすべて **ユーザー責任**
+
+つまり SLANG は呼び出しコードを `CALL <address>` として吐くだけで、その
+address が今そこに居るかは関知しない (低レベル言語の責務分担)。
+
+#### 仕組み (内部、参考)
+
+`slangc` が各 ASM に **Exports** (= 自分が定義する関数: `; FUNC <name>`) と
+**User Function References** (= 自分が呼ぶ他ファイル関数: `; EXTERN <name>`)
+の 2 セクションをコメントとして出力する。`slangbuild` がこれらを検出した
+場合、自動的に prelink モードに入る:
+
+```
+Pass 1: 各 target に dummy imports (全 extern を $0000 EQU) を渡してアセンブル
+        → 各 target.pass1.sym 取得 (= 自身が定義する label のアドレス確定)
+Pass 2: 全 target の Exports セクションに列挙された関数だけを拾って
+        ExportedFunctionTable を構築
+        (注: runtime 関数等 export 宣言されていない label は除外、衝突なし)
+Pass 3: combined imports.asm を生成 (= user function は ExportedFunctionTable
+        から、shared runtime / globals は main.sym から解決) → 各 target を
+        本番アセンブル
+```
+
+`-nsa` (no super-assemble) は **prelink モード時のみ** 付与され、Pass 1
+と Pass 3 で同じ target 内のラベルアドレスが一致することを保証する。
+PR-B 既存の単段フロー (cross-ref 無しの場合) では `-nsa` を付けない。
+
+#### 制約 (本 PR-B2)
+
+- 関数シンボルのみ対応。overlay private 変数 / overlay work / data の
+  cross-reference は未対応
+- `#MODULE` のネストは禁止 (`#END` 不足の検出を兼ねて compile エラー)

--- a/src/SLANGCompiler.Build/AsmSectionParser.cs
+++ b/src/SLANGCompiler.Build/AsmSectionParser.cs
@@ -1,0 +1,68 @@
+using System.Text.RegularExpressions;
+
+namespace SLANGCompiler.Build;
+
+/// <summary>
+/// PR-A / PR-B / PR-B2 が ASM ファイルに出力する固定セクション内のラベル名を
+/// regex 抽出する汎用パーサ。
+///
+/// セクションは `; === <Header> ===` で開始し、次のセクション (or EOF) で終わる。
+/// 対象セクション内の指定 prefix (`; FUNC <name>` / `; EXTERN <name>`) の
+/// 行から name を取り出す。対象セクション外の同形コメントは無視。
+/// </summary>
+public static class AsmSectionParser
+{
+    // セクションヘッダ行 `; === ... ===`
+    private static readonly Regex SectionHeader = new(
+        @"^\s*;\s*===.*===\s*$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// `; FUNC <name>` 形式の行から name を抽出 (行先頭空白許容、後続コメント許容)
+    /// </summary>
+    private static readonly Regex FuncLine = new(
+        @"^\s*;\s*FUNC\s+([A-Za-z_][A-Za-z0-9_.]*)\b",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// `; EXTERN <name>` 形式の行から name を抽出
+    /// </summary>
+    private static readonly Regex ExternLine = new(
+        @"^\s*;\s*EXTERN\s+([A-Za-z_][A-Za-z0-9_.]*)\b",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// 指定セクション群内の `; FUNC <name>` 行から name を抽出 (重複排除、出現順保持)
+    /// </summary>
+    public static List<string> ExtractFuncNames(string asmText, IEnumerable<string> targetSectionHeaders)
+        => Extract(asmText, targetSectionHeaders, FuncLine);
+
+    /// <summary>
+    /// 指定セクション群内の `; EXTERN <name>` 行から name を抽出
+    /// </summary>
+    public static List<string> ExtractExternNames(string asmText, IEnumerable<string> targetSectionHeaders)
+        => Extract(asmText, targetSectionHeaders, ExternLine);
+
+    private static List<string> Extract(string asmText, IEnumerable<string> targetSectionHeaders, Regex lineRegex)
+    {
+        var targets = new HashSet<string>(targetSectionHeaders, StringComparer.Ordinal);
+        var names = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        bool inTargetSection = false;
+
+        foreach (var rawLine in asmText.Split('\n'))
+        {
+            var line = rawLine.TrimEnd('\r');
+            if (SectionHeader.IsMatch(line))
+            {
+                inTargetSection = targets.Contains(line.TrimStart());
+                continue;
+            }
+            if (!inTargetSection) continue;
+            var m = lineRegex.Match(line);
+            if (m.Success && seen.Add(m.Groups[1].Value))
+                names.Add(m.Groups[1].Value);
+        }
+        return names;
+    }
+}

--- a/src/SLANGCompiler.Build/AssemblerRunner.cs
+++ b/src/SLANGCompiler.Build/AssemblerRunner.cs
@@ -25,16 +25,13 @@ public class AssemblerRunner
     /// main ASM をアセンブルして bin + sym を出力。
     /// `-sm minimal-equ` で出力 sym は overlay の filtered imports に流用可能な形式に。
     /// </summary>
-    public AssemblerResult AssembleMain(string asmPath, string outBinPath, string outSymPath)
+    /// <param name="superAssemble">true (default) = 既存挙動 (JR/JP 自動最適化)。
+    /// false = `-nsa` 付与で命令長を固定 (PR-B2 prelink Pass 1/3 用、Pass 1 と
+    /// Pass 3 で同じファイル内ラベルアドレスを一致させるため)</param>
+    public AssemblerResult AssembleMain(string asmPath, string outBinPath, string outSymPath,
+                                        bool superAssemble = true)
     {
-        var args = new[]
-        {
-            asmPath,
-            "-bin", outBinPath,
-            "-sym", outSymPath,
-            "-sm", "minimal-equ",
-            "-f",
-        };
+        var args = BuildArgs(new[] { asmPath }, outBinPath, outSymPath, superAssemble);
         return Run(args);
     }
 
@@ -43,19 +40,27 @@ public class AssemblerRunner
     /// imports は AILZ80ASM 側で先頭ファイル扱いになるため、その EQU 群が
     /// overlay 側の CALL から参照される。
     /// </summary>
+    /// <param name="superAssemble">true (default) = 既存挙動 (PR-B 単段フロー用)、
+    /// false = `-nsa` 付与 (PR-B2 prelink Pass 1/3 用)</param>
     public AssemblerResult AssembleOverlay(string importsAsmPath, string overlayAsmPath,
-                                           string outBinPath, string outSymPath)
+                                           string outBinPath, string outSymPath,
+                                           bool superAssemble = true)
     {
-        var args = new[]
-        {
-            importsAsmPath,
-            overlayAsmPath,
-            "-bin", outBinPath,
-            "-sym", outSymPath,
-            "-sm", "minimal-equ",
-            "-f",
-        };
+        var args = BuildArgs(new[] { importsAsmPath, overlayAsmPath },
+                             outBinPath, outSymPath, superAssemble);
         return Run(args);
+    }
+
+    private static string[] BuildArgs(string[] inputs, string outBinPath, string outSymPath,
+                                      bool superAssemble)
+    {
+        var list = new List<string>(inputs);
+        list.Add("-bin"); list.Add(outBinPath);
+        list.Add("-sym"); list.Add(outSymPath);
+        list.Add("-sm");  list.Add("minimal-equ");
+        list.Add("-f");
+        if (!superAssemble) list.Add("-nsa");
+        return list.ToArray();
     }
 
     private AssemblerResult Run(string[] args)

--- a/src/SLANGCompiler.Build/AssemblerRunner.cs
+++ b/src/SLANGCompiler.Build/AssemblerRunner.cs
@@ -28,10 +28,13 @@ public class AssemblerRunner
     /// <param name="superAssemble">true (default) = 既存挙動 (JR/JP 自動最適化)。
     /// false = `-nsa` 付与で命令長を固定 (PR-B2 prelink Pass 1/3 用、Pass 1 と
     /// Pass 3 で同じファイル内ラベルアドレスを一致させるため)</param>
+    /// <param name="lstPath">non-null なら `-lst &lt;path&gt;` を付与してリスト
+    /// ファイルを出力。本番アセンブル (単段モード or prelink Pass 3) では指定し、
+    /// prelink Pass 1 (中間用) では null にして無駄な出力を避ける。</param>
     public AssemblerResult AssembleMain(string asmPath, string outBinPath, string outSymPath,
-                                        bool superAssemble = true)
+                                        bool superAssemble = true, string? lstPath = null)
     {
-        var args = BuildArgs(new[] { asmPath }, outBinPath, outSymPath, superAssemble);
+        var args = BuildArgs(new[] { asmPath }, outBinPath, outSymPath, superAssemble, lstPath);
         return Run(args);
     }
 
@@ -42,21 +45,23 @@ public class AssemblerRunner
     /// </summary>
     /// <param name="superAssemble">true (default) = 既存挙動 (PR-B 単段フロー用)、
     /// false = `-nsa` 付与 (PR-B2 prelink Pass 1/3 用)</param>
+    /// <param name="lstPath">non-null なら `-lst &lt;path&gt;` を付与</param>
     public AssemblerResult AssembleOverlay(string importsAsmPath, string overlayAsmPath,
                                            string outBinPath, string outSymPath,
-                                           bool superAssemble = true)
+                                           bool superAssemble = true, string? lstPath = null)
     {
         var args = BuildArgs(new[] { importsAsmPath, overlayAsmPath },
-                             outBinPath, outSymPath, superAssemble);
+                             outBinPath, outSymPath, superAssemble, lstPath);
         return Run(args);
     }
 
     private static string[] BuildArgs(string[] inputs, string outBinPath, string outSymPath,
-                                      bool superAssemble)
+                                      bool superAssemble, string? lstPath)
     {
         var list = new List<string>(inputs);
         list.Add("-bin"); list.Add(outBinPath);
         list.Add("-sym"); list.Add(outSymPath);
+        if (lstPath != null) { list.Add("-lst"); list.Add(lstPath); }
         list.Add("-sm");  list.Add("minimal-equ");
         list.Add("-f");
         if (!superAssemble) list.Add("-nsa");

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using SLANGCompiler.Runtime;
 
 namespace SLANGCompiler.Build;
 
@@ -102,47 +103,32 @@ public class Driver
                                        .ToList();
             foreach (var p in overlayAsms) intermediates.Add(p);
 
-            // === Step 2: AILZ80ASM main ===
+            // === Step 2: PrelinkPlan 構築 (cross-ref 検出) ===
             var asm = _resolver.ResolveAilz80Asm(_opts.AsmPath);
             if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: using AILZ80ASM: {asm.Path}");
-
             var runner = new AssemblerRunner(asm.Path, _opts.Verbose);
-            var mainResult = runner.AssembleMain(mainAsm, mainBin, mainSym);
-            if (!mainResult.Success)
+
+            var planTargets = new List<(string Label, string AsmPath)>
             {
-                Console.Error.Write(mainResult.Stderr);
-                Console.Error.WriteLine($"slangbuild: main assembly failed (exit {mainResult.ExitCode})");
-                return mainResult.ExitCode;
+                ("main", mainAsm),
+            };
+            for (int i = 0; i < overlayAsms.Count; i++)
+                planTargets.Add(($"overlay {i}", overlayAsms[i]));
+            var plan = PrelinkPlan.Build(planTargets);
+
+            if (plan.IsTrivial)
+            {
+                // === 単段モード (PR-B 既存パス) ===
+                int rc = AssembleSingleStage(runner, plan, mainAsm, mainBin, mainSym,
+                                             overlayAsms, outputDir, intermediates);
+                if (rc != 0) return rc;
             }
-            // main.sym は cleanup 対象 (overlay 完了後に消す)
-            intermediates.Add(mainSym);
-
-            // === Step 3-4: 各 overlay ===
-            foreach (var overlayAsm in overlayAsms)
+            else
             {
-                var overlayBase = Path.GetFileNameWithoutExtension(overlayAsm); // <prefix>._mN
-                var importsAsm = Path.Combine(outputDir, overlayBase + ".imports.asm");
-                var overlayBin = Path.Combine(outputDir, overlayBase + ".bin");
-                var overlaySym = Path.Combine(outputDir, overlayBase + ".sym");
-
-                var (_, unresolved) = OverlayImportsBuilder.Build(mainSym, overlayAsm, importsAsm);
-                intermediates.Add(importsAsm);
-
-                if (unresolved.Count > 0 && _opts.Verbose)
-                {
-                    Console.Error.WriteLine(
-                        $"slangbuild: {overlayBase}: {unresolved.Count} unresolved EXTERN(s) "
-                        + "(main.sym lacks: " + string.Join(", ", unresolved) + ")");
-                }
-
-                var ovResult = runner.AssembleOverlay(importsAsm, overlayAsm, overlayBin, overlaySym);
-                if (!ovResult.Success)
-                {
-                    Console.Error.Write(ovResult.Stderr);
-                    Console.Error.WriteLine($"slangbuild: overlay assembly failed for {overlayBase} (exit {ovResult.ExitCode})");
-                    return ovResult.ExitCode;
-                }
-                intermediates.Add(overlaySym);
+                // === prelink モード (PR-B2): Pass 1 → Pass 2 → Pass 3 ===
+                int rc = AssemblePrelink(runner, plan, mainBin, mainSym,
+                                         outputDir, intermediates);
+                if (rc != 0) return rc;
             }
 
             if (_opts.Verbose)
@@ -178,6 +164,144 @@ public class Driver
         var name = Path.GetFileName(inputPath);
         var dot = name.LastIndexOf('.');
         return dot >= 0 ? name[..dot] : name;
+    }
+
+    /// <summary>
+    /// 単段モード (PR-B 既存パス): main を直接アセンブル → 各 overlay について
+    /// `OverlayImportsBuilder` で main.sym から filtered EQU を生成 → overlay を
+    /// アセンブル。cross-ref が無いケースで使う。
+    /// </summary>
+    private int AssembleSingleStage(AssemblerRunner runner, PrelinkPlan plan,
+        string mainAsm, string mainBin, string mainSym,
+        List<string> overlayAsms, string outputDir, List<string> intermediates)
+    {
+        var mainResult = runner.AssembleMain(mainAsm, mainBin, mainSym);
+        if (!mainResult.Success)
+        {
+            Console.Error.Write(mainResult.Stderr);
+            Console.Error.WriteLine($"slangbuild: main assembly failed (exit {mainResult.ExitCode})");
+            return mainResult.ExitCode;
+        }
+        intermediates.Add(mainSym);
+
+        foreach (var overlayAsm in overlayAsms)
+        {
+            var overlayBase = Path.GetFileNameWithoutExtension(overlayAsm);
+            var importsAsm = Path.Combine(outputDir, overlayBase + ".imports.asm");
+            var overlayBin = Path.Combine(outputDir, overlayBase + ".bin");
+            var overlaySym = Path.Combine(outputDir, overlayBase + ".sym");
+
+            var (_, unresolved) = OverlayImportsBuilder.Build(mainSym, overlayAsm, importsAsm);
+            intermediates.Add(importsAsm);
+
+            if (unresolved.Count > 0 && _opts.Verbose)
+            {
+                Console.Error.WriteLine(
+                    $"slangbuild: {overlayBase}: {unresolved.Count} unresolved EXTERN(s) "
+                    + "(main.sym lacks: " + string.Join(", ", unresolved) + ")");
+            }
+
+            var ovResult = runner.AssembleOverlay(importsAsm, overlayAsm, overlayBin, overlaySym);
+            if (!ovResult.Success)
+            {
+                Console.Error.Write(ovResult.Stderr);
+                Console.Error.WriteLine($"slangbuild: overlay assembly failed for {overlayBase} (exit {ovResult.ExitCode})");
+                return ovResult.ExitCode;
+            }
+            intermediates.Add(overlaySym);
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// prelink モード (PR-B2 新規): cross-ref があるケース。
+    ///   Pass 1: 各 target に dummy imports ($0000 EQU) を渡してアセンブル → pass1.sym 取得
+    ///   Pass 2: 全 target の Exports + pass1.sym から ExportedFunctionTable 構築
+    ///   Pass 3: combined real imports を生成して再アセンブル → 本番 bin/sym
+    /// `-nsa` 付与で命令長を固定し、Pass 1 と Pass 3 で同じ target 内のラベル
+    /// アドレスが一致することを保証する。
+    /// </summary>
+    private int AssemblePrelink(AssemblerRunner runner, PrelinkPlan plan,
+        string mainBin, string mainSym, string outputDir, List<string> intermediates)
+    {
+        if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: prelink mode (cross-references found)");
+
+        // Pass 1: 各 target を dummy imports でアセンブル → pass1 sym 取得
+        var pass1Symbols = new Dictionary<string, Dictionary<string, int>>(); // target.Label → sym dict
+        foreach (var t in plan.Targets)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(t.AsmPath);
+            var dummyImportsPath = Path.Combine(outputDir, baseName + ".dummy.imports.asm");
+            var pass1BinPath = Path.Combine(outputDir, baseName + ".pass1.bin");
+            var pass1SymPath = Path.Combine(outputDir, baseName + ".pass1.sym");
+
+            PrelinkPlan.WriteDummyImports(t, dummyImportsPath);
+            intermediates.Add(dummyImportsPath);
+
+            var result = runner.AssembleOverlay(dummyImportsPath, t.AsmPath,
+                                                pass1BinPath, pass1SymPath,
+                                                superAssemble: false);
+            if (!result.Success)
+            {
+                Console.Error.Write(result.Stderr);
+                Console.Error.WriteLine(
+                    $"slangbuild: prelink Pass 1 failed for {t.Label} (exit {result.ExitCode})");
+                return result.ExitCode;
+            }
+            // Pass 1 の bin はテンポラリ即削除 (sym だけ Pass 2 で使う)
+            try { File.Delete(pass1BinPath); } catch { }
+            intermediates.Add(pass1SymPath);
+            pass1Symbols[t.Label] = SymFileReader.ReadFile(pass1SymPath);
+        }
+
+        // Pass 2: ExportedFunctionTable を構築
+        var exportedTable = new ExportedFunctionTable();
+        foreach (var t in plan.Targets)
+            exportedTable.Add(t.Label, t.Exports, pass1Symbols[t.Label]);
+
+        // Pass 3: combined real imports を生成 → 本番アセンブル
+        var mainPass1Sym = pass1Symbols.GetValueOrDefault("main", new Dictionary<string, int>());
+        foreach (var t in plan.Targets)
+        {
+            var baseName = Path.GetFileNameWithoutExtension(t.AsmPath);
+            var importsAsm = Path.Combine(outputDir, baseName + ".imports.asm");
+            var (_, unresolved) = PrelinkPlan.WriteRealImports(
+                t, exportedTable, mainPass1Sym, importsAsm);
+            intermediates.Add(importsAsm);
+
+            if (unresolved.Count > 0 && _opts.Verbose)
+            {
+                Console.Error.WriteLine(
+                    $"slangbuild: {t.Label}: {unresolved.Count} unresolved EXTERN(s) "
+                    + "(none found in any target sym: " + string.Join(", ", unresolved) + ")");
+            }
+
+            // 本番出力ファイル名: main は <prefix>.bin、overlay は <prefix>._mN.bin
+            string outBin, outSym;
+            if (t.Label == "main")
+            {
+                outBin = mainBin;
+                outSym = mainSym;
+            }
+            else
+            {
+                outBin = Path.Combine(outputDir, baseName + ".bin");
+                outSym = Path.Combine(outputDir, baseName + ".sym");
+            }
+
+            var result = runner.AssembleOverlay(importsAsm, t.AsmPath, outBin, outSym,
+                                                superAssemble: false);
+            if (!result.Success)
+            {
+                Console.Error.Write(result.Stderr);
+                Console.Error.WriteLine(
+                    $"slangbuild: prelink Pass 3 failed for {t.Label} (exit {result.ExitCode})");
+                return result.ExitCode;
+            }
+            if (t.Label != "main") intermediates.Add(outSym);
+        }
+        intermediates.Add(mainSym);
+        return 0;
     }
 
     private int SpawnSlangc(ResolvedTool slangc, string inputPath, string outAsmPath, string env)

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -175,7 +175,8 @@ public class Driver
         string mainAsm, string mainBin, string mainSym,
         List<string> overlayAsms, string outputDir, List<string> intermediates)
     {
-        var mainResult = runner.AssembleMain(mainAsm, mainBin, mainSym);
+        var mainLst = Path.ChangeExtension(mainBin, ".LST");
+        var mainResult = runner.AssembleMain(mainAsm, mainBin, mainSym, lstPath: mainLst);
         if (!mainResult.Success)
         {
             Console.Error.Write(mainResult.Stderr);
@@ -190,6 +191,7 @@ public class Driver
             var importsAsm = Path.Combine(outputDir, overlayBase + ".imports.asm");
             var overlayBin = Path.Combine(outputDir, overlayBase + ".bin");
             var overlaySym = Path.Combine(outputDir, overlayBase + ".sym");
+            var overlayLst = Path.Combine(outputDir, overlayBase + ".LST");
 
             var (_, unresolved) = OverlayImportsBuilder.Build(mainSym, overlayAsm, importsAsm);
             intermediates.Add(importsAsm);
@@ -201,7 +203,8 @@ public class Driver
                     + "(main.sym lacks: " + string.Join(", ", unresolved) + ")");
             }
 
-            var ovResult = runner.AssembleOverlay(importsAsm, overlayAsm, overlayBin, overlaySym);
+            var ovResult = runner.AssembleOverlay(importsAsm, overlayAsm, overlayBin, overlaySym,
+                                                  lstPath: overlayLst);
             if (!ovResult.Success)
             {
                 Console.Error.Write(ovResult.Stderr);
@@ -277,20 +280,22 @@ public class Driver
             }
 
             // 本番出力ファイル名: main は <prefix>.bin、overlay は <prefix>._mN.bin
-            string outBin, outSym;
+            string outBin, outSym, outLst;
             if (t.Label == "main")
             {
                 outBin = mainBin;
                 outSym = mainSym;
+                outLst = Path.ChangeExtension(mainBin, ".LST");
             }
             else
             {
                 outBin = Path.Combine(outputDir, baseName + ".bin");
                 outSym = Path.Combine(outputDir, baseName + ".sym");
+                outLst = Path.Combine(outputDir, baseName + ".LST");
             }
 
             var result = runner.AssembleOverlay(importsAsm, t.AsmPath, outBin, outSym,
-                                                superAssemble: false);
+                                                superAssemble: false, lstPath: outLst);
             if (!result.Success)
             {
                 Console.Error.Write(result.Stderr);

--- a/src/SLANGCompiler.Build/ExportedFunctionTable.cs
+++ b/src/SLANGCompiler.Build/ExportedFunctionTable.cs
@@ -1,0 +1,64 @@
+using SLANGCompiler.Runtime;
+
+namespace SLANGCompiler.Build;
+
+/// <summary>
+/// PR-B2 prelink Pass 2 で構築する「全 target が export 宣言した関数」のアドレス
+/// 集約 table。
+///
+/// 設計の核心 (Codex 指摘):
+///   全 .sym を union するのではなく、各 target の `; === Exported User Functions ===`
+///   セクションに列挙された関数名だけを採用する。runtime 関数 (MPRNT, DIVHLDE8.div81
+///   等) は target ごとに複製されて .sym に乗るが、export set には入らないので
+///   衝突しない。local label / private symbol も自動的に除外される。
+/// </summary>
+public class ExportedFunctionTable
+{
+    /// <summary>関数名 (case-insensitive) → 絶対アドレス</summary>
+    public Dictionary<string, int> Symbols { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>関数名 → 定義元の説明 (例: "main", "overlay 0")</summary>
+    public Dictionary<string, string> SourceByName { get; } =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// 1 target 分の export 関数を Pass 1 sym から登録する。同名重複は防御エラー。
+    /// </summary>
+    /// <param name="sourceLabel">"main" or "overlay 0" 等、エラー報告用ラベル</param>
+    /// <param name="exportNames">この target が `; FUNC <name>` で宣言した関数名集合</param>
+    /// <param name="pass1Symbols">この target の Pass 1 出力 .sym (label → addr)</param>
+    public void Add(string sourceLabel, IEnumerable<string> exportNames,
+                    IReadOnlyDictionary<string, int> pass1Symbols)
+    {
+        foreach (var name in exportNames)
+        {
+            if (!pass1Symbols.TryGetValue(name, out var addr))
+            {
+                // export 宣言があるのに pass 1 sym に対応ラベルが無い = compiler のバグ
+                // または ASM の手書き不整合。スキップして警告 (driver 上位で詳細表示)
+                continue;
+            }
+            if (Symbols.TryGetValue(name, out var existingAddr))
+            {
+                if (existingAddr != addr)
+                {
+                    throw new InvalidOperationException(
+                        $"ExportedFunctionTable: duplicate export '{name}' with different "
+                        + $"addresses ({SourceByName[name]}: ${existingAddr:X4}, "
+                        + $"{sourceLabel}: ${addr:X4}). "
+                        + "SLANG semantic should have prevented same-named exports across targets; "
+                        + "this is a defensive check.");
+                }
+                // 同名同アドレスは無視 (= alias 等で偶然同じになるケース、本来あり得ない)
+                continue;
+            }
+            Symbols[name] = addr;
+            SourceByName[name] = sourceLabel;
+        }
+    }
+
+    /// <summary>関数名を解決。未登録なら null。</summary>
+    public int? Resolve(string name)
+        => Symbols.TryGetValue(name, out var addr) ? addr : null;
+}

--- a/src/SLANGCompiler.Build/PrelinkPlan.cs
+++ b/src/SLANGCompiler.Build/PrelinkPlan.cs
@@ -1,0 +1,140 @@
+using System.Text;
+using SLANGCompiler.Runtime;
+
+namespace SLANGCompiler.Build;
+
+/// <summary>
+/// PR-B2 prelink モード: 各 ASM target (main + 各 overlay) の Exports / Imports
+/// セクションを集計し、Pass 1 用 dummy imports + Pass 3 用 combined real imports を
+/// 生成する。
+///
+/// cross-ref が無いプロジェクト (= overlay 無し or ユーザー関数 cross-ref 無し)
+/// では `IsTrivial = true` で driver は単段フロー (PR-B 既存パス) に分岐する。
+/// </summary>
+public class PrelinkPlan
+{
+    /// <summary>1 つの ASM target (main または overlay) の cross-ref 情報</summary>
+    public class TargetInfo
+    {
+        public string Label { get; set; } = "";   // "main", "overlay 0", ...
+        public string AsmPath { get; set; } = "";
+        public List<string> Exports { get; set; } = new(); // `; FUNC <name>` から
+        public List<string> UserFunctionImports { get; set; } = new(); // PR-B2 新セクション
+        public List<string> SharedImports { get; set; } = new();       // PR-B 既存 3 セクションの合算
+    }
+
+    public List<TargetInfo> Targets { get; } = new();
+
+    /// <summary>cross-ref が無い (= 全 target で UserFunctionImports が空) なら true。
+    /// この場合 driver は PR-B 既存の単段フローを使う。</summary>
+    public bool IsTrivial =>
+        Targets.All(t => t.UserFunctionImports.Count == 0);
+
+    // PR-A 出力の固定セクションヘッダ (本 PR-B2 で driver が拾う対象)
+    private static readonly string[] ExportsSectionHeaders =
+    {
+        "; === Exported User Functions ===",
+    };
+    private static readonly string[] UserFunctionImportsSectionHeaders =
+    {
+        "; === User Function References ===",
+    };
+    private static readonly string[] SharedImportsSectionHeaders =
+    {
+        "; === Shared Runtime References (resolved via two-stage assembly) ===",
+        "; === Shared Symbols (from main) ===",
+        "; === String references (from main) ===",
+    };
+
+    /// <summary>
+    /// 与えられた ASM ファイル群から PrelinkPlan を構築する。
+    /// </summary>
+    /// <param name="targets">(label, asmPath) のリスト。例: [("main", "test.ASM"), ("overlay 0", "test._m0.ASM"), ...]</param>
+    public static PrelinkPlan Build(IEnumerable<(string Label, string AsmPath)> targets)
+    {
+        var plan = new PrelinkPlan();
+        foreach (var (label, asmPath) in targets)
+        {
+            var asmText = File.ReadAllText(asmPath);
+            plan.Targets.Add(new TargetInfo
+            {
+                Label = label,
+                AsmPath = asmPath,
+                Exports = AsmSectionParser.ExtractFuncNames(asmText, ExportsSectionHeaders),
+                UserFunctionImports = AsmSectionParser.ExtractExternNames(asmText, UserFunctionImportsSectionHeaders),
+                SharedImports = AsmSectionParser.ExtractExternNames(asmText, SharedImportsSectionHeaders),
+            });
+        }
+        return plan;
+    }
+
+    /// <summary>
+    /// Pass 1 用: 全 extern を $0000 EQU で埋めた dummy imports.asm を書き出す。
+    /// 命令長確定のため target の AILZ80ASM Pass 1 でアセンブルできる状態にする。
+    /// </summary>
+    public static void WriteDummyImports(TargetInfo target, string outputPath)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("; SLANG slangbuild — Pass 1 dummy imports (all $0000 for length determination)");
+        sb.AppendLine($"; source target: {Path.GetFileName(target.AsmPath)}");
+        sb.AppendLine();
+        var allExterns = target.UserFunctionImports.Concat(target.SharedImports)
+                              .Distinct(StringComparer.OrdinalIgnoreCase)
+                              .OrderBy(n => n, StringComparer.OrdinalIgnoreCase);
+        foreach (var name in allExterns)
+            sb.AppendLine($"{name} equ $0000");
+        File.WriteAllText(outputPath, sb.ToString());
+    }
+
+    /// <summary>
+    /// Pass 3 用: combined real imports.asm を書き出す。
+    ///   - User Function References → ExportedFunctionTable から実アドレス
+    ///   - Shared Imports → mainPass1Symbols (= main resident な実アドレス) から
+    ///
+    /// 戻り値: (出力 path, 未解決ラベル名のリスト)。未解決は warning 扱いで素通し
+    /// (AILZ80ASM 側で「未定義シンボル」エラーとして報告される設計)。
+    /// </summary>
+    public static (string OutputPath, List<string> Unresolved) WriteRealImports(
+        TargetInfo target,
+        ExportedFunctionTable exportedTable,
+        IReadOnlyDictionary<string, int> mainPass1Symbols,
+        string outputPath)
+    {
+        var unresolved = new List<string>();
+        var sb = new StringBuilder();
+        sb.AppendLine("; SLANG slangbuild — Pass 3 combined real imports");
+        sb.AppendLine($"; source target: {Path.GetFileName(target.AsmPath)}");
+        sb.AppendLine();
+
+        // 1) User Function References: target が呼ぶ他 target の関数を ExportedFunctionTable で解決
+        if (target.UserFunctionImports.Count > 0)
+        {
+            sb.AppendLine("; --- user function cross-references ---");
+            foreach (var name in target.UserFunctionImports)
+            {
+                var addr = exportedTable.Resolve(name);
+                if (addr.HasValue)
+                    sb.AppendLine($"{name} equ ${addr.Value:X4}");
+                else
+                    unresolved.Add(name);
+            }
+            sb.AppendLine();
+        }
+
+        // 2) Shared Imports: PR-B 経路 (main resident な runtime / global / string)
+        if (target.SharedImports.Count > 0)
+        {
+            sb.AppendLine("; --- shared runtime / globals / strings (from main) ---");
+            foreach (var name in target.SharedImports)
+            {
+                if (mainPass1Symbols.TryGetValue(name, out var addr))
+                    sb.AppendLine($"{name} equ ${addr:X4}");
+                else
+                    unresolved.Add(name);
+            }
+        }
+
+        File.WriteAllText(outputPath, sb.ToString());
+        return (outputPath, unresolved);
+    }
+}

--- a/src/SLANGCompiler.Build/ToolResolver.cs
+++ b/src/SLANGCompiler.Build/ToolResolver.cs
@@ -73,22 +73,25 @@ public class ToolResolver
     /// dev 環境想定: repo root を起点に slangc の publish 物を探す。
     /// <c>src/SLANGCompiler.CLI/bin/(Release|Debug)/net8.0/&lt;RID&gt;/publish/slangc(.exe)</c>
     /// 配布物の `<root>/bin/slangc` パターンには触れない (= 通常解決順 2 が拾う想定)。
+    ///
+    /// **RID 選択** (Codex 指摘): 全 RID 走査で更新時刻最新を選ぶと、複数 RID 用に
+    /// publish 物が並んでいる環境 (macOS で osx-arm64 + linux-x64 等) で OS の異なる
+    /// バイナリを拾って exec format error になる。現在 OS の RID 候補リストを
+    /// 順序付きで保持し、その範囲内でだけ「同一 RID で Release/Debug 両方ある場合は
+    /// 更新時刻最新」で絞る。
     /// </summary>
     private string? LocateDevPublishedSlangc(string name)
     {
         var binRoot = LocateRepoDir("src/SLANGCompiler.CLI/bin");
         if (binRoot == null) return null;
 
-        // Release/Debug × <RID>/publish を全部走査して最新を拾う
-        string? newest = null;
-        DateTime newestTime = DateTime.MinValue;
-        foreach (var config in new[] { "Release", "Debug" })
+        foreach (var rid in GetCurrentOsRidCandidates())
         {
-            var configDir = Path.Combine(binRoot, config, "net8.0");
-            if (!Directory.Exists(configDir)) continue;
-            foreach (var ridDir in Directory.GetDirectories(configDir))
+            string? newest = null;
+            DateTime newestTime = DateTime.MinValue;
+            foreach (var config in new[] { "Release", "Debug" })
             {
-                var candidate = Path.Combine(ridDir, "publish", name);
+                var candidate = Path.Combine(binRoot, config, "net8.0", rid, "publish", name);
                 if (!File.Exists(candidate)) continue;
                 var t = File.GetLastWriteTimeUtc(candidate);
                 if (t > newestTime)
@@ -97,8 +100,53 @@ public class ToolResolver
                     newestTime = t;
                 }
             }
+            if (newest != null) return newest;
         }
-        return newest;
+        return null;
+    }
+
+    /// <summary>
+    /// 現在 OS で実行可能な RID の候補リストを優先順で返す。
+    /// 1 番目は `OS-arch` の正確一致、2 番目以降は同 OS の他 arch (= Rosetta 等の
+    /// 互換実行を想定)。OS が違うものは含めない。
+    /// </summary>
+    private static IReadOnlyList<string> GetCurrentOsRidCandidates()
+    {
+        var archStr = RuntimeInformation.OSArchitecture switch
+        {
+            Architecture.X64   => "x64",
+            Architecture.Arm64 => "arm64",
+            Architecture.X86   => "x86",
+            var other          => other.ToString().ToLowerInvariant(),
+        };
+
+        string[] family;
+        string osPrefix;
+        if (OperatingSystem.IsMacOS())
+        {
+            osPrefix = "osx";
+            family = new[] { "osx-arm64", "osx-x64" };
+        }
+        else if (OperatingSystem.IsLinux())
+        {
+            osPrefix = "linux";
+            family = new[] { "linux-x64", "linux-arm64", "linux-musl-x64" };
+        }
+        else if (OperatingSystem.IsWindows())
+        {
+            osPrefix = "win";
+            family = new[] { "win-x64", "win-arm64", "win-x86" };
+        }
+        else
+        {
+            return Array.Empty<string>();
+        }
+
+        var primary = $"{osPrefix}-{archStr}";
+        var ordered = new List<string> { primary };
+        foreach (var rid in family)
+            if (rid != primary) ordered.Add(rid);
+        return ordered;
     }
 
     /// <summary>repo root を辿って指定相対ディレクトリを探す (LocateRepoFile の dir 版)</summary>

--- a/src/SLANGCompiler.Build/ToolResolver.cs
+++ b/src/SLANGCompiler.Build/ToolResolver.cs
@@ -27,16 +27,35 @@ public class ToolResolver
     /// 解決順:
     /// 1) cliOverride (--slangc 引数)
     /// 2) bundled: {baseDir}/slangc(.exe), {baseDir}/bin/slangc(.exe)
-    /// 3) PATH 上の slangc
-    /// 4) dev fallback: dotnet (= caller が `dotnet run --project ...` を組み立てる)
+    /// 3) dev publish: repo root を辿って
+    ///    src/SLANGCompiler.CLI/bin/(Release|Debug)/net8.0/&lt;RID&gt;/publish/slangc(.exe)
+    ///    が見つかればそれ (= dev 環境で publish 済みの最新 slangc を PATH 上の
+    ///    旧版より優先)
+    /// 4) PATH 上の slangc (= 配布版を OS にインストールしたケース)
+    /// 5) dev fallback: dotnet (= caller が `dotnet run --project ...` を組み立てる)
     /// </summary>
     public ResolvedTool ResolveSlangc(string? cliOverride)
     {
         var name = $"slangc{ExeSuffix}";
-        var path = ResolveExecutable(cliOverride, name, includeBundledTools: false);
-        if (path != null) return new ResolvedTool(path, ResolutionKind.DirectExe);
 
-        // dev fallback: dotnet run --project <repo>/src/SLANGCompiler.CLI/...
+        // 1) cliOverride / 2) bundled (PATH 検索なしバージョン)
+        if (!string.IsNullOrEmpty(cliOverride) && File.Exists(cliOverride))
+            return new ResolvedTool(cliOverride, ResolutionKind.DirectExe);
+        var direct = Path.Combine(_baseDir, name);
+        if (File.Exists(direct)) return new ResolvedTool(direct, ResolutionKind.DirectExe);
+        var binDir = Path.Combine(_baseDir, "bin", name);
+        if (File.Exists(binDir)) return new ResolvedTool(binDir, ResolutionKind.DirectExe);
+
+        // 3) dev publish 物 (= dev 環境で `dotnet publish` 済みの最新 slangc)
+        //    PATH 上の旧版に上書きされないよう、PATH 検索より前に挿入する
+        var devPublish = LocateDevPublishedSlangc(name);
+        if (devPublish != null) return new ResolvedTool(devPublish, ResolutionKind.DirectExe);
+
+        // 4) PATH
+        var onPath = FindOnPath(name);
+        if (onPath != null) return new ResolvedTool(onPath, ResolutionKind.DirectExe);
+
+        // 5) dev fallback: dotnet run --project <repo>/src/SLANGCompiler.CLI/...
         var dotnet = FindOnPath($"dotnet{ExeSuffix}");
         if (dotnet != null)
         {
@@ -46,8 +65,52 @@ public class ToolResolver
         }
 
         throw new FileNotFoundException(
-            "slangc not found. Tried: --slangc, bundled bin, PATH, and dev `dotnet run` fallback. "
+            "slangc not found. Tried: --slangc, bundled bin, dev publish, PATH, and dev `dotnet run` fallback. "
             + "Specify --slangc <path> explicitly.");
+    }
+
+    /// <summary>
+    /// dev 環境想定: repo root を起点に slangc の publish 物を探す。
+    /// <c>src/SLANGCompiler.CLI/bin/(Release|Debug)/net8.0/&lt;RID&gt;/publish/slangc(.exe)</c>
+    /// 配布物の `<root>/bin/slangc` パターンには触れない (= 通常解決順 2 が拾う想定)。
+    /// </summary>
+    private string? LocateDevPublishedSlangc(string name)
+    {
+        var binRoot = LocateRepoDir("src/SLANGCompiler.CLI/bin");
+        if (binRoot == null) return null;
+
+        // Release/Debug × <RID>/publish を全部走査して最新を拾う
+        string? newest = null;
+        DateTime newestTime = DateTime.MinValue;
+        foreach (var config in new[] { "Release", "Debug" })
+        {
+            var configDir = Path.Combine(binRoot, config, "net8.0");
+            if (!Directory.Exists(configDir)) continue;
+            foreach (var ridDir in Directory.GetDirectories(configDir))
+            {
+                var candidate = Path.Combine(ridDir, "publish", name);
+                if (!File.Exists(candidate)) continue;
+                var t = File.GetLastWriteTimeUtc(candidate);
+                if (t > newestTime)
+                {
+                    newest = candidate;
+                    newestTime = t;
+                }
+            }
+        }
+        return newest;
+    }
+
+    /// <summary>repo root を辿って指定相対ディレクトリを探す (LocateRepoFile の dir 版)</summary>
+    private string? LocateRepoDir(string relPath)
+    {
+        var dir = new DirectoryInfo(_baseDir);
+        for (int i = 0; i < 8 && dir != null; i++, dir = dir.Parent)
+        {
+            var candidate = Path.Combine(dir.FullName, relPath);
+            if (Directory.Exists(candidate)) return candidate;
+        }
+        return null;
     }
 
     /// <summary>

--- a/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
+++ b/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
@@ -36,6 +36,12 @@ public class CodeGenerator
     /// CLI 側 (.inc 生成等) で shared runtime 関数のラベルを引くために露出。null の場合は
     /// runtime manager がない (= test 単独 Generate 等)。</summary>
     public RuntimePlan? RuntimePlan => _runtimePlan;
+
+    // PrepareRuntimePlan の dry-run で集めた per-target の called functions。
+    // PR-B2 で main / overlay それぞれに Exports / Imports セクションを emit するときに
+    // 参照する (= ユーザー関数の cross-reference 判定)。null は未収集状態。
+    private HashSet<string>? _mainCalledFunctions;
+    private Dictionary<int, HashSet<string>>? _overlayCalledFunctions;
     private bool IsCodeReadonly => _envConfig?.CodeReadonly == true;
 
     public CodeGenerator(IrModule module, Runtime.RuntimeManager? runtimeManager = null,
@@ -118,6 +124,11 @@ public class CodeGenerator
 
         _runtimePlan = RuntimePlanner.Build(mainCalled, _module.Overlays,
             overlayCalled, _runtimeManager, inlineNames);
+
+        // PR-B2: per-target called functions を保持し、Exports/Imports セクション emit
+        // で再利用する
+        _mainCalledFunctions = mainCalled;
+        _overlayCalledFunctions = overlayCalled;
     }
 
     private string GenerateOverlay(OverlayModule overlay)
@@ -208,6 +219,9 @@ public class CodeGenerator
             }
             _e.Raw($"__WORKEND_M{overlay.Index}__ EQU ({workLabel} + {offset})");
         }
+
+        // PR-B2: User function cross-reference セクション (Exports + Imports)
+        EmitFunctionCrossRefs(overlay.Index);
 
         // 共有 runtime 関数: shared promoted な main resident 関数を overlay 側から
         // EXTERN 参照する。AILZ80ASM には EXTERN がないため、現状はコメント形式で出力し、
@@ -467,6 +481,11 @@ public class CodeGenerator
             }
         }
 
+        // PR-B2: User function cross-reference セクション (Exports + Imports)
+        // slangbuild prelink モードがこのセクションを読んで全 target 間の関数
+        // アドレス解決を行う。AILZ80ASM 的にはコメントなので影響なし。
+        EmitFunctionCrossRefs(overlayIndex: null);
+
         // プログラム末尾マーカー
         _e.Label("SLANG_PROG_END");
 
@@ -642,6 +661,85 @@ public class CodeGenerator
         if (_runtimePlan != null)
             return _runtimePlan.GetMainInitFunctions().Any();
         return _runtimeManager.GetUsedFunctions().Any(f => !string.IsNullOrEmpty(f.InitCode));
+    }
+
+    /// <summary>
+    /// PR-B2: User function cross-reference セクションを emit する。
+    ///
+    /// - Exports セクション: 自分が定義する SLANG 関数を `; FUNC <name>` 形式で列挙
+    ///   (driver は ここから export set を抽出して全 sym union 衝突を回避)
+    /// - Imports セクション: 自分が呼ぶ他 target の SLANG 関数を `; EXTERN <name>` 形式
+    ///   (driver はここを起点に prelink Pass 1/3 で extern を $0000 → 実アドレス
+    ///   に解決する)
+    ///
+    /// runtime 関数 / local label / private symbol は対象外 (= driver の export
+    /// 集合に入らないので名前衝突も起きない)。
+    /// </summary>
+    /// <param name="overlayIndex">main を emit 中なら null、overlay i を emit 中なら i</param>
+    private void EmitFunctionCrossRefs(int? overlayIndex)
+    {
+        // 自分が定義する関数 + 自分が呼んだ関数 (per-target) を取り出す
+        IEnumerable<string> myFunctions;
+        HashSet<string>? myCalled;
+        if (overlayIndex.HasValue)
+        {
+            var overlay = _module.Overlays[overlayIndex.Value];
+            myFunctions = overlay.Functions.Select(f => f.Name);
+            myCalled = _overlayCalledFunctions != null
+                && _overlayCalledFunctions.TryGetValue(overlayIndex.Value, out var oc)
+                ? oc : null;
+        }
+        else
+        {
+            myFunctions = _module.Functions.Select(f => f.Name);
+            myCalled = _mainCalledFunctions;
+        }
+
+        // === Exported User Functions === (常に出す、空でも driver が認識できるよう)
+        var exports = myFunctions.OrderBy(n => n, StringComparer.OrdinalIgnoreCase).ToList();
+        if (exports.Count > 0)
+        {
+            _e.Blank();
+            _e.Comment("=== Exported User Functions ===");
+            foreach (var name in exports)
+                _e.Raw($"; FUNC {name}");
+        }
+
+        // 「他 target の関数 → どこに定義されているか」マップを作る (Imports 用)
+        if (myCalled == null) return;
+        var otherFunctionsByLocation = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        if (overlayIndex.HasValue)
+        {
+            // overlay の場合: main + 他 overlay が定義する関数を imports 候補に
+            foreach (var f in _module.Functions)
+                otherFunctionsByLocation[f.Name] = "main";
+            foreach (var ov in _module.Overlays)
+            {
+                if (ov.Index == overlayIndex.Value) continue;
+                foreach (var f in ov.Functions)
+                    otherFunctionsByLocation[f.Name] = $"overlay {ov.Index}";
+            }
+        }
+        else
+        {
+            // main の場合: 全 overlay が定義する関数を imports 候補に
+            foreach (var ov in _module.Overlays)
+                foreach (var f in ov.Functions)
+                    otherFunctionsByLocation[f.Name] = $"overlay {ov.Index}";
+        }
+
+        // === User Function References ===
+        var imports = myCalled
+            .Where(name => otherFunctionsByLocation.ContainsKey(name))
+            .OrderBy(n => n, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (imports.Count > 0)
+        {
+            _e.Blank();
+            _e.Comment("=== User Function References ===");
+            foreach (var name in imports)
+                _e.Raw($"; EXTERN {name}  ; defined in {otherFunctionsByLocation[name]}");
+        }
     }
 
     // システムレジスタワーク変数の定義（旧実装準拠の順序）

--- a/src/SLANGCompiler.Core/Lexer/Preprocessor.cs
+++ b/src/SLANGCompiler.Core/Lexer/Preprocessor.cs
@@ -47,10 +47,16 @@ public class Preprocessor
                     break;
 
                 case TokenKind.PreprocElse:
-                case TokenKind.PreprocEnd:
-                    // Stray #ELSE/#END outside #IF block - skip
+                    // Stray #ELSE outside #IF block - skip
                     i++;
                     break;
+
+                // PreprocEnd は Parser (ParseModuleBlock) が `#END` として消費する
+                // ため、ここでは skip せず result に流す。`#IF...#END` ブロック内の
+                // `#END` は ProcessIf 内で消費済みなので、ここに到達するのは
+                // `#MODULE...#END` の終端等の trail-level な `#END` のみ。
+                // (PR-B2 で発見した PR-A バグ修正: 従来は `#END` も skip され、
+                //  ParseModuleBlock の `#END` 検出が機能しなかった)
 
                 case TokenKind.Const:
                     // CONST宣言からプリプロセッサ用の定数値を抽出

--- a/src/SLANGCompiler.Core/Parser/Parser.cs
+++ b/src/SLANGCompiler.Core/Parser/Parser.cs
@@ -186,6 +186,18 @@ public class Parser
                 Advance();
                 break;
             }
+            // #MODULE は入れ子不可。連続する `#MODULE $X ... #END #MODULE $Y ...` は
+            // 外側 ParseTopLevel で個別の overlay として扱われるべきだが、もし `#END` が
+            // 不足して次の `#MODULE` が現れた場合、ParseTopLevel の `case TokenKind.Module`
+            // が再帰的に ParseModuleBlock を呼んでネスト ModuleBlock を作ってしまう。
+            // 明示エラーで止める。
+            if (Check(TokenKind.Module))
+            {
+                _diagnostics.Error(
+                    "#MODULE cannot be nested. Insert #END to close the outer #MODULE before starting a new one.",
+                    Current.Span);
+                break;
+            }
             if (Match(TokenKind.Semicolon)) continue;
             int errorsBefore = _diagnostics.ErrorCount;
             int before = _pos;

--- a/tests/SLANGCompiler.Tests/AsmSectionParserTests.cs
+++ b/tests/SLANGCompiler.Tests/AsmSectionParserTests.cs
@@ -1,0 +1,76 @@
+using Xunit;
+using SLANGCompiler.Build;
+
+namespace SLANGCompiler.Tests;
+
+/// <summary>
+/// PR-B2: ASM ファイルの固定セクション内のラベル抽出を検証。
+/// </summary>
+public class AsmSectionParserTests
+{
+    private static readonly string[] ExportsHeaders =
+        { "; === Exported User Functions ===" };
+    private static readonly string[] ImportsHeaders =
+        { "; === User Function References ===" };
+
+    [Fact]
+    public void ExtractFuncNames_TargetSectionOnly()
+    {
+        var asm = @"
+; === Some Other Section ===
+; FUNC IGNORED1
+; FUNC IGNORED2
+
+; === Exported User Functions ===
+; FUNC MAIN
+; FUNC HELPER
+
+; === Some Trailing Section ===
+; FUNC IGNORED3
+";
+        var names = AsmSectionParser.ExtractFuncNames(asm, ExportsHeaders);
+        Assert.Equal(new[] { "MAIN", "HELPER" }, names);
+    }
+
+    [Fact]
+    public void ExtractExternNames_TargetSectionOnly()
+    {
+        var asm = @"
+; === Some Other Section ===
+; EXTERN IGNORED
+
+; === User Function References ===
+; EXTERN MYSUB    ; defined in overlay 0
+; EXTERN HELPER   ; defined in main
+
+; === Tail ===
+; EXTERN ALSO_IGNORED
+";
+        var names = AsmSectionParser.ExtractExternNames(asm, ImportsHeaders);
+        Assert.Equal(new[] { "MYSUB", "HELPER" }, names);
+    }
+
+    [Fact]
+    public void Deduplicates_PreservesFirstOrder()
+    {
+        var asm = @"
+; === Exported User Functions ===
+; FUNC A
+; FUNC B
+; FUNC A
+";
+        var names = AsmSectionParser.ExtractFuncNames(asm, ExportsHeaders);
+        Assert.Equal(new[] { "A", "B" }, names);
+    }
+
+    [Fact]
+    public void NoMatchingSection_ReturnsEmpty()
+    {
+        var asm = @"
+; === Wrong Header ===
+; FUNC FOO
+";
+        var names = AsmSectionParser.ExtractFuncNames(asm, ExportsHeaders);
+        Assert.Empty(names);
+    }
+}

--- a/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
@@ -308,6 +308,127 @@ MYSUB() BEGIN BEEP(); END;
         Assert.Equal(beepAddr, callTarget);
     }
 
+    // ---- PR-B2 prelink E2E (関数 cross-reference) ----
+
+    /// <summary>bin 内に「CALL <expectedAddr>」(`CD lo hi`) バイト列があるかを判定。
+    /// 起動コード等の他の CALL に紛れずに「特定のアドレスを指す CALL」の存在だけを
+    /// 確認する用途。</summary>
+    private static bool BinaryContainsCall(byte[] bin, int expectedAddr)
+    {
+        byte lo = (byte)(expectedAddr & 0xFF);
+        byte hi = (byte)((expectedAddr >> 8) & 0xFF);
+        for (int i = 0; i < bin.Length - 2; i++)
+        {
+            if (bin[i] == 0xCD && bin[i + 1] == lo && bin[i + 2] == hi) return true;
+        }
+        return false;
+    }
+
+    [Fact]
+    public void Prelink_MainCallsOverlayFunction_ResolvesToOverlayAddress()
+    {
+        // main から overlay 内 SLANG 関数 MYSUB を呼ぶ → main.bin の CALL が
+        // overlay の MYSUB アドレス ($3000 起点) を指す
+        var slPath = Path.Combine(_tempDir, "m2o.SL");
+        File.WriteAllText(slPath, @"
+MAIN() BEGIN MYSUB(); END;
+#MODULE $3000
+MYSUB() BEGIN END;
+#END
+");
+        var (code, _, stderr) = RunSlangbuild(slPath, "--keep-asm");
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+
+        // imports.asm が prelink モードで生成されている
+        var imports = File.ReadAllText(Path.Combine(_tempDir, "m2o.imports.asm"));
+        Assert.Contains("MYSUB equ $3000", imports);
+
+        // main.bin に「CALL $3000」(MYSUB を呼ぶ命令) が含まれる
+        var mainBin = File.ReadAllBytes(Path.Combine(_tempDir, "m2o.bin"));
+        Assert.True(BinaryContainsCall(mainBin, 0x3000),
+            "main.bin should contain CALL $3000 (= MYSUB in overlay)");
+    }
+
+    [Fact]
+    public void Prelink_OverlayCallsMainFunction_ResolvesToMainAddress()
+    {
+        // overlay から main 内 SLANG 関数 HELPER を呼ぶ → overlay.bin の CALL が
+        // main の HELPER アドレスを指す
+        var slPath = Path.Combine(_tempDir, "o2m.SL");
+        File.WriteAllText(slPath, @"
+HELPER() BEGIN END;
+MAIN() BEGIN HELPER(); END;
+#MODULE $3000
+MYSUB() BEGIN HELPER(); END;
+#END
+");
+        var (code, _, stderr) = RunSlangbuild(slPath, "--keep-asm");
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+
+        // overlay の imports.asm に HELPER の本物アドレスが入る
+        var ovImports = File.ReadAllText(Path.Combine(_tempDir, "o2m._m0.imports.asm"));
+        var match = System.Text.RegularExpressions.Regex.Match(ovImports,
+            @"HELPER\s+equ\s+\$([0-9A-Fa-f]+)");
+        Assert.True(match.Success);
+        var helperAddr = Convert.ToInt32(match.Groups[1].Value, 16);
+
+        // overlay.bin に「CALL <helperAddr>」(main 内 HELPER を呼ぶ命令) が含まれる
+        var ovBin = File.ReadAllBytes(Path.Combine(_tempDir, "o2m._m0.bin"));
+        Assert.True(BinaryContainsCall(ovBin, helperAddr),
+            $"overlay.bin should contain CALL ${helperAddr:X4} (= HELPER in main)");
+    }
+
+    [Fact]
+    public void Prelink_OverlayCallsOtherOverlay_ResolvesAcrossOverlays()
+    {
+        // overlay 0 から overlay 1 の関数を呼ぶ → overlay 0.bin の CALL が
+        // overlay 1 の本物アドレス ($4000 起点) を指す
+        var slPath = Path.Combine(_tempDir, "o2o.SL");
+        File.WriteAllText(slPath, @"
+MAIN() BEGIN END;
+#MODULE $3000
+M0FUNC() BEGIN M1FUNC(); END;
+#END
+#MODULE $4000
+M1FUNC() BEGIN END;
+#END
+");
+        var (code, _, stderr) = RunSlangbuild(slPath, "--keep-asm");
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+
+        // overlay 0 の imports に M1FUNC の本物アドレスが入る
+        var imports = File.ReadAllText(Path.Combine(_tempDir, "o2o._m0.imports.asm"));
+        Assert.Contains("M1FUNC equ $4000", imports);
+
+        // overlay 0 .bin に「CALL $4000」(M1FUNC を呼ぶ命令) が含まれる
+        var ov0Bin = File.ReadAllBytes(Path.Combine(_tempDir, "o2o._m0.bin"));
+        Assert.True(BinaryContainsCall(ov0Bin, 0x4000),
+            "overlay 0.bin should contain CALL $4000 (= M1FUNC in overlay 1)");
+    }
+
+    [Fact]
+    public void Prelink_NotTriggered_WhenNoCrossRef()
+    {
+        // overlay は使うが cross-ref 無し (= overlay 内関数を main から呼ばない、
+        // overlay → main も呼ばない) → 単段モード (PR-B 既存パス) で動く。
+        // dummy.imports.asm が出ない (= prelink Pass 1 が走らなかった証拠)。
+        var slPath = Path.Combine(_tempDir, "trivial.SL");
+        File.WriteAllText(slPath, @"
+MAIN() BEGIN END;
+#MODULE $3000
+MYSUB() BEGIN END;
+#END
+");
+        var (code, _, stderr) = RunSlangbuild(slPath, "--keep-asm");
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+
+        // prelink モードなら <prefix>.dummy.imports.asm が生成される
+        Assert.False(File.Exists(Path.Combine(_tempDir, "trivial.dummy.imports.asm")),
+            "Single-stage mode expected; dummy imports should not be produced");
+        Assert.False(File.Exists(Path.Combine(_tempDir, "trivial.pass1.sym")),
+            "Single-stage mode expected; pass1 sym should not be produced");
+    }
+
     [Fact]
     public void MissingInputFile_ReportsError()
     {

--- a/tests/SLANGCompiler.Tests/ExportedFunctionTableTests.cs
+++ b/tests/SLANGCompiler.Tests/ExportedFunctionTableTests.cs
@@ -1,0 +1,95 @@
+using Xunit;
+using SLANGCompiler.Build;
+
+namespace SLANGCompiler.Tests;
+
+/// <summary>
+/// PR-B2 ExportedFunctionTable の検証。
+/// 全 sym union ではなく、各 target が export 宣言した関数だけを採用する
+/// (= runtime 関数等の同名重複が衝突しない) ことを確認。
+/// </summary>
+public class ExportedFunctionTableTests
+{
+    [Fact]
+    public void Add_ExportedNamesOnlyAreIncluded()
+    {
+        var table = new ExportedFunctionTable();
+        // main は MAIN と HELPER を export 宣言。pass1.sym には他にも runtime 関数の
+        // ラベルがあるが、export set に無いので無視される。
+        var pass1 = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MAIN"]    = 0x012C,
+            ["HELPER"]  = 0x0150,
+            ["MPRNT"]   = 0x0200,  // runtime 関数 = export 対象外
+            ["WORK10"]  = 0x0300,  // local label = export 対象外
+        };
+        table.Add("main", new[] { "MAIN", "HELPER" }, pass1);
+
+        Assert.Equal(0x012C, table.Resolve("MAIN"));
+        Assert.Equal(0x0150, table.Resolve("HELPER"));
+        Assert.Null(table.Resolve("MPRNT"));   // export されていないので無視
+        Assert.Null(table.Resolve("WORK10"));
+    }
+
+    [Fact]
+    public void Add_DifferentTargetsWithSameRuntimeLabel_NoConflict()
+    {
+        // runtime 関数 (例: MPRNT) は main と overlay 両方の pass1.sym に出るが、
+        // どちらの target も export 宣言していないので衝突しない。
+        var table = new ExportedFunctionTable();
+        var mainPass1 = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MAIN"]  = 0x012C,
+            ["MPRNT"] = 0x0200,
+        };
+        var overlayPass1 = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MYSUB"] = 0x3000,
+            ["MPRNT"] = 0x3100,  // overlay 側にも MPRNT が複製されている (異アドレス)
+        };
+        table.Add("main", new[] { "MAIN" }, mainPass1);
+        table.Add("overlay 0", new[] { "MYSUB" }, overlayPass1); // MPRNT は export 宣言なし
+
+        Assert.Equal(0x012C, table.Resolve("MAIN"));
+        Assert.Equal(0x3000, table.Resolve("MYSUB"));
+        Assert.Null(table.Resolve("MPRNT")); // export されていないので衝突しない
+    }
+
+    [Fact]
+    public void Add_DuplicateExportWithDifferentAddress_Throws()
+    {
+        // 異 target に同名 export がある (= SLANG semantic 違反、本来あり得ない)。
+        // driver 側で防御的にエラー化することを確認。
+        var table = new ExportedFunctionTable();
+        var mainPass1 = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["DUP"] = 0x0100,
+        };
+        var overlayPass1 = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["DUP"] = 0x3000,
+        };
+        table.Add("main", new[] { "DUP" }, mainPass1);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            table.Add("overlay 0", new[] { "DUP" }, overlayPass1));
+        Assert.Contains("DUP", ex.Message);
+        Assert.Contains("duplicate", ex.Message);
+    }
+
+    [Fact]
+    public void Add_MissingPass1Symbol_SilentlySkips()
+    {
+        // export 宣言があるが pass1.sym に対応ラベル無し (= compiler バグ系)
+        // → スキップ (driver 上位の警告に任せる)
+        var table = new ExportedFunctionTable();
+        var pass1 = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["FOO"] = 0x0100,
+        };
+        table.Add("main", new[] { "FOO", "MISSING" }, pass1);
+
+        Assert.Equal(0x0100, table.Resolve("FOO"));
+        Assert.Null(table.Resolve("MISSING"));
+    }
+}

--- a/tests/SLANGCompiler.Tests/PrelinkPlanTests.cs
+++ b/tests/SLANGCompiler.Tests/PrelinkPlanTests.cs
@@ -1,0 +1,139 @@
+using Xunit;
+using SLANGCompiler.Build;
+
+namespace SLANGCompiler.Tests;
+
+/// <summary>
+/// PR-B2 PrelinkPlan の検証 (cross-ref 集計、IsTrivial 判定、imports 生成)。
+/// </summary>
+public class PrelinkPlanTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public PrelinkPlanTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"slang_pp_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private string WriteAsm(string fileName, string content)
+    {
+        var path = Path.Combine(_tempDir, fileName);
+        File.WriteAllText(path, content);
+        return path;
+    }
+
+    [Fact]
+    public void Build_NoCrossRef_IsTrivial()
+    {
+        // overlay の Imports セクションが無い (or User Function References が空)
+        var mainAsm = WriteAsm("main.ASM", @"
+; === Exported User Functions ===
+; FUNC MAIN
+
+; === Shared Symbols (from main) ===
+; EXTERN _V_X
+");
+        var plan = PrelinkPlan.Build(new[] { ("main", mainAsm) });
+        Assert.True(plan.IsTrivial);
+        Assert.Single(plan.Targets);
+        Assert.Empty(plan.Targets[0].UserFunctionImports);
+        Assert.Single(plan.Targets[0].SharedImports);
+    }
+
+    [Fact]
+    public void Build_WithUserFunctionImports_NotTrivial()
+    {
+        var mainAsm = WriteAsm("main.ASM", @"
+; === Exported User Functions ===
+; FUNC MAIN
+
+; === User Function References ===
+; EXTERN MYSUB    ; defined in overlay 0
+");
+        var overlayAsm = WriteAsm("main._m0.ASM", @"
+; === Exported User Functions ===
+; FUNC MYSUB
+");
+        var plan = PrelinkPlan.Build(new[]
+        {
+            ("main", mainAsm),
+            ("overlay 0", overlayAsm),
+        });
+        Assert.False(plan.IsTrivial);
+        Assert.Equal(2, plan.Targets.Count);
+        Assert.Contains("MYSUB", plan.Targets[0].UserFunctionImports);
+    }
+
+    [Fact]
+    public void WriteDummyImports_AllExternsAt0000()
+    {
+        var target = new PrelinkPlan.TargetInfo
+        {
+            Label = "test",
+            AsmPath = Path.Combine(_tempDir, "test.ASM"),
+            UserFunctionImports = new List<string> { "MYSUB", "HELPER" },
+            SharedImports = new List<string> { "MPRNT", "_V_X" },
+        };
+        var dummyPath = Path.Combine(_tempDir, "test.dummy.imports.asm");
+        PrelinkPlan.WriteDummyImports(target, dummyPath);
+
+        var content = File.ReadAllText(dummyPath);
+        Assert.Contains("MYSUB equ $0000", content);
+        Assert.Contains("HELPER equ $0000", content);
+        Assert.Contains("MPRNT equ $0000", content);
+        Assert.Contains("_V_X equ $0000", content);
+    }
+
+    [Fact]
+    public void WriteRealImports_ResolvesFromExportTableAndMainSym()
+    {
+        var target = new PrelinkPlan.TargetInfo
+        {
+            Label = "main",
+            AsmPath = Path.Combine(_tempDir, "main.ASM"),
+            UserFunctionImports = new List<string> { "MYSUB" },
+            SharedImports = new List<string> { "MPRNT" },
+        };
+        var exported = new ExportedFunctionTable();
+        exported.Add("overlay 0", new[] { "MYSUB" },
+            new Dictionary<string, int> { ["MYSUB"] = 0x3000 });
+
+        var mainPass1Sym = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["MPRNT"] = 0x0150,
+        };
+
+        var realPath = Path.Combine(_tempDir, "real.imports.asm");
+        var (_, unresolved) = PrelinkPlan.WriteRealImports(target, exported, mainPass1Sym, realPath);
+
+        Assert.Empty(unresolved);
+        var content = File.ReadAllText(realPath);
+        Assert.Contains("MYSUB equ $3000", content);
+        Assert.Contains("MPRNT equ $0150", content);
+    }
+
+    [Fact]
+    public void WriteRealImports_UnresolvedNamesReported()
+    {
+        var target = new PrelinkPlan.TargetInfo
+        {
+            Label = "main",
+            AsmPath = Path.Combine(_tempDir, "main.ASM"),
+            UserFunctionImports = new List<string> { "MISSING_FUNC" },
+            SharedImports = new List<string> { "MISSING_SYM" },
+        };
+        var exported = new ExportedFunctionTable();
+        var realPath = Path.Combine(_tempDir, "real.imports.asm");
+        var (_, unresolved) = PrelinkPlan.WriteRealImports(target, exported,
+            new Dictionary<string, int>(), realPath);
+
+        Assert.Contains("MISSING_FUNC", unresolved);
+        Assert.Contains("MISSING_SYM", unresolved);
+    }
+}


### PR DESCRIPTION
**Stacked on top of #144 (PR-B)**. PR-A → PR-B → PR-B2 → PR-C の順次マージで main に取り込む想定。

## Summary

PR-B (#144) の二段アセンブル機構を一般化し、main / overlay 間で **任意の SLANG 関数の相互呼び出し** を実バイナリレベルで解決できるようにする。

現状 (PR-B まで): \`CALL MYSUB\` (overlay 内関数を main から呼ぶ) は main ASM に修飾なしで出るが、main 単独アセンブル時に未定義シンボルで AILZ80ASM が止まる。
PR-B2 後: prelink 二段アセンブルで main / overlay の Exports と Imports を突き合わせ、**main → overlay / overlay → main / overlay → overlay** すべてのケースで実バイナリの CALL アドレスが正しく解決される。

## Scope

### サポート (関数シンボルのみ)
- main → overlay function
- overlay → overlay function
- overlay → main function

### サポート外 (今回は意図的に対応しない)
- overlay private 変数への相互参照
- overlay work / data の cross-reference
- 呼び先 overlay のロード状態検証
- swap タイミングの安全保証

### 仕様 (= ユーザー責任)
- 解決するのは **アドレスだけ**
- 呼び先 overlay が実行時にロードされている保証は driver / runtime には無い
- 同一 ORG を共有する overlay 間 call は未定義動作になりうる
- swap 制御 / 呼び出し可否はすべて **ユーザー責任** (低レベル言語の責務分担)

## Architecture

\`\`\`
[slangc]
  各 ASM に 2 セクションを出力 (コメント、AILZ80ASM 影響なし)
    ; === Exported User Functions ===     ← 自分が定義する関数 (FUNC <name>)
    ; === User Function References ===    ← 自分が呼ぶ他ファイル関数 (EXTERN <name>)

[slangbuild]
  cross-reference 検出時に prelink モードへ自動切替 (なければ PR-B 単段):

  Pass 1: 各 target に dummy imports (全 extern を $0000 EQU) でアセンブル
          → 各 target.pass1.sym 取得 (= 自身の定義ラベルのアドレス確定)
  Pass 2: 全 target の Exports セクションに列挙された関数だけを拾い、
          ExportedFunctionTable を構築 (= runtime 関数等の sym 衝突を回避)
  Pass 3: combined imports.asm (User Function は ExportedFunctionTable / 
          Shared 系は main.pass1.sym から解決) で本番アセンブル
\`\`\`

\`-nsa\` (no super-assemble) は **prelink Pass 1/3 のみ** 付与し、Pass 1 と Pass 3 で同じ target 内のラベルアドレスが一致することを保証 (PR-B 既存単段フローには付けない)。

## Codex 指摘の反映 (本 PR 内で対応済み)

- **(高) Pass 1/3 の対象**: user function だけでなく PR-B 既存の Shared Runtime References / Shared Symbols / String references も含めた **全 extern** を dummy/real imports の対象に
- **(高) sym union 衝突**: 全 .sym union ではなく、各 target の Exports セクションに宣言された関数だけを採用 (runtime 関数 MPRNT 等は target ごとに複製されるが対象外なので衝突しない)
- **(中) combined imports**: Pass 3 は driver が target ごとに 1 ファイル \`<T>.imports.asm\` を生成 (多入力 / 順序依存の複雑性を排除)
- **(中) -nsa 範囲**: prelink モード時のみ付与、PR-B 既存単段フローは挙動不変

## PR-A バグ 2 件を本 PR 内で同時修正

実装中に PR-A (#143) のバグを 2 件発見:

1. **Preprocessor が `#END` を skip**: `#IF` 関連の stray skip ロジックが `#MODULE...#END` の `#END` まで巻き込んで Parser に届けていなかった。結果として複数 `#MODULE` を書くと 2 つ目以降がネスト ModuleBlock として 1 つ目の defs に入り込み、全 overlay が \`Index=0\` で同名ファイルに上書きされていた (= 既存 PR-A は **複数 #MODULE を扱えていなかった**)
2. **`#MODULE` ネスト禁止**: ParseModuleBlock 内で `#MODULE` トークン検出時に明示エラー化 (= `#END` 不足の早期検出)

## Changes (5 commits)

| commit | 内容 |
|---|---|
| 1 (compiler) | Exports/Imports セクション + Preprocessor #END 修正 + #MODULE ネスト禁止 |
| 2 (driver) | AsmSectionParser + ExportedFunctionTable + AssemblerRunner -nsa |
| 3 (driver) | PrelinkPlan + Driver の prelink モード分岐 |
| 4 (tests) | unit (AsmSectionParser 4 / ExportedFunctionTable 4 / PrelinkPlan 5) + E2E (4 件 prelink + 既存) |
| 5 (docs) | docs/SLANG-spec.md + CHANGELOG.md |

## Test plan
- [x] **190/190 全合格** (\`dotnet test\`、既存 173 + PR-B2 新規 17)
- [x] main → overlay / overlay → overlay / overlay → main の 3 経路を E2E でバイナリ検証 (CALL アドレスが本物アドレスと一致)
- [x] cross-ref が無いケースは PR-B の単段フローに自動 fallback (\`Prelink_NotTriggered_WhenNoCrossRef\`)
- [x] 複数 \`#MODULE\` (2 つ以上) が個別 overlay として認識される (PR-A バグ修正の検証は手動スモーク + 既存 PR-A テストの回帰維持)
- [x] \`-nsa\` で実 SLANG 出力 ASM (FMANDEL/MANDEL/MAGICSMPL) が問題なくアセンブルできる (Phase 0 スパイクで確認)

## Known limitations (PR-C へ)

- 既存 \`runtime/lsx*.asm\` 等への \`@resident shared\` 付与は本 PR 範囲外。これと組み合わせて初めて runtime 共有のメモリ節約効果が出る
- \`@works WORK10\` 重複問題 (cpm 環境の P10 関数、Issue #145) は別途 fix が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)