### PR TITLE
PR-C2: 他 10 env の runtime に @resident 付与 (横展開)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased (v0.23.0 候補)
 
+- 残り 10 環境 (msxlsx / msx2 / msxrom / sos / sosx1 / pc80mk2 / pc80mk2x / pc88mk2sr / vgs0 / zxn) の runtime にも `; @resident shared|local` を付与 (PR-C2) — PR-C1 の手順を機械的に横展開
+  - 対象 30 ファイル / 527 関数の追加付与 (env ごとに 1 commit)
+  - 真の self-mod として `local` 化した関数 (PR-C2 で新規):
+    - `libsos_print.PRMODE` / `libpc80mk2xbios_print.PRMODE` (PRT+1 の operand patch)
+    - `libp88_base.PSET` (PSETADR / PSETCOLOR の operand patch)
+    - 各 base ファイルの `SLANGINIT` (8 件、main inline 専用)
+  - **全 env 累計**: shared 773 関数 / local 14 関数 (10 base SLANGINIT + M8ALOAD + 3 PRMODE/PSET)
+  - smoke 検証 (env ごと): `slangc -E <env> examples/<sample>.SL` で SLANG 段の compile 成功確認。pc80mk2 / pc80mk2x は `AILZ80ASM` までのフルアセンブルも `0 error/warn` (#145 系統のため厚めに)
+  - 全テスト 190 / 190 合格 (PR-C1 と同じ test base、回帰なし)
 - lsx / x1 環境の runtime ライブラリに `; @resident shared|local` を全関数付与 (PR-C1) — `#MODULE $addr RESIDENT` で実バイナリでメモリ節約効果
   - 対象 17 ファイル (lsx.env / x1.env が参照する .asm を `tools/resident-audit.py --env` で機械的に列挙) / 260 関数
   - 内訳: **shared 258 関数 / local 2 関数** (`SLANGINIT` = main inline 専用, `M8ALOAD` = 命令オペランド書き換えあり)

--- a/runtime/libmsx2_file.asm
+++ b/runtime/libmsx2_file.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name LSXFILE
+; @resident shared
 ; @calls MULHLDE
 ; fnum to FCB address
 LSXCALCFCB:
@@ -28,6 +29,7 @@ RET
 
 
 ; @name FOPEN
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum DE=fname addr BC=mode
 LD (LSXFCB),HL
@@ -100,6 +102,7 @@ RET
 
 
 ; @name FSEEK
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum DE=offset BC=mode(0=head, 1=current, 2=tail)
 CALL LSXFCHECKNUM
@@ -132,6 +135,7 @@ RET
 
 
 ; @name FGETC
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum
 
@@ -174,6 +178,7 @@ DS  1
 
 
 ; @name FPUTC
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum DE=chr
 
@@ -216,6 +221,7 @@ DS  1
 
 
 ; @name FCLOSE
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum
 CALL LSXCALCFCB
@@ -231,6 +237,7 @@ RET
 
 
 ; @name FREAD
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum DE=address BC=size
 
@@ -259,6 +266,7 @@ RET
 
 
 ; @name FWRITE
+; @resident shared
 ; @calls LSXCALLS,FWORK,LSXFILE
 ; HL=fnum DE=address BC=size
 
@@ -286,6 +294,7 @@ RET
 
 
 ; @name FWORK
+; @resident shared
 LSXFCBS: DS 8
 LSXFCB: DW 0
 LSXFMODE: DW 0

--- a/runtime/libmsx_grp.asm
+++ b/runtime/libmsx_grp.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name MSXGRPBASE
+; @resident shared
 ; @calls MSXGRPSYS,MSXGRPWORK
 ; @lib MSXLIB
 CONSOLE_COLUMNS equ 32
@@ -38,12 +39,14 @@ VDP_STATUS EQU $99
 
 
 ; @name MSX_CALLBIOS
+; @resident shared
 ; @lib MSXLIB
 	push hl
 	pop ix
 	jp msxbios
 
 ; @name MSX_SCREEN
+; @resident shared
 ; @lib MSXLIB
 	ld	a,l
 	ld	hl, 005Fh	; CHGMOD
@@ -52,6 +55,7 @@ VDP_STATUS EQU $99
 	jp msxbios
 
 ; @name MSXGRPSYS
+; @resident shared
 ; @lib MSXLIB
 
 msxbios:
@@ -63,6 +67,7 @@ msxbios:
 	ret
 
 ; @name MSX_SET_COLOR
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	; HL = foreground
@@ -90,6 +95,7 @@ msxbios:
 	ret
 
 ; @name MSX_VWRITE
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	; hl = source, de = dest, bc = count
@@ -97,6 +103,7 @@ msxbios:
 	jp	msxbios
 
 ; @name MSX_VWRITE_DIRECT
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	; hl = source, de = dest, bc = count
@@ -122,6 +129,7 @@ wrtloop:
 	ret
 
 ; @name MSX_VFILL
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	; hl = addr, value = de, count = bc
@@ -131,6 +139,7 @@ wrtloop:
 	jp	msxbios
 
 ; @name GET_VDP_REG
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	ld de,RG0SAV
@@ -142,6 +151,7 @@ wrtloop:
 	ret
 
 ; @name SET_VDP_REG
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	push	ix
@@ -153,6 +163,7 @@ wrtloop:
 	ret
 
 ; @name SET_SPRITE_16HFLIP
+; @resident shared
 ; @calls MSXGRPBASE,MSXGRPWORK,MSXGRPSYS
 ; @lib MSXLIB
 	; hl = pattern index, de = data
@@ -211,12 +222,14 @@ flip_and_copy:
 	;jp WRTVRM
 
 ; @name MSXGRPWORK
+; @resident shared
 ; @lib MSXLIB
 ; @works VDP_ATTR:1
 ;
 
 
 ; @name MSXCALLS
+; @resident shared
 CHPUT   EQU $00A2
 EXPTBL  EQU $FCC1
 ENASLT  EQU $0024
@@ -229,6 +242,7 @@ GTSTCK  EQU $00D5
 
 
 ; @name STICK2
+; @resident shared
 ; @calls MSXCALLS
 LD A,L
 LD IX,GTSTCK

--- a/runtime/libmsx_iot.asm
+++ b/runtime/libmsx_iot.asm
@@ -2,11 +2,13 @@
 ; SLANG Runtime Library (new format)
 
 ; @name IOT_COMMON
+; @resident shared
 MSX0IO  EQU $58
 MSX0IO2 EQU $57
 
 
 ; @name IOT_SET_DEVICE_PATH
+; @resident shared
 ; @calls IOT_COMMON,STRLEN
 PUSH  DE
 ; HL = Device Path
@@ -59,6 +61,7 @@ RET
 
 
 ; @name IOTGET_INT
+; @resident shared
 ; @calls STRLEN,IOT_COMMON,IOT_SET_DEVICE_PATH
 ; HL = Device Path
 
@@ -84,6 +87,7 @@ RET
 
 
 ; @name IOTGET_STR
+; @resident shared
 ; @calls IOT_COMMON,IOT_SET_DEVICE_PATH
 ; HL = Device Path
 ; DE = String Address
@@ -120,6 +124,7 @@ RET
 
 
 ; @name IOTPUT_INT
+; @resident shared
 ; @calls IOT_COMMON,IOT_SET_DEVICE_PATH
 ; HL = Device Path
 ; DE = Value
@@ -150,6 +155,7 @@ RET
 
 
 ; @name IOTPUT_STR
+; @resident shared
 ; @calls IOT_COMMON,IOT_SET_DEVICE_PATH,STRLEN
 ; HL = Device Path
 ; DE = Value

--- a/runtime/libmsx_psg.asm
+++ b/runtime/libmsx_psg.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name PSG_BASE
+; @resident shared
 ; @lib PSGLIB
 RDVRM:        EQU $004A	; BIOS RDVRM
 WRTVRM:       EQU $004D	; BIOS WRTVRM
@@ -27,6 +28,7 @@ H_TIMI:       EQU $FD9F   ; 垂直帰線割り込みフック
 
 
 ; @name PSG_INIT
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; ====================================================================================================
@@ -136,6 +138,7 @@ SOUNDDRV_INITWK_L1:
     RET
 
 ; @name PSG_PLAY
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; ====================================================================================================
@@ -182,6 +185,7 @@ SOUNDDRV_BGMPLAY:
     RET
 
 ; @name PSG_SFX
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; ====================================================================================================
@@ -241,6 +245,7 @@ SOUNDDRV_SFXPLAY_EXIT:
     RET
 
 ; @name PSG_STOP
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; ====================================================================================================
@@ -298,6 +303,7 @@ SOUNDDRV_STOP_L2:
     RET
 
 ; @name PSG_PAUSE
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; ====================================================================================================
@@ -331,6 +337,7 @@ SOUNDDRV_PAUSE_EXIT:
     RET
 
 ; @name PSG_RESUME
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; ====================================================================================================
@@ -377,6 +384,7 @@ SOUNDDRV_RESUME_EXIT:
     RET
 
 ; @name PSG_PROC
+; @resident shared
 ; @calls PSG_BASE
 ; @lib PSGLIB
 ; @works SOUNDDRV_H_TIMI_BACKUP:5,SOUNDDRV_STATE:1,SOUNDDRV_WK_MIXING_TONE:1,SOUNDDRV_WK_MIXING_NOISE:1,SOUNDDRV_BGMWK:48,SOUNDDRV_DUMMYWK:16,SOUNDDRV_SFXWK:48
@@ -891,6 +899,7 @@ SOUNDDRV_TONETBL:
 
 
 ; @name PSG_END
+; @resident shared
 ; @calls PSG_BASE,PSG_STOP
 ; @lib PSGLIB
     DI
@@ -907,6 +916,7 @@ SOUNDDRV_TONETBL:
     RET
 
 ; @name VSYNC
+; @resident shared
 ; VSYNC(MSX) / not implemented
 RET
 

--- a/runtime/libmsx_spdrv.asm
+++ b/runtime/libmsx_spdrv.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name SPDRV_INCLUDE
+; @resident shared
 ; @lib MSXSPDRV
 ; -----------------------------------------------------------------------------
 ;  Constant definitions for MSX
@@ -74,12 +75,14 @@ jiffy			EQU 0xFC9E
 
 
 ; @name SPDRV_WORK
+; @resident shared
 ; @calls SPDRV_INCLUDE
 ; @lib MSXSPDRV
 ; @works sprite_page:1,sprite_index:1,sprite_attribute:128
 ;
 
 ; @name SPDRV_INITIALIZE
+; @resident shared
 ; @calls SPDRV_WORK
 ; @lib MSXSPDRV
 
@@ -124,6 +127,7 @@ vram_sprite_attribute2	EQU vram_sprite_attribute1 + 128
 ;				endscope
 
 ; @name SPDRV_FLIP
+; @resident shared
 ; @calls SPDRV_WORK
 ; @lib MSXSPDRV
 ; spdrv_flip::
@@ -144,6 +148,7 @@ vram_sprite_attribute2	EQU vram_sprite_attribute1 + 128
 ;				endscope
 
 ; @name SPDRV_SET
+; @resident shared
 ; @calls SPDRV_WORK
 ; @lib MSXSPDRV
 ; HL = sprite attribute index
@@ -164,6 +169,7 @@ ret
 
 
 ; @name SPDRV_MOVE
+; @resident shared
 ; @calls SPDRV_WORK
 ; @lib MSXSPDRV
 
@@ -188,6 +194,7 @@ LD (HL),E
 
 
 ; @name SPDRV_UPDATE
+; @resident shared
 ; @calls SPDRV_WORK
 ; @lib MSXSPDRV
 ; spdrv_update:
@@ -256,12 +263,14 @@ LD (HL),E
 ;				endscope
 
 ; @name SPDRV2_WORK
+; @resident shared
 ; @calls SPDRV_INCLUDE
 ; @lib MSXSPDRV
 ; @works sprite_page:1,sprite_index:1,sprite_color_work:32,sprite_attribute:256
 ;
 
 ; @name SPDRV2_INITIALIZE
+; @resident shared
 ; @calls SPDRV2_WORK
 ; @lib MSXSPDRV
 
@@ -322,6 +331,7 @@ disable_y				EQU 216
 ;				endscope
 
 ; @name SPDRV2_FLIP
+; @resident shared
 ; @calls SPDRV2_WORK
 ; @lib MSXSPDRV
 ;				scope		spdrv_flip
@@ -343,6 +353,7 @@ disable_y				EQU 216
 ;				endscope
 
 ; @name SPDRV2_SET
+; @resident shared
 ; @calls SPDRV2_WORK
 ; @lib MSXSPDRV
 ; HL = sprite attribute index
@@ -364,6 +375,7 @@ ret
 
 
 ; @name SPDRV2_MOVE
+; @resident shared
 ; @calls SPDRV2_WORK
 ; @lib MSXSPDRV
 
@@ -389,6 +401,7 @@ LD (HL),E
 
 
 ; @name SPDRV2_UPDATE
+; @resident shared
 ; @calls SPDRV2_WORK
 ; @lib MSXSPDRV
 ;				scope		spdrv_update

--- a/runtime/libmsxlsx_base.asm
+++ b/runtime/libmsxlsx_base.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name SLANGINIT
+; @resident local
 ; @calls sWORK,LSXCALLS
 LD HL,($0001)
 LD (WBOOTBK),HL
@@ -39,6 +40,7 @@ SLANG_ROM_START:
 
 
 ; @name LSXCALLS
+; @resident shared
 BDOS EQU $0005
 PRNOUT EQU $05
 INPOUT EQU $06
@@ -54,6 +56,7 @@ DTA1	EQU	0080H
 
 
 ; @name STOP
+; @resident shared
 ; @param_count 0
 LD HL,(WBOOTBK)
 LD ($00001),HL
@@ -61,6 +64,7 @@ JP 0
 
 
 ; @name sSYSTEM
+; @resident shared
 ; @param_count 0
 ; @calls LSXCALLS
 EXX
@@ -82,6 +86,7 @@ RET
 
 
 ; @name sMSG
+; @resident shared
 ; @param_count 0
 ; @calls LSXCALLS,sMSX
 PUSH	HL
@@ -90,6 +95,7 @@ JR	sMSG1
 
 
 ; @name sMSX
+; @resident shared
 ; @param_count 0
 ; @calls LSXCALLS,sPRINT
 PUSH	HL
@@ -112,21 +118,25 @@ RET
 
 
 ; @name sLPTOF
+; @resident shared
 ; @param_count 0
 RET
 
 
 ; @name sLPTON
+; @resident shared
 ; @param_count 0
 RET
 
 
 ; @name sWIDCH
+; @resident shared
 ; @param_count 0
 RET
 
 
 ; @name sMPRNT
+; @resident shared
 ; @param_count 0
 ; @calls sPRINT
 EX	(SP),HL
@@ -142,6 +152,7 @@ RET
 
 
 ; @name sNL
+; @resident shared
 ; @param_count 0
 ; @calls sZPRINT,sWORK
 PUSH	AF
@@ -157,6 +168,7 @@ RET
 
 
 ; @name sPRINTS
+; @resident shared
 ; @param_count 0
 ; @calls sPRINT
 PUSH	AF
@@ -168,6 +180,7 @@ RET
 
 
 ; @name sLTNL
+; @resident shared
 ; @param_count 0
 ; @calls sPRINTS
 PUSH	AF
@@ -176,6 +189,7 @@ JR	LTNL1
 
 
 ; @name sCSR
+; @resident shared
 ; @param_count 0
 ; @calls sWORK
 LD	HL,(sXYADR)
@@ -183,6 +197,7 @@ RET
 
 
 ; @name sSCRN
+; @resident shared
 ; @param_count 0
 ; @calls lLOC1
 ; for LSX-Dodgers
@@ -199,6 +214,7 @@ RET
 
 
 ; @name lLOC1
+; @resident shared
 ; @param_count 0
 ; @calls sWORK
 PUSH	DE
@@ -220,6 +236,7 @@ RET
 
 
 ; @name sLOC
+; @resident shared
 ; @param_count 0
 ; @calls sWORK,sPCLR,sZPRINT
 CALL	sPCLR
@@ -239,6 +256,7 @@ RET
 
 
 ; @name sPAUSE
+; @resident shared
 ; @param_count 0
 ; @calls sBRKEY,sGETKY,sINKEY,sBRKEY
 CALL	sBRKEY
@@ -271,6 +289,7 @@ RET
 
 
 ; @name sBRKEY
+; @resident shared
 ; @param_count 0
 ; @calls sGETKY
 CALL	sGETKY
@@ -282,6 +301,7 @@ BRKEY1:
 
 
 ; @name sHEX
+; @resident shared
 ; @param_count 0
 ; @calls sCAP
 CALL	sCAP
@@ -299,6 +319,7 @@ RET
 
 
 ; @name sCAP
+; @resident shared
 ; @param_count 0
 CP	"a"
 RET	C
@@ -309,6 +330,7 @@ RET
 
 
 ; @name sZPRINT
+; @resident shared
 ; @param_count 0
 ; @calls sSYSTEM
 EX	(SP),HL
@@ -337,6 +359,7 @@ RET
 
 
 ; @name BEEP
+; @resident shared
 ; @param_count 0
 ; @calls sPRNT0
 PUSH	AF
@@ -345,6 +368,7 @@ JR	sPRNT01
 
 
 ; @name sPRNT0
+; @resident shared
 ; @param_count 0
 ; @calls sPRINT
 PUSH	AF
@@ -358,6 +382,7 @@ RET
 
 
 ; @name sGETL
+; @resident shared
 ; @param_count 0
 ; @calls sPRINT,sWORK,sFGETL,sKYBFC
 PUSH	BC
@@ -460,6 +485,7 @@ JP	sPRINT
 
 
 ; @name sFGETL
+; @resident shared
 ; @param_count 0
 ; @calls sWORK,sBRKEY,sINKBF
 CALL	.fgetl1
@@ -495,6 +521,7 @@ JR	.fgetl1
 
 
 ; @name sINKBF
+; @resident shared
 ; @param_count 0
 ; @calls sWORK
 PUSH	HL
@@ -515,6 +542,7 @@ RET
 
 
 ; @name sASC
+; @resident shared
 ; @param_count 0
 AND	$0F
 OR	$30
@@ -525,6 +553,7 @@ RET
 
 
 ; @name sGETKY
+; @resident shared
 ; @param_count 0
 ; @calls LSXCALLS,sFLGET
 PUSH	BC
@@ -536,6 +565,7 @@ JR	GETKY1
 
 
 ; @name sFLGET
+; @resident shared
 ; @param_count 0
 ; @calls sSYSTEM
 PUSH	BC
@@ -572,6 +602,7 @@ RET
 
 
 ; @name sINKEY
+; @resident shared
 ; @param_count 0
 ; @calls sGETKY
 CALL	sGETKY
@@ -581,6 +612,7 @@ RET
 
 
 ; @name sLPRNT
+; @resident shared
 ; @param_count 0
 ; @calls sSYSTEM
 PUSH	BC
@@ -597,6 +629,7 @@ RET
 
 
 ; @name sKYBFC
+; @resident shared
 ; @param_count 0
 ; @calls sSYSTEM,sWORK
 PUSH	AF
@@ -619,6 +652,7 @@ RET
 
 
 ; @name sPRINT
+; @resident shared
 ; @param_count 0
 ; @calls sWORK,sCTRL,sSYSTEM
 PUSH	BC
@@ -655,6 +689,7 @@ RET
 
 
 ; @name sPCLR
+; @resident shared
 ; @param_count 0
 ; @calls sWORK
 XOR	A
@@ -663,6 +698,7 @@ RET
 
 
 ; @name sCTRL
+; @resident shared
 ; @param_count 0
 ; @calls sWORK,sPCLR,sSYSTEM,sPRINT,sZPRINT
 CP	$0D
@@ -716,6 +752,7 @@ JR	sPRINT3
 
 
 ; @name sBOOT
+; @resident shared
 ; @param_count 0
 LD	HL,0
 LD	($0001),HL
@@ -723,6 +760,7 @@ JP	0
 
 
 ; @name sHLHEX
+; @resident shared
 ; @param_count 0
 ; @calls sHEX
 PUSH	HL
@@ -769,6 +807,7 @@ RET
 
 
 ; @name sWORK
+; @resident shared
 ; @param_count 0
 ; @works sXYADR:2,sKBFAD:128,sKBFAD0:1,sKBFAD1:1,sKBFADX:81,sPRBF:80,sSUBPS:2,sSUBBF:256,sSPBK:2,WBOOTBK:2,_CTCVEC:2
 sCRTCD: DB $6F

--- a/runtime/libmsxrom_base.asm
+++ b/runtime/libmsxrom_base.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name MSXCALLS
+; @resident shared
 CHPUT   EQU $00A2
 EXPTBL  EQU $FCC1
 ENASLT  EQU $0024
@@ -14,6 +15,7 @@ GTSTCK  EQU $00D5
 
 
 ; @name SLANGINIT
+; @resident local
 ; @calls MSXWORK,MSXCALLS
 ; MSX 32k ROM
 
@@ -66,11 +68,13 @@ JP INFLOOP
 
 
 ; @name STOP
+; @resident shared
 ; @param_count 0
 JP INFLOOP
 
 
 ; @name MSXWORK
+; @resident shared
 ; @param_count 0
 ; @works sXYADR:2,sKBFAD:128,sKBFAD0:1,sKBFAD1:1,sKBFADX:81,sPRBF:80,sSUBPS:2,sSUBBF:256,sSPBK:2,WBOOTBK:2,WORK10:10
 sCRTCD: DB $6F

--- a/runtime/libmsxrom_input.asm
+++ b/runtime/libmsxrom_input.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name STICK
+; @resident shared
 ; @calls MSXCALLS
 LD A,L
 CALL GTSTCK
@@ -11,6 +12,7 @@ RET
 
 
 ; @name STICK2
+; @resident shared
 ; @calls MSXCALLS
 LD A,L
 CALL GTSTCK

--- a/runtime/libmsxrom_print.asm
+++ b/runtime/libmsxrom_print.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name WIDTH
+; @resident shared
 ; @param_count 1
 ; @calls MSXCALLS
 LD A,L
@@ -12,12 +13,14 @@ RET
 
 
 ; @name PRMODE
+; @resident shared
 ; @param_count 1
 ; PRMODE not supported
 RET
 
 
 ; @name SCREEN
+; @resident shared
 ; @param_count 2
 ; @calls sSCRN
 LD H,E
@@ -28,6 +31,7 @@ RET
 
 
 ; @name LOCATE
+; @resident shared
 ; @param_count 2
 LD H,L
 LD L,E
@@ -36,6 +40,7 @@ RET
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$09
@@ -43,6 +48,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -50,12 +56,14 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PSTR2
 EX DE,HL
@@ -64,12 +72,14 @@ JR PSTR2
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -83,6 +93,7 @@ JR .pstr1
 
 
 ; @name PSTR2
+; @resident shared
 ; @param_count 2
 ; @calls PCHR
 .pstr1
@@ -95,6 +106,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 CALL PRT
@@ -103,12 +115,14 @@ JR PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -116,12 +130,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -137,6 +153,7 @@ CALL SASC
 
 
 ; @name PRT
+; @resident shared
 ; @param_count 1
 ; @calls MSXCALLS
 CALL CHPUT
@@ -144,6 +161,7 @@ RET
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -155,6 +173,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -163,6 +182,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -170,6 +190,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX,MSXWORK
@@ -201,11 +222,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -216,12 +239,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2
@@ -237,6 +262,7 @@ RET
 
 
 ; @name VTOS
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls DIVHLDE8

--- a/runtime/libp88_base.asm
+++ b/runtime/libp88_base.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name SLANGINIT
+; @resident local
 ; @calls P88WORK,VTOS,P88INT
 DI
 
@@ -47,6 +48,7 @@ JP MAIN
 
 
 ; @name VSYNC
+; @resident shared
 P8WaitVBlank:
 in	    a,($40)
 and     $20
@@ -59,6 +61,7 @@ ret
 
 
 ; @name PSET
+; @resident local
 ; @calls GETVRAMADR
 ; HL = X, DE= Y, BC = COLOR
 DI
@@ -127,6 +130,7 @@ RET
 
 
 ; @name SETGRP
+; @resident shared
 ; @calls P88WORK
 ; HL =
 ;   0 = 青プレーン独立
@@ -159,6 +163,7 @@ RET
 
 
 ; @name GETVRAMADR
+; @resident shared
 ; HL = X, DE = Y
 PUSH BC
 
@@ -216,6 +221,7 @@ RET
 
 
 ; @name P88INT
+; @resident shared
 ALIGN	256
 ;
 ;	割り込みベクタ:アドレス下位1バイトが0になるように
@@ -284,6 +290,7 @@ scrinitcode_end:
 
 
 ; @name P88WORK
+; @resident shared
 ; @works IO32H:1
 ;
 

--- a/runtime/libp88_file.asm
+++ b/runtime/libp88_file.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name Disk_Load
+; @resident shared
 ; @calls Disk_FileName
 ; HL = path Address, DE = load address
 push de
@@ -13,6 +14,7 @@ jp $0000 + $3
 
 
 ; @name Disk_FileName
+; @resident shared
 ; HL = path Address
 ; Disk_FileName (deにFileNameのaddressを返す)
 call $0000 + $1e
@@ -25,6 +27,7 @@ ret
 
 
 ; @name Disk_Load3
+; @resident shared
 ; HL = load address, DE = offset, BC = size
 
 ; limit 64KB
@@ -36,11 +39,13 @@ ret
 
 
 ; @name Disk_Save
+; @resident shared
 ; HL = save data address, b=cnt c=drv d=Trk e=Sec
 jp $0000 + 12
 
 
 ; @name Disk_SecLoad
+; @resident shared
 ; HL = load data address, b=cnt c=drv d=Trk e=Sec
 jp $0000 + 33
 

--- a/runtime/libp88_print.asm
+++ b/runtime/libp88_print.asm
@@ -2,27 +2,32 @@
 ; SLANG Runtime Library (new format)
 
 ; @name P88PCOMMON
+; @resident shared
 VRMTOP EQU $F3C8
 LOCX: DB 0
 LOCY: DB 0
 
 
 ; @name WIDTH
+; @resident shared
 ; @param_count 1
 RET
 
 
 ; @name PRMODE
+; @resident shared
 ; @param_count 1
 RET
 
 
 ; @name SCREEN
+; @resident shared
 ; @param_count 2
 RET
 
 
 ; @name LOCATE
+; @resident shared
 ; @param_count 2
 LD H,E
 LD (LOCX),HL
@@ -30,6 +35,7 @@ RET
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 ; TAB -> Space
@@ -38,6 +44,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -45,24 +52,28 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$0D
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -76,6 +87,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 CALL PRT
@@ -84,12 +96,14 @@ JR PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -97,12 +111,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -118,6 +134,7 @@ CALL SASC
 
 
 ; @name PRT
+; @resident shared
 ; @param_count 1
 ; @calls GETLOCADR
 PUSH HL
@@ -181,6 +198,7 @@ DS  4
 
 
 ; @name GETLOCADR
+; @resident shared
 ; @calls P88PCOMMON
 PUSH	BC
 LD	BC,(LOCX)
@@ -226,6 +244,7 @@ RET
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -237,6 +256,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -245,6 +265,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -252,6 +273,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX
@@ -283,11 +305,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -298,12 +322,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2

--- a/runtime/libpc80mk2_base.asm
+++ b/runtime/libpc80mk2_base.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name PC80CALLS
+; @resident shared
 ;-----------------------------------------------------------------------
 ; 定数定義
 ;
@@ -96,6 +97,7 @@ ATRB:
 
 
 ; @name SLANGINIT
+; @resident local
 ; @calls PC80CALLS,PC80WORK
 INIT:
 ; 初期化
@@ -124,6 +126,7 @@ JP INFLOOP
 
 
 ; @name MEMMODE
+; @resident shared
 ; @calls PC80CALLS
 ; HL = READ: 0=ROM / 1=RAM
 ; DE = WRITE: 0=ROM / 1=RAM
@@ -156,6 +159,7 @@ RET
 
 
 ; @name CMDSCREEN
+; @resident shared
 ; HL = GRAPHIC MODE(0=640x200 MONO、1=640x200Attribute Color、2=320x200、4 Color 1,3=320x200、4 Color 1)
 ; DE = 0 = GRAPHIC OFF / 1 = GRAPHIC ON
 ; BC = COLOR CODE
@@ -203,16 +207,19 @@ RET
 
 
 ; @name LOADCMT
+; @resident shared
 CALL $BF3   ; CMT Read Start
 CALL $5F3A  ; LOAD CMT Machine binary
 RET
 
 
 ; @name SD_ROPEN
+; @resident shared
 JP $600f
 
 
 ; @name SD_FGET
+; @resident shared
 CALL $6006
 LD L,A
 LD H,0
@@ -220,31 +227,38 @@ RET
 
 
 ; @name SD_RREAD
+; @resident shared
 JP $6009
 
 
 ; @name SD_WAOPEN
+; @resident shared
 JP $6012
 
 
 ; @name SD_WNOPEN
+; @resident shared
 JP $601B
 
 
 ; @name SD_FPUT
+; @resident shared
 LD A,L
 JP $6018
 
 
 ; @name SD_FWRITE
+; @resident shared
 JP $6015
 
 
 ; @name SD_WCLOSE
+; @resident shared
 JP $601E
 
 
 ; @name SETGVRAM
+; @resident shared
 ; HL = 0=Main Memory / 1=GVRAM
 push bc
 
@@ -265,12 +279,14 @@ ret
 
 
 ; @name PC80WORK
+; @resident shared
 ; @param_count 0
 ; @works WORKDUMMY:2
 ;
 
 
 ; @name KANJILOCATE
+; @resident shared
 ; @lib PC80KANJI
 	; HL = X
 	; DE = Y
@@ -281,6 +297,7 @@ ret
 	ret
 
 ; @name KANJIPUT
+; @resident shared
 ; @lib PC80KANJI
 
 ; 0�ɂ����640x200���[�h�A1�`3�ɂ����320x200���[�h�Ŏw�肵���F�ŕ`�悳��܂�(�e�L�g�[)
@@ -954,6 +971,7 @@ KanjiVRAM:	dw	$8000
 
 
 ; @name PCGDEF2
+; @resident shared
 ; @calls PCGDEF
 ; (256 chr mode)
 ; HL = chr code(0x00-0x7f) DE = address
@@ -976,6 +994,7 @@ JP PCGDEF.defmain
 
 
 ; @name PCGDEF
+; @resident shared
 ; (128 chr mode)
 ; HL = chr code(0x00-0x7f) DE = address
 EX DE,HL
@@ -1079,6 +1098,7 @@ RET
 
 
 ; @name STICK2
+; @resident shared
 ; TENKEY INPUT
 ; result:
 ;   bit0 up
@@ -1146,6 +1166,7 @@ RET
 
 
 ; @name STRIG
+; @resident shared
 LD HL,0
 IN A,(KEYP09)
 AND KEY09.SPACE
@@ -1156,6 +1177,7 @@ RET
 
 
 ; @name VSYNC
+; @resident shared
 IN	A, (KEYP08)
 RLCA
 RET	NC
@@ -1171,6 +1193,7 @@ RET
 
 
 ; @name KEYCHK
+; @resident shared
 LD C,L
 IN L,(C)
 LD H,0
@@ -1178,6 +1201,7 @@ RET
 
 
 ; @name BEEP
+; @resident shared
 LD A,L
 AND 1
 RLA

--- a/runtime/libpc80mk2_print.asm
+++ b/runtime/libpc80mk2_print.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name WIDTH
+; @resident shared
 ; HL=80 or 40
 ld  b,l
 ld  c,25
@@ -9,6 +10,7 @@ jp	BIOS.WIDTH
 
 
 ; @name WIDTH2
+; @resident shared
 ; HL=80 or 40
 ; DE=25 or 20
 ld  b,l
@@ -17,6 +19,7 @@ jp	BIOS.WIDTH
 
 
 ; @name TEXTMODE
+; @resident shared
 ; L = 0でファンクションキー非表示、1で表示
 ; E = 0で白黒、1でカラー
 XOR A
@@ -39,6 +42,7 @@ jp	BIOS.FUNC_COLOR 	; ファンクションキーを消してカラーモード�
 
 
 ; @name LOCATE
+; @resident shared
 ; HL=x DE=y
 LD H,L
 LD L,E
@@ -74,6 +78,7 @@ jp BIOS.LOCATE
 
 
 ; @name PRT
+; @resident shared
 ; @calls PC80CALLS
 ; @works WORK10:10
 CALL BIOS.PUTCRT1
@@ -81,6 +86,7 @@ RET
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$09
@@ -88,6 +94,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -95,12 +102,14 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PSTR2
 EX DE,HL
@@ -109,12 +118,14 @@ JR PSTR2
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -128,6 +139,7 @@ JR .pstr1
 
 
 ; @name PSTR2
+; @resident shared
 ; @param_count 2
 ; @calls PCHR
 .pstr1
@@ -140,6 +152,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 OR A
@@ -150,12 +163,14 @@ JR NZ,PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -163,12 +178,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -184,6 +201,7 @@ CALL SASC
 
 
 ; @name CTRL0D
+; @resident shared
 ; @calls CSR,AT_VRCALC
 CALL _POS
 LD L,0
@@ -198,6 +216,7 @@ RET
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -209,6 +228,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -217,6 +237,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -224,6 +245,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX
@@ -255,11 +277,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -270,12 +294,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2
@@ -291,6 +317,7 @@ RET
 
 
 ; @name VTOS
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls DIVHLDE8
@@ -325,6 +352,7 @@ RET
 
 
 ; @name SETATR
+; @resident shared
 ; @lib PC80ASM
 ; HL = �s
 ; DE = �J�n�ʒuX

--- a/runtime/libpc80mk2_sound.asm
+++ b/runtime/libpc80mk2_sound.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name SND_COMMON
+; @resident shared
 ; @lib PC80SND
 
 
@@ -167,11 +168,13 @@ SND:
 
 
 ; @name SND_STOP
+; @resident shared
 ; @calls SND_COMMON
 ; @lib PC80SND
 SNDStop:
 
 ; @name SND_INIT
+; @resident shared
 ; @calls SND_COMMON
 ; @lib PC80SND
 ;-----------------------------------------------------------------------
@@ -195,6 +198,7 @@ SNDInitialize:
 	ret			; �I������
 
 ; @name SND_PLAY
+; @resident shared
 ; @calls SND_COMMON
 ; @lib PC80SND
 ;-----------------------------------------------------------------------
@@ -239,6 +243,7 @@ SNDMusicStart:
 	ret			; �I������
 
 ; @name SND_SEPLAY
+; @resident shared
 ; @calls SND_COMMON
 ; @lib PC80SND
 ;-----------------------------------------------------------------------
@@ -254,6 +259,7 @@ SNDEffectStart:
 	ret
 
 ; @name SND_SYNC
+; @resident shared
 ; @calls SND_COMMON,SND_PROC
 ; @lib PC80SND
 ;-----------------------------------------------------------------------
@@ -281,6 +287,7 @@ SNDDiver:
 	ret
 
 ; @name SND_PROC
+; @resident shared
 ; @calls SND_COMMON
 ; @lib PC80SND
 ;-----------------------------------------------------------------------
@@ -332,6 +339,7 @@ SNDTimer:
 	ret
 
 ; @name SND_ISPLAYING
+; @resident shared
 ; @calls SND_COMMON
 ; @lib PC80SND
 ;-----------------------------------------------------------------------

--- a/runtime/libpc80mk2xbios_base.asm
+++ b/runtime/libpc80mk2xbios_base.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name PC80CALLS
+; @resident shared
 ; @works AT_WIDTH:1
 ;-----------------------------------------------------------------------
 ; 定数定義
@@ -120,6 +121,7 @@ ATRB:
 
 
 ; @name SLANGINIT
+; @resident local
 ; @calls PC80CALLS,PC80WORK
 INIT:
 
@@ -175,6 +177,7 @@ DB 'XBIOS.CMT',0
 
 
 ; @name MEMMODE
+; @resident shared
 ; @calls PC80CALLS
 ; HL = READ: 0=ROM / 1=RAM
 ; DE = WRITE: 0=ROM / 1=RAM
@@ -206,6 +209,7 @@ RET
 
 
 ; @name CMDSCREEN
+; @resident shared
 ; HL = GRAPHIC MODE(0=640x200 MONO、1=640x200Attribute Color、2=320x200、4 Color 1,3=320x200、4 Color 1)
 ; DE = 0 = GRAPHIC OFF / 1 = GRAPHIC ON
 ; BC = COLOR CODE
@@ -252,6 +256,7 @@ RET
 
 
 ; @name LOADCMT
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $BF3   ; CMT Read Start
@@ -260,6 +265,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_UTIL
+; @resident shared
 SDROM_ENABLE:
 PUSH AF
 LD A,(XBIOS.PORT31)
@@ -284,6 +290,7 @@ RET
 
 
 ; @name SD_ROPEN
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $600f
@@ -291,6 +298,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_FGET
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $6006
@@ -301,6 +309,7 @@ RET
 
 
 ; @name SD_RREAD
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $6009
@@ -308,6 +317,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_WAOPEN
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $6012
@@ -315,6 +325,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_WNOPEN
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $601B
@@ -322,6 +333,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_FPUT
+; @resident shared
 ; @calls SD_UTIL
 LD A,L
 CALL SDROM_ENABLE
@@ -330,6 +342,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_FWRITE
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $6015
@@ -337,6 +350,7 @@ JP SDROM_DISABLE
 
 
 ; @name SD_WCLOSE
+; @resident shared
 ; @calls SD_UTIL
 CALL SDROM_ENABLE
 CALL $601E
@@ -344,6 +358,7 @@ JP SDROM_DISABLE
 
 
 ; @name SETGVRAM
+; @resident shared
 ; HL = 0=Main Memory / 1=GVRAM
 push bc
 
@@ -364,12 +379,14 @@ ret
 
 
 ; @name PC80WORK
+; @resident shared
 ; @param_count 0
 ; @works WORKDUMMY:2
 ;
 
 
 ; @name KANJILOCATE
+; @resident shared
 ; @lib PC80KANJI
 	; HL = X
 	; DE = Y
@@ -380,6 +397,7 @@ ret
 	ret
 
 ; @name KANJIPUT
+; @resident shared
 ; @lib PC80KANJI
 
 ; 0�ɂ����640x200���[�h�A1�`3�ɂ����320x200���[�h�Ŏw�肵���F�ŕ`�悳��܂�(�e�L�g�[)
@@ -1053,6 +1071,7 @@ KanjiVRAM:	dw	$8000
 
 
 ; @name PCGDEF2
+; @resident shared
 ; @calls PCGDEF
 ; (256 chr mode)
 ; HL = chr code(0x00-0x7f) DE = address
@@ -1075,6 +1094,7 @@ JP PCGDEF.defmain
 
 
 ; @name PCGDEF
+; @resident shared
 ; (128 chr mode)
 ; HL = chr code(0x00-0x7f) DE = address
 EX DE,HL
@@ -1178,6 +1198,7 @@ RET
 
 
 ; @name STICK2
+; @resident shared
 ; TENKEY INPUT
 ; result:
 ;   bit0 up
@@ -1245,6 +1266,7 @@ RET
 
 
 ; @name STRIG
+; @resident shared
 LD HL,0
 IN A,(KEYP09)
 AND KEY09.SPACE
@@ -1255,6 +1277,7 @@ RET
 
 
 ; @name VSYNC
+; @resident shared
 IN	A, (KEYP08)
 RLCA
 RET	NC
@@ -1270,6 +1293,7 @@ RET
 
 
 ; @name KEYCHK
+; @resident shared
 LD C,L
 IN L,(C)
 LD H,0
@@ -1277,6 +1301,7 @@ RET
 
 
 ; @name BEEP
+; @resident shared
 LD A,L
 AND 1
 RLA
@@ -1289,6 +1314,7 @@ RET
 
 
 ; @name GET_PORT31
+; @resident shared
 LD A,(XBIOS.PORT31)
 LD L,A
 LD H,0
@@ -1296,6 +1322,7 @@ RET
 
 
 ; @name SET_PORT31
+; @resident shared
 LD  A,L
 OUT (31H),A
 LD (XBIOS.PORT31),A

--- a/runtime/libpc80mk2xbios_input.asm
+++ b/runtime/libpc80mk2xbios_input.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name INKEY
+; @resident shared
 ; @param_count 1
 ; @calls PC80CALLS
 LD A,L
@@ -22,6 +23,7 @@ RET
 
 
 ; @name LINPUT
+; @resident shared
 ; @param_count 2
 ; @calls PC80CALLS,GETL
 PUSH HL
@@ -32,12 +34,14 @@ JR GETLPROC
 
 
 ; @name GETL
+; @resident shared
 ; @param_count 1
 ; @calls GETLIN,PC80CALLS
 LD E,0
 
 
 ; @name GETLIN
+; @resident shared
 ; @param_count 2
 ; @calls PC80CALLS
 LD D,0
@@ -82,6 +86,7 @@ RET
 
 
 ; @name INPUT
+; @resident shared
 ; @param_count 0
 ; @calls LINPUT,ADECI,PC80CALLS
 LD BC,0
@@ -132,6 +137,7 @@ RET
 
 
 ; @name ADECI
+; @resident shared
 ; @param_count 0
 SUB $30
 RET C

--- a/runtime/libpc80mk2xbios_print.asm
+++ b/runtime/libpc80mk2xbios_print.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name WIDTH
+; @resident shared
 ; @param_count 1
 ; @calls PC80CALLS
 LD A,L
@@ -11,12 +12,14 @@ RET
 
 
 ; @name TEXTMODE
+; @resident shared
 ; @param_count 2
 ; ignore
 RET
 
 
 ; @name PRMODE
+; @resident local
 ; @param_count 1
 ; @calls PC80CALLS,PRT
 LD A,L
@@ -37,6 +40,7 @@ RET
 
 
 ; @name SCREEN
+; @resident shared
 ; @param_count 2
 ; @calls PC80CALLS
 LD H,E
@@ -47,6 +51,7 @@ RET
 
 
 ; @name LOCATE
+; @resident shared
 ; @param_count 2
 ; @calls PC80CALLS
 LD H,E
@@ -54,6 +59,7 @@ JP XBIOS.LOCATE
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$1C
@@ -61,6 +67,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -68,24 +75,28 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$0D
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -99,6 +110,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 CALL PRT
@@ -107,12 +119,14 @@ JR PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -120,12 +134,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -141,6 +157,7 @@ CALL SASC
 
 
 ; @name PRT
+; @resident shared
 ; @param_count 1
 ; @calls PC80CALLS
 JP XBIOS.PRINT
@@ -151,6 +168,7 @@ DS  4
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -162,6 +180,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -170,6 +189,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -177,6 +197,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX
@@ -208,11 +229,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -223,12 +246,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2
@@ -244,6 +269,7 @@ RET
 
 
 ; @name SETATR
+; @resident shared
 ; @calls PC80CALLS
 ld a,c
 

--- a/runtime/libsos_base.asm
+++ b/runtime/libsos_base.asm
@@ -5,6 +5,7 @@
 ; X1 固有の CTC 検出・X1turbo 割り込みパッチが必要な場合は libsosx1_base を使用。
 
 ; @name SLANGINIT
+; @resident local
 ; @calls RRET,SOSCALLS
 EXX
 POP HL
@@ -51,12 +52,14 @@ RETADR:
 
 
 ; @name STOP
+; @resident shared
 ; @param_count 0
 SCF
 JP RRET
 
 
 ; @name SOSCALLS
+; @resident shared
 ; @works AT_WIDTH:1,_WK1FD0:1
 sLPTOF  EQU 1FD6H
 sLPTON  EQU 1FD9H
@@ -89,6 +92,7 @@ sWIDTH  EQU 1F5CH
 
 
 ; @name BEEP
+; @resident shared
 CALL $1FC4
 RET
 

--- a/runtime/libsos_file.asm
+++ b/runtime/libsos_file.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name FILEWORKS
+; @resident shared
 FBADDEVICE    EQU $0f
 FOPENMODEERROR  EQU $10
 FOUTOFFILE    EQU $11
@@ -38,6 +39,7 @@ DS 12
 
 
 ; @name FOPEN
+; @resident shared
 ; @param_count 3
 ; @calls SOSCALLS,FILEWORKS,FILEUTIL
 CALL SETIX
@@ -244,6 +246,7 @@ JP FILEERROR
 
 
 ; @name FSEEK
+; @resident shared
 ; @param_count 3
 ; @calls SOSCALLS,FILEWORKS,FILEUTIL
 CALL SETIX
@@ -296,6 +299,7 @@ RET
 
 
 ; @name FPUTC
+; @resident shared
 ; @param_count 2
 ; @calls SOSCALLS,FILEWORKS,FILEUTIL,FPG
 LD C, 0
@@ -307,6 +311,7 @@ JP FNORMAL
 
 
 ; @name FGETC
+; @resident shared
 ; @param_count 1
 ; @calls SOSCALLS,FILEWORKS,FILEUTIL,FPG
 LD D, 0
@@ -317,6 +322,7 @@ JP FNORMAL
 
 
 ; @name FPG
+; @resident shared
 ; @calls SOSCALLS,FILEWORKS,FILEUTIL,FPG
 PUSH DE
 CALL SETIX
@@ -441,6 +447,7 @@ JP FILEERROR
 
 
 ; @name FCLOSE
+; @resident shared
 ; @param_count 1
 ; @calls SOSCALLS,FILEWORKS,FILEUTIL
 CALL SETIX
@@ -485,6 +492,7 @@ JP FILEERROR
 
 
 ; @name FREAD
+; @resident shared
 ; @calls FGETC
 ; HL = fnum DE = address BC = size
 LD (.freadnum),HL
@@ -526,6 +534,7 @@ DW  0
 
 
 ; @name FWRITE
+; @resident shared
 ; @calls FPUTC
 ; HL = fnum DE = address BC = size
 LD (.fwritenum),HL
@@ -568,6 +577,7 @@ DW  0
 
 
 ; @name FILEUTIL
+; @resident shared
 SCHDIR:
 LD A, $ff
 LD (SPACEOS), A

--- a/runtime/libsos_input.asm
+++ b/runtime/libsos_input.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name INKEY
+; @resident shared
 ; @param_count 1
 ; @calls SOSCALLS
 LD A,L
@@ -22,6 +23,7 @@ RET
 
 
 ; @name LINPUT
+; @resident shared
 ; @param_count 2
 ; @calls SOSCALLS,GETL
 PUSH HL
@@ -32,12 +34,14 @@ JR GETLPROC
 
 
 ; @name GETL
+; @resident shared
 ; @param_count 1
 ; @calls GETLIN,SOSCALLS
 LD E,0
 
 
 ; @name GETLIN
+; @resident shared
 ; @param_count 2
 ; @calls SOSCALLS
 LD D,0
@@ -82,6 +86,7 @@ RET
 
 
 ; @name INPUT
+; @resident shared
 ; @param_count 0
 ; @calls LINPUT,ADECI,SOSCALLS
 LD BC,0
@@ -132,6 +137,7 @@ RET
 
 
 ; @name ADECI
+; @resident shared
 ; @param_count 0
 SUB $30
 RET C

--- a/runtime/libsos_pcg.asm
+++ b/runtime/libsos_pcg.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name PCGDEFS
+; @resident shared
 ; @param_count 3
 ; @calls PCGDEF
 ; HL = STARTIDX (ascii code), DE = ADDR (24 bytes/tile), BC = COUNT
@@ -30,6 +31,7 @@ DEC BC
 JR .pcgdefs_loop
 
 ; @name PCGDEF
+; @resident shared
 ; HL = ascii code DE = address
 PUSH DE
 LD E,L

--- a/runtime/libsos_print.asm
+++ b/runtime/libsos_print.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name WIDTH
+; @resident shared
 ; @param_count 1
 ; @calls SOSCALLS
 LD A,L
@@ -11,6 +12,7 @@ RET
 
 
 ; @name PRMODE
+; @resident local
 ; @param_count 1
 ; @calls SOSCALLS,PRT
 LD A,L
@@ -31,6 +33,7 @@ RET
 
 
 ; @name SCREEN
+; @resident shared
 ; @param_count 2
 ; @calls SOSCALLS
 LD H,E
@@ -41,6 +44,7 @@ RET
 
 
 ; @name LOCATE
+; @resident shared
 ; @param_count 2
 ; @calls SOSCALLS
 LD H,E
@@ -48,6 +52,7 @@ JP sLOC
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$1C
@@ -55,6 +60,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -62,24 +68,28 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$0D
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -93,6 +103,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 CALL PRT
@@ -101,12 +112,14 @@ JR PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -114,12 +127,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -135,6 +150,7 @@ CALL SASC
 
 
 ; @name PRT
+; @resident shared
 ; @param_count 1
 ; @calls SOSCALLS
 JP sPRINT
@@ -145,6 +161,7 @@ DS  4
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -156,6 +173,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -164,6 +182,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -171,6 +190,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX
@@ -202,11 +222,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -217,12 +239,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2

--- a/runtime/libsosx1_base.asm
+++ b/runtime/libsosx1_base.asm
@@ -5,6 +5,7 @@
 ; 純粋 S-OS 環境（libsos_base）とは併用不可（SLANGINIT 等ラベル重複のため）。
 
 ; @name SLANGINIT
+; @resident local
 ; @calls RRET,SOSCALLS
 EXX
 POP HL
@@ -185,12 +186,14 @@ RET
 
 
 ; @name STOP
+; @resident shared
 ; @param_count 0
 SCF
 JP RRET
 
 
 ; @name SOSCALLS
+; @resident shared
 ; @works AT_WIDTH:1,_CTC:2,_CTCVEC:2,_ISRADR:2,_ISRHANDLER:2,_WK1FD0:1
 sLPTOF  EQU 1FD6H
 sLPTON  EQU 1FD9H
@@ -223,6 +226,7 @@ sWIDTH  EQU 1F5CH
 
 
 ; @name BEEP
+; @resident shared
 CALL $1FC4
 RET
 

--- a/runtime/libvgs0_base.asm
+++ b/runtime/libvgs0_base.asm
@@ -2,12 +2,14 @@
 ; SLANG Runtime Library (new format)
 
 ; @name VGSCALLS
+; @resident shared
 DUMMY   EQU $0000
 ADDR_OAM EQU $9000
 ADDR_OAM16 EQU $9A00
 
 
 ; @name SLANGINIT
+; @resident local
 ; @calls VGSWORK,VGSCALLS
 im 1
 di
@@ -46,11 +48,13 @@ JP INFLOOP
 
 
 ; @name STOP
+; @resident shared
 ; @param_count 0
 JP INFLOOP
 
 
 ; @name vgs0_bank0_switch
+; @resident shared
 ; L = bank num
 ld a, l
 out ($B0), a
@@ -58,6 +62,7 @@ ret
 
 
 ; @name vgs0_bank1_switch
+; @resident shared
 ; L = bank num
 ld a, l
 out ($B1), a
@@ -65,6 +70,7 @@ ret
 
 
 ; @name vgs0_bank2_switch
+; @resident shared
 ; L = bank num
 ld a, l
 out ($B2), a
@@ -72,18 +78,21 @@ ret
 
 
 ; @name vgs0_bank3_switch
+; @resident shared
 ld a, l
 out ($B3), a
 ret
 
 
 ; @name vgs0_rambank_switch
+; @resident shared
 ld a,l
 out ($B4), a
 ret
 
 
 ; @name vgs0_bank0_get
+; @resident shared
 in a, ($B0)
 ld l, a
 ld h,0
@@ -91,6 +100,7 @@ ret
 
 
 ; @name vgs0_bank1_get
+; @resident shared
 in a, ($B1)
 ld l, a
 ld h,0
@@ -98,6 +108,7 @@ ret
 
 
 ; @name vgs0_bank2_get
+; @resident shared
 in a, ($B2)
 ld l, a
 ld h,0
@@ -105,6 +116,7 @@ ret
 
 
 ; @name vgs0_bank3_get
+; @resident shared
 in a, ($B3)
 ld l, a
 ld h,0
@@ -112,6 +124,7 @@ ret
 
 
 ; @name vgs0_rambank_get
+; @resident shared
 in a, ($B4)
 ld l, a
 ld h,0
@@ -119,6 +132,7 @@ ret
 
 
 ; @name vgs0_wait_vsync
+; @resident shared
 ld hl, $9F07
 wait_vblank_loop:
 ld a, (hl)
@@ -128,12 +142,14 @@ ret
 
 
 ; @name vgs0_dma
+; @resident shared
 ld a, l
 out ($C0), a
 ret
 
 
 ; @name vgs0_memset
+; @resident shared
 ; HL = dst
 ; DE = value
 ; BC = cnt
@@ -153,6 +169,7 @@ ret
 
 
 ; @name vgs0_memcpy
+; @resident shared
 ; HL = dst
 ; DE = src
 ; BC = cnt
@@ -168,6 +185,7 @@ ret
 
 
 ; @name vgs0_collision_check
+; @resident shared
 ; HL = addr
 in a, ($C4)
 ld l, a
@@ -176,6 +194,7 @@ ret
 
 
 ; @name vgs0_mul
+; @resident shared
 ; HL = val1
 ; DE = val2
 ld h,e
@@ -186,6 +205,7 @@ ret
 
 
 ; @name vgs0_smul
+; @resident shared
 ; HL = val1
 ; DE = val2
 ld h,e
@@ -196,6 +216,7 @@ ret
 
 
 ; @name vgs0_div
+; @resident shared
 ; HL = val1
 ; DE = val2
 ; val1 / val2
@@ -208,6 +229,7 @@ ret
 
 
 ; @name vgs0_sdiv
+; @resident shared
 ; HL = val1
 ; DE = val2
 ; val1 / val2 (signed)
@@ -220,6 +242,7 @@ ret
 
 
 ; @name vgs0_mod
+; @resident shared
 ; HL = val1
 ; DE = val2
 ; val1 % val2
@@ -232,6 +255,7 @@ ret
 
 
 ; @name vgs0_mul16
+; @resident shared
 ; HL = HL * E
 ; push bc
 ld c,e
@@ -242,6 +266,7 @@ RET
 
 
 ; @name vgs0_smul16
+; @resident shared
 ; HL = HL * E
 ; push bc
 ld c,e
@@ -252,6 +277,7 @@ RET
 
 
 ; @name vgs0_div16
+; @resident shared
 ; HL = val1
 ; DE = val2
 ; val1 / val2
@@ -262,6 +288,7 @@ ret
 
 
 ; @name vgs0_sdiv16
+; @resident shared
 ; HL = val1
 ; DE = val2
 ; val1 / val2 (signed)
@@ -272,6 +299,7 @@ ret
 
 
 ; @name vgs0_sin
+; @resident shared
 ld a, l
 out ($C6), a
 ld l, a
@@ -284,6 +312,7 @@ ret
 
 
 ; @name vgs0_cos
+; @resident shared
 ld a, l
 out ($C7), a
 ld l, a
@@ -296,6 +325,7 @@ ret
 
 
 ; @name vgs0_atan2
+; @resident shared
 ; HL = yx
 in a, ($C8)
 ld l, a
@@ -304,6 +334,7 @@ ret
 
 
 ; @name vgs0_atan2b
+; @resident shared
 ; vgs0_atan2b(y, x) と、書ける
 ; HL = y
 ; DE = x
@@ -317,43 +348,51 @@ ret
 
 
 ; @name vgs0_srand8
+; @resident shared
 ld a, l
 out ($C9), a
 ret
 
 
 ; @name vgs0_rand8
+; @resident shared
 in a, ($C9)
 ret
 
 
 ; @name vgs0_srand16
+; @resident shared
 ld a, l
 out ($CA), a
 ret
 
 
 ; @name vgs0_rand16
+; @resident shared
 in a, ($CA)
 ret
 
 
 ; @name vgs0_noise_seed
+; @resident shared
 in a, ($CB)
 ret
 
 
 ; @name vgs0_noise_limitX
+; @resident shared
 out ($CC), a
 ret
 
 
 ; @name vgs0_noise_limitY
+; @resident shared
 out ($CD), a
 ret
 
 
 ; @name vgs0_noise
+; @resident shared
 ; HL = x
 ; DE = y
 in a,($CE)
@@ -362,6 +401,7 @@ ret
 
 
 ; @name vgs0_noise_oct
+; @resident shared
 ; HL = oct
 ; DE = x
 ; BC = y
@@ -379,6 +419,7 @@ ret
 
 
 ; @name vgs0_joypad_get
+; @resident shared
 in a, ($A0)
 xor $FF
 ld l, a
@@ -387,42 +428,49 @@ ret
 
 
 ; @name vgs0_bgm_play
+; @resident shared
 ld a, l
 out ($E0), a
 ret
 
 
 ; @name vgs0_bgm_pause
+; @resident shared
 ld a, 0
 out ($E1), a
 ret
 
 
 ; @name vgs0_bgm_resume
+; @resident shared
 ld a, 1
 out ($E1), a
 ret
 
 
 ; @name vgs0_bgm_fadeout
+; @resident shared
 ld a, 2
 out ($E1), a
 ret
 
 
 ; @name vgs0_se_play
+; @resident shared
 ld a, l
 out ($F0), a
 ret
 
 
 ; @name vgs0_se_stop
+; @resident shared
 ld a, l
 out ($F1), a
 ret
 
 
 ; @name vgs0_se_playing
+; @resident shared
 ld a, l
 out ($F2), a
 ld l, a
@@ -430,6 +478,7 @@ ret
 
 
 ; @name vgs0_save
+; @resident shared
 ; HL = addr
 ; DE = size
 LD c,l
@@ -444,6 +493,7 @@ ret
 
 
 ; @name vgs0_load
+; @resident shared
 ; HL = addr
 ; DE = size
 LD c,l
@@ -458,6 +508,7 @@ ret
 
 
 ; @name vgs0_oam_set16
+; @resident shared
 ; (ret), h, w, ptn, attr, y, x, num の順で入っている
 LD HL,12+2
 ADD HL,SP
@@ -553,6 +604,7 @@ RET
 
 
 ; @name vgs0_oam_set
+; @resident shared
 ; (ret), h, w, ptn, attr, y, x, num の順で入っている
 LD HL,12+2
 ADD HL,SP
@@ -696,6 +748,7 @@ RET
 
 
 ; @name vgs0_oam_move
+; @resident shared
 ; HL = num
 ; DE = X
 ; BC = Y
@@ -719,6 +772,7 @@ RET
 
 
 ; @name vgs0_debug
+; @resident shared
 .loop
 ld a, (hl)
 out ($00), a
@@ -730,6 +784,7 @@ ret
 
 
 ; @name VGSWORK
+; @resident shared
 ; @param_count 0
 ; @works LOCX:1,LOCY:1,TXTATR:1,TXTPLANE:1,WORK10:12
 ;

--- a/runtime/libvgs0_print.asm
+++ b/runtime/libvgs0_print.asm
@@ -2,21 +2,25 @@
 ; SLANG Runtime Library (new format)
 
 ; @name WIDTH
+; @resident shared
 ; @param_count 1
 RET
 
 
 ; @name PRMODE
+; @resident shared
 ; @param_count 1
 RET
 
 
 ; @name SCREEN
+; @resident shared
 ; @param_count 2
 RET
 
 
 ; @name LOCATE
+; @resident shared
 ; @param_count 2
 LD H,E
 LD (LOCX),HL
@@ -24,6 +28,7 @@ RET
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 ; TAB -> Space
@@ -32,6 +37,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -39,24 +45,28 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$0D
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -70,6 +80,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 CALL PRT
@@ -78,12 +89,14 @@ JR PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -91,12 +104,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -112,6 +127,7 @@ CALL SASC
 
 
 ; @name PRT
+; @resident shared
 ; @param_count 1
 ; @calls VGSWORK,GETLOCADR
 PUSH HL
@@ -157,6 +173,7 @@ RET
 
 
 ; @name GETLOCADR
+; @resident shared
 PUSH AF
 PUSH DE
 LD A,(LOCY)
@@ -180,6 +197,7 @@ RET
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -191,6 +209,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -199,6 +218,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -206,6 +226,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX,VGSWORK
@@ -237,11 +258,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -252,12 +275,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2
@@ -273,6 +298,7 @@ RET
 
 
 ; @name COLOR
+; @resident shared
 ; @calls VGSWORK
 LD A,(TXTATR)
 AND $F0
@@ -282,6 +308,7 @@ RET
 
 
 ; @name TEXTPLANE
+; @resident shared
 ; @calls VGSWORK
 ; HL = 0 -> BG / 1 -> FG
 LD A,$80

--- a/runtime/libx1_sgl.asm
+++ b/runtime/libx1_sgl.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name X1SGLINCLUDE
+; @resident shared
 ; @lib x1sgl
 ;---------------------------------------------------------------;
 ;	Copyright (c) 2019 macro_define.asm
@@ -7024,6 +7025,7 @@ num_buff:
 
 
 ; @name X1SGLBASE
+; @resident shared
 ; @lib x1sgl
 ; @works SGLSPRDISPBUF:32
 	; SGLBASE
@@ -7058,6 +7060,7 @@ SGL_VRCALC:
     RET
 
 ; @name SGL_INIT
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 
@@ -7106,6 +7109,7 @@ BITLINE_BUFFER1:
 
 
 ; @name SGL_DEFPAT
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; hl = pat num , de = address
@@ -7115,6 +7119,7 @@ BITLINE_BUFFER1:
 	jp cdm_set_data8_bank_main
 
 ; @name SGL_SPRCREATE
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; hl = pattern num, de = kind
@@ -7159,6 +7164,7 @@ sgl_error:
 	ret
 
 ; @name SGL_SPRDESTROY
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; hl = sprite handle
@@ -7170,6 +7176,7 @@ sgl_error:
 	ret
 
 ; @name SGL_SPRSET
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; HL = sprite handle, DE = data address
@@ -7179,6 +7186,7 @@ sgl_error:
 	ret
 
 ; @name SGL_SPRPAT
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; HL = sprite handle, DE = pattern number
@@ -7189,6 +7197,7 @@ sgl_error:
 	ret
 
 ; @name SGL_SPRMOVE
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; HLに入っているワークのX,Yを書き換える
@@ -7206,6 +7215,7 @@ sgl_error:
 	RET
 
 ; @name SGL_SPRDISP
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
     ; 表示/非表示の設定
@@ -7220,6 +7230,7 @@ sgl_error:
     ret
 
 ; @name SGL_FPSMODE
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	ld a,l
@@ -7227,6 +7238,7 @@ sgl_error:
 	ret
 
 ; @name SGL_VSYNC
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE
 ; @lib x1sgl
 	; キャラクタ処理
@@ -7246,6 +7258,7 @@ sgl_error:
 	ret
 
 ; @name SGL_PRINT
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE,AT_VRCALC
 ; @lib x1sgl
 	; HL = x, DE = y, BC = STRING ADDRESS
@@ -7262,6 +7275,7 @@ sgl_error:
 	jp render_text
 
 ; @name SGL_PRINT2
+; @resident shared
 ; @calls X1SGLINCLUDE,X1SGLBASE,AT_VRCALC
 ; @lib x1sgl
 	; HL = x, DE = y, BC = STRING ADDRESS

--- a/runtime/libzxn_base.asm
+++ b/runtime/libzxn_base.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name ZXNCALLS
+; @resident shared
 DUMMY   EQU $0000
 KEY_SCAN	EQU $028E
 KEY_TEST	EQU $031E
@@ -12,6 +13,7 @@ DOS_GET_EOF EQU $0139
 
 
 ; @name SLANGINIT
+; @resident local
 ; @calls ZXNWORK,ZXNCALLS
 ; im 1
 di
@@ -43,11 +45,13 @@ JP INFLOOP
 
 
 ; @name STOP
+; @resident shared
 ; @param_count 0
 JP INFLOOP
 
 
 ; @name ZXN_READ_REG
+; @resident shared
 ; @param_count 1
 ; L = NEXTREG register
 ; LD H,0
@@ -62,6 +66,7 @@ RET
 
 
 ; @name ZXN_WRITE_REG
+; @resident shared
 ; @param_count 2
 LD A,L
 LD BC,$243B
@@ -88,6 +93,7 @@ RET
 
 
 ; @name ZXN_SET_BANK_8K
+; @resident shared
 ; HL = mmu(0〜7)
 ; DE = page
 LD A,$50
@@ -106,6 +112,7 @@ RET
 
 
 ; @name ZXN_SET_BANK_16K
+; @resident shared
 LD A,$50
 ADD A,L
 LD D,A    ; register number
@@ -137,6 +144,7 @@ RET
 
 
 ; @name ZXN_BANK_SET_ESX
+; @resident shared
 ; 最初の16kをROMにリセット
 ; NEXTREG $50,$FF
 DB $ED,$91,$50,$FF
@@ -146,6 +154,7 @@ RET
 
 
 ; @name SET_CPU_SPEED
+; @resident shared
 ; @calls ZXN_WRITE_REG
 ; HL = 0 = 3.5MHz / 1 = 7MHz / 2 = 14MHz / 3 = 28MHz
 EX DE,HL
@@ -154,6 +163,7 @@ JP ZXN_WRITE_REG
 
 
 ; @name ZXN_ULA_SET_SHADOW
+; @resident shared
 ; HL = 0 -> not shadow(bank 5) / 1 -> shadow(bank 7)
 SLA L
 SLA L
@@ -165,6 +175,7 @@ RET
 
 
 ; @name ULA_VISIBLE
+; @resident shared
 ; HL 0 = invisible / 1 = visible
 ; 0 <-> 1
 LD A,L
@@ -181,6 +192,7 @@ RET
 
 
 ; @name SET_PAL
+; @resident shared
 ; HL = Selects palette for read or write($43)
 ; DE = IDX
 ; BC = COLOR
@@ -205,6 +217,7 @@ RET
 
 
 ; @name SET_PALALL
+; @resident shared
 ; HL = Selects palette for read or write($43)
 ; DE = COLOR Address
 LD A,(EULA_CTRL)
@@ -232,6 +245,7 @@ RET
 
 
 ; @name SET_PAL9
+; @resident shared
 ; HL = Selects palette for read or write($43)
 ; DE = IDX
 ; BC = COLOR(9bits)
@@ -259,6 +273,7 @@ RET
 
 
 ; @name SET_PAL9ALL
+; @resident shared
 ; HL = Selects palette for read or write($43)
 ; DE = COLOR Address
 LD A,(EULA_CTRL)
@@ -290,6 +305,7 @@ RET
 
 
 ; @name L2_SCREEN
+; @resident shared
 ; HL 0 = 256x192 / 1 = 320x256 / 2 = 640x256(4bpp)
 SLA L
 SLA L
@@ -301,6 +317,7 @@ RET
 
 
 ; @name L2_VISIBLE
+; @resident shared
 ; @calls ZXNWORK
 ; HL 0 = invisible / 1 = visible
 LD A,(L2_ACCESS)
@@ -314,24 +331,28 @@ RET
 
 
 ; @name L2_SETRAM
+; @resident shared
 LD A,L
 DB $ED,$92,$12
 RET
 
 
 ; @name L2_SETRAMSHADOW
+; @resident shared
 LD A,L
 DB $ED,$92,$13
 RET
 
 
 ; @name L2_TRANSPARENCY
+; @resident shared
 LD A,L
 DB $ED,$92,$14
 RET
 
 
 ; @name L2_OFFSET
+; @resident shared
 ; HL = X Offset
 ; DE = Y Offset
 LD A,L
@@ -348,6 +369,7 @@ RET
 
 
 ; @name L2_CLIPWINDOW
+; @resident shared
 ; @calls ZXNWORK
 ; スタックには近い順に(RETADR),Y2,Y1,X2,X1が積まれている
 LD (SPTMP),SP
@@ -384,6 +406,7 @@ RET
 
 
 ; @name TILE_INIT
+; @resident shared
 ; HL 0 = 40x32 / 1 = 80x32
 ; DE 0 = 2byte / 1 = 1byte
 LD A,(TILE_CTRL)
@@ -403,6 +426,7 @@ RET
 
 
 ; @name TILE_VISIBLE
+; @resident shared
 ; HL 0 = Invisible / 1 = Visible
 LD A,(TILE_CTRL)
 AND $7F
@@ -415,6 +439,7 @@ RET
 
 
 ; @name TILE_GLOBALATR
+; @resident shared
 ; HL = Default Tilemap Attribute
 LD A,L
 DB $ED,$92,$6C
@@ -422,6 +447,7 @@ RET
 
 
 ; @name TILE_SETADR
+; @resident shared
 ; HL = tilemap address
 ; DE = tile address
 
@@ -437,6 +463,7 @@ RET
 
 
 ; @name TILE_CLIP
+; @resident shared
 ; @calls ZXNWORK
 ; スタックには近い順に(RETADR),Y2,Y1,X2,X1が積まれている
 LD (SPTMP),SP
@@ -473,6 +500,7 @@ RET
 
 
 ; @name TILE_OFFSET
+; @resident shared
 ; HL = X Offset
 ; DE = Y Offset
 
@@ -491,6 +519,7 @@ RET
 
 
 ; @name TILE_DEFS
+; @resident shared
 ; HL = Index
 ; DE = Tile Address
 ; BC = Tile Count
@@ -540,6 +569,7 @@ RET
 
 
 ; @name TILE_DEF
+; @resident shared
 ; HL Tile Index
 ; DE Tile Data Address
 
@@ -576,6 +606,7 @@ RET
 
 
 ; @name TILE_SETMAP
+; @resident shared
 ; @calls MULHLDE
 ; HL = X
 ; DE = Y
@@ -633,6 +664,7 @@ RET
 
 
 ; @name LAYER_PRIORITY
+; @resident shared
 ; HL
 ; 0 S L U
 ; 1 L S U
@@ -654,6 +686,7 @@ RET
 
 
 ; @name SPR_LOAD
+; @resident shared
 ; HL = index
 ; DE = address
 ; BC = size
@@ -685,6 +718,7 @@ DB %10000111
 
 
 ; @name SPR_VISIBLE
+; @resident shared
 ; @calls ZXNWORK
 LD A,(SPL_SYS)
 AND $FE
@@ -695,6 +729,7 @@ RET
 
 
 ; @name SPR_SETID
+; @resident shared
 ; HL = Sprite Id
 LD A,L
 ; NEXTREG $34,A
@@ -703,6 +738,7 @@ RET
 
 
 ; @name SPR_SET
+; @resident shared
 ;
 ; スタックには近い順に(RETADR)PAT,Y,X,IDXが積まれている
 ; PatはAttribute 2が上位、Attribute 3が下位に来た値であるが、特例としてX座標の最上位ビットはX側が使われる
@@ -738,6 +774,7 @@ RET
 
 
 ; @name SPR_MOVE
+; @resident shared
 ; HL = (low)spr num / (high)Attribute 2(7-4 pal offset, 3 flip X, 2 flip Y, 1 rotate)
 ; DE = X
 ; BC = Y
@@ -762,6 +799,7 @@ RET
 
 
 ; @name SPR_STARTANCHOR
+; @resident shared
 ; SPR_SETの直後に呼び出すとSPR_SETしたスプライトが親スプライトになる
 ; SPR_SETの第四引数には$4000をORする事
 LD A,$20
@@ -771,6 +809,7 @@ RET
 
 
 ; @name SPR_SETREL
+; @resident shared
 ; HL = X
 ; DE = Y
 ; C  = PAT
@@ -802,6 +841,7 @@ RET
 
 
 ; @name SPR_SCALE
+; @resident shared
 ; HL = (low)spr num  (high)7-6 H+N6(H->4bit sprite)
 ; DE = X scale factor(1x,2x,4x,8x)
 ; BC = Y scale factor(1x,2x,4x,8x)
@@ -823,6 +863,7 @@ RET
 
 
 ; @name SPR_CLIP
+; @resident shared
 ; @calls ZXNWORK
 ; スタックには近い順に(RETADR),Y2,Y1,X2,X1が積まれている
 LD (SPTMP),SP
@@ -859,6 +900,7 @@ RET
 
 
 ; @name SPR_HIDE
+; @resident shared
 ; HL Sprite Num
 LD A,L
 DB $ED,$92,$34
@@ -869,6 +911,7 @@ DB $ED,$92,$38
 
 
 ; @name STICK
+; @resident shared
 ; HL = 0 (JOYSTICK 1) or 1 (JOYSTICK2)
 LD A,L
 CP 1
@@ -885,6 +928,7 @@ RET
 
 
 ; @name COPPER_SET
+; @resident shared
 ; HL = Copper Instructions Address
 ; DE = Copper Size
 
@@ -910,11 +954,13 @@ RET
 
 
 ; @name ZXN_VSYNC
+; @resident shared
 HALT
 RET
 
 
 ; @name ZXN_SETIM2
+; @resident shared
 ; @calls VSYNC_JP
 ; HL = InterrultHandler
 ; DE = ($C5)($C4)   ; (CTC channel interrupts)(INT and ULA)
@@ -941,10 +987,12 @@ RET
 
 
 ; @name VSYNC_JP
+; @resident shared
 JP !VSYNC_PROC
 
 
 ; @name ZXNWORK
+; @resident shared
 ; @param_count 0
 ; @works LOCX:1,LOCY:1,SPL_SYS:1,ULA_CTRL:1,EULA_CTRL:1,L2_ACCESS:1,TILE_CTRL:1,TXTATR:1,TXTPLANE:1,FHEADER:8,SPTMP:2,WORK10:12
 ;

--- a/runtime/libzxn_file.asm
+++ b/runtime/libzxn_file.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name FOPEN
+; @resident shared
 ; @calls ZXNCALLS,ZXNWORK
 ; HL = fname addr, DE = mode
 PUSH IX
@@ -95,6 +96,7 @@ RET
 
 
 ; @name FCLOSE
+; @resident shared
 ; @calls ZXNCALLS,ZXNWORK
 ; HL = File Handle
 LD A,L
@@ -130,6 +132,7 @@ RET
 
 
 ; @name FSEEK
+; @resident shared
 ; @calls ZXNCALLS,ZXNWORK
 ; HL = file handle, DE = bytes to seek address, BC = mode
 PUSH IX
@@ -161,6 +164,7 @@ RET
 
 
 ; @name FSTAT
+; @resident shared
 ; @calls ZXNCALLS,ZXNWORK
 ; HL = file handle, DE = stat address
 PUSH IX
@@ -178,6 +182,7 @@ RET
 
 
 ; @name FREAD
+; @resident shared
 ; @calls ZXNCALLS,ZXNWORK
 ; HL = file handle, DE = address, BC = size
 PUSH IX
@@ -194,6 +199,7 @@ RET
 
 
 ; @name FWRITE
+; @resident shared
 ; @calls ZXNCALLS,ZXNWORK
 ; HL = file handle, DE = address, BC = size
 PUSH IX

--- a/runtime/libzxn_input.asm
+++ b/runtime/libzxn_input.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name INKEY
+; @resident shared
 ; @calls GETC
 ; 　入力されたキーの値を返す。
 ; 　　　n=0のときS-OSの#GETKYと同じ → リアルタイム入力。入力されたものをA。されてなければ0。
@@ -38,6 +39,7 @@ RET
 
 
 ; @name LINPUT
+; @resident shared
 ; 未実装
 ; LINPUT(格納アドレス, 長さ)
 ; コールし た時点のカーソル以降を続み込むほかはGETLlN関数と同じ。
@@ -45,6 +47,7 @@ RET
 
 
 ; @name GETL
+; @resident shared
 ; 未実装
 ; HL 格納アドレス
 ; キーボードから1行入力し，格納アドレスに格納し，行の長さを返す。
@@ -53,6 +56,7 @@ RET
 
 
 ; @name GETLIN
+; @resident shared
 ; 未実装
 ; GETLlN (格納アドレス, 長さ)
 ; 1行の最大長を指定できるほかは，GETL関数と同じ。オーバーした分は無視される。
@@ -60,6 +64,7 @@ RET
 
 
 ; @name INPUT
+; @resident shared
 ; 未実装
 ; キーボードから入力された数値を返す。先頭に$を付けると，16進数とみなす。
 ; コールした時点のカーソル以降を読み込み，正常な入力が行われた場合は^CARRY=0，
@@ -68,6 +73,7 @@ RET
 
 
 ; @name GETC
+; @resident shared
 ; @calls ZXNWORK,ZXNCALLS
 call KEY_SCAN
 jp nz, .EMPTY_INKEY
@@ -91,6 +97,7 @@ ret
 
 
 ; @name GETKEY
+; @resident shared
 LD A,L
 CP 8
 JR NC,.extendkey

--- a/runtime/libzxn_nextdaw.asm
+++ b/runtime/libzxn_nextdaw.asm
@@ -2,6 +2,7 @@
 ; SLANG Runtime Library (new format)
 
 ; @name ZXNDAWCALLS
+; @resident shared
 _NextDAW_PlayerAddr            EQU $E000                      ; Driver code address
 _NextDAW_InitSong              EQU _NextDAW_PlayerAddr+(3*0)    ; Initialize/set song to play.
 _NextDAW_UpdateSong            EQU _NextDAW_PlayerAddr+(3*1)    ; Call once per frame (NextDAW will automatically update at either 50Hz or 60Hz, depending on the Next's configuration).
@@ -19,6 +20,7 @@ _NextDAW_EnablePSGWrite        EQU _NextDAW_PlayerAddr+(3*12)   ; a: 0 = disable
 
 
 ; @name NextDAW_InitSystem
+; @resident shared
 ; @calls ZXNDAWCALLS
 ; L = mmu1
 ; E = mmu2
@@ -35,6 +37,7 @@ RET
 
 
 ; @name NextDAW_InitSong
+; @resident shared
 ; @calls ZXNDAWCALLS
 ; hl = data mapping table
 ; e  = force mono
@@ -54,6 +57,7 @@ RET
 
 
 ; @name NextDAW_UpdateSong
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -66,6 +70,7 @@ RET
 
 
 ; @name NextDAW_PlaySong
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -78,6 +83,7 @@ RET
 
 
 ; @name NextDAW_StopSong
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -90,6 +96,7 @@ RET
 
 
 ; @name NextDAW_StopSongHard
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -102,6 +109,7 @@ RET
 
 
 ; @name NextDAW_UpdateSongNoAY
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -114,6 +122,7 @@ RET
 
 
 ; @name NextDAW_UpdateAY
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -126,6 +135,7 @@ RET
 
 
 ; @name NextDAW_InitSFXBank
+; @resident shared
 ; @calls ZXNDAWCALLS
 ; L = bank index [0..3]
 ; E = sfx bank data page
@@ -150,6 +160,7 @@ RET
 
 
 ; @name NextDAW_PlaySFX
+; @resident shared
 ; @calls ZXNDAWCALLS
 ; L = bank index [0..3]
 ; E = sfx index [0..63]
@@ -168,6 +179,7 @@ RET
 
 
 ; @name NextDAW_UpdateSFX
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -180,6 +192,7 @@ RET
 
 
 ; @name NextDAW_GetPSGDataPtr
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY
@@ -192,6 +205,7 @@ RET
 
 
 ; @name NextDAW_EnablePSGWrite
+; @resident shared
 ; @calls ZXNDAWCALLS
 PUSH IX
 PUSH IY

--- a/runtime/libzxn_print.asm
+++ b/runtime/libzxn_print.asm
@@ -2,21 +2,25 @@
 ; SLANG Runtime Library (new format)
 
 ; @name WIDTH
+; @resident shared
 ; @param_count 1
 RET
 
 
 ; @name PRMODE
+; @resident shared
 ; @param_count 1
 RET
 
 
 ; @name SCREEN
+; @resident shared
 ; @param_count 2
 RET
 
 
 ; @name LOCATE
+; @resident shared
 ; @param_count 2
 LD H,E
 LD (LOCX),HL
@@ -24,6 +28,7 @@ RET
 
 
 ; @name PTAB
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 ; TAB -> Space
@@ -32,6 +37,7 @@ JR PCR1
 
 
 ; @name PSPC
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,' '
@@ -39,24 +45,28 @@ JR PCR1
 
 
 ; @name PCRONE
+; @resident shared
 ; @param_count 0
 ; @calls PCR
 LD HL,1
 
 
 ; @name PCR
+; @resident shared
 ; @param_count 1
 ; @calls PCR1
 LD E,$0D
 
 
 ; @name PCR1
+; @resident shared
 ; @param_count 1
 ; @calls PSTR
 EX DE,HL
 
 
 ; @name PSTR
+; @resident shared
 ; @param_count 2
 ; @calls PRT
 .pstr1
@@ -70,6 +80,7 @@ JR .pstr1
 
 
 ; @name PCHR
+; @resident shared
 ; @calls PRT
 LD A, H
 CALL PRT
@@ -78,12 +89,14 @@ JR PRT
 
 
 ; @name CRDISP
+; @resident shared
 ; @calls PRT
 LD A,$0D
 JR PRT
 
 
 ; @name PHEX4
+; @resident shared
 ; @param_count 1
 ; @calls PHEX2
 LD A,H
@@ -91,12 +104,14 @@ CALL PHEX
 
 
 ; @name PHEX2
+; @resident shared
 ; @param_count 1
 ; @calls PHEX
 LD A,L
 
 
 ; @name PHEX
+; @resident shared
 ; @param_count 1
 ; @calls SASC,PRT
 PUSH AF
@@ -112,6 +127,7 @@ CALL SASC
 
 
 ; @name PRT
+; @resident shared
 ; @param_count 1
 ; @calls ZXNWORK,GETLOCADR
 PUSH HL
@@ -186,6 +202,7 @@ RET
 
 
 ; @name GETLOCADR
+; @resident shared
 PUSH AF
 PUSH DE
 LD A,(LOCY)
@@ -209,6 +226,7 @@ RET
 
 
 ; @name PSIGN
+; @resident shared
 ; @param_count 1
 ; @calls PRT,NEGHL,P10
 BIT 7, H
@@ -220,6 +238,7 @@ CALL NEGHL
 
 
 ; @name P10
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10to5,P10toN
@@ -228,6 +247,7 @@ JR P10toN
 
 
 ; @name P10to5
+; @resident shared
 ; @param_count 1
 ; @function_type Machine
 ; @calls P10toN
@@ -235,6 +255,7 @@ LD DE, 0005
 
 
 ; @name P10toN
+; @resident shared
 ; @param_count 2
 ; @function_type Machine
 ; @calls PRT,VTOS,PMSX,ZXNWORK
@@ -266,11 +287,13 @@ JR .p10ton4
 
 
 ; @name PMSX
+; @resident shared
 ; @calls PMSX1
 LD B, 00
 
 
 ; @name PMSX1
+; @resident shared
 ; @calls PRT,PMSG
 LD A, (HL)
 CP B
@@ -281,12 +304,14 @@ JR PMSX1
 
 
 ; @name PMSG
+; @resident shared
 ; @calls PMSX1
 LD B, $0D
 JR PMSX1
 
 
 ; @name MPRNT
+; @resident shared
 ; @calls PRT
 EX (SP),HL
 .mprnt2
@@ -302,6 +327,7 @@ RET
 
 
 ; @name COLOR
+; @resident shared
 ; @calls ZXNWORK
 LD A,(TXTATR)
 AND $F0

--- a/tools/resident-apply.py
+++ b/tools/resident-apply.py
@@ -134,6 +134,170 @@ OVERRIDES = {
         # PR-C1 はまず保守的に local。後で再評価。
         "M8ALOAD": "local",
     },
+
+    # ---- PR-C2: 横展開 env ----
+    # MSX 系
+    "libmsxlsx_base.asm": {
+        "SLANGINIT": "local",  # main inline only
+        # 残りは liblsx_base と同パターン (work 変数書き込み = false positive)
+        "sLOC":      "shared",
+        "sGETL":     "shared",
+        "sFGETL":    "shared",
+        "sINKBF":    "shared",
+        "sKYBFC":    "shared",
+        "sPRINT":    "shared",
+        "sPCLR":     "shared",
+    },
+    "libmsx_grp.asm": {
+        "MSX_SET_COLOR": "shared",  # BAKCLR/BDRCLR/FORCLR/VDP_ATTR は MSX system var (= work)
+    },
+    "libmsx_iot.asm": {
+        "IOTGET_STR": "shared",  # HL register false-positive
+    },
+    "libmsx_psg.asm": {
+        # SOUNDDRV_STATE は work module var, IX は register, H_TIMI は MSX BIOS hook
+        "PSG_INIT":   "shared",
+        "PSG_PLAY":   "shared",
+        "PSG_SFX":    "shared",
+        "PSG_STOP":   "shared",
+        "PSG_PAUSE":  "shared",
+        "PSG_RESUME": "shared",
+        "PSG_PROC":   "shared",
+    },
+    "libmsx_spdrv.asm": {
+        # MSXSPDRV.sprite_* は module-prefixed work
+        "SPDRV_INITIALIZE":  "shared",
+        "SPDRV_FLIP":        "shared",
+        "SPDRV_UPDATE":      "shared",
+        "SPDRV2_INITIALIZE": "shared",
+        "SPDRV2_FLIP":       "shared",
+        "SPDRV2_UPDATE":     "shared",
+    },
+    "libmsx2_file.asm": {
+        "FOPEN": "shared",  # HL register / LSXFCB,LSXFMODE work
+    },
+    "libmsxrom_base.asm": {
+        "SLANGINIT": "local",  # main inline only
+    },
+    "libmsxrom_print.asm": {
+        "WIDTH": "shared",  # LINL40 は MSX system var (= work)
+        "VTOS":  "shared",  # HL register false-positive
+    },
+
+    # SOS 系
+    "libsos_base.asm": {
+        "SLANGINIT": "local",
+    },
+    "libsosx1_base.asm": {
+        "SLANGINIT": "local",
+    },
+    "libsos_input.asm": {
+        "GETLIN": "shared",
+        "INPUT":  "shared",
+    },
+    "libsos_print.asm": {
+        "WIDTH":  "shared",  # AT_WIDTH は work
+        "PRMODE": "local",   # PRT+1 を patch する真の self-mod
+    },
+    "libsos_file.asm": {
+        # FILEWORKS data carrier (SPACEOS/DIREND/sDSK) を共有
+        "FOPEN":    "shared",
+        "FPG":      "shared",
+        "FCLOSE":   "shared",
+        "FILEUTIL": "shared",
+    },
+    "libsos_pcg.asm": {
+        "PCGDEF": "shared",  # PCG_NODISPADR は関数内 inline data
+    },
+
+    # PC-8001/8801 系
+    "libpc80mk2_base.asm": {
+        "SLANGINIT":   "local",
+        "MEMMODE":     "shared",  # HL register
+        "CMDSCREEN":   "shared",  # N80WORK.PORT31 work
+        "KANJILOCATE": "shared",  # KanjiX/KanjiY work
+        "KANJIPUT":    "shared",  # KanjiVRAM/KanjiX/KanjiY work + hl register
+    },
+    "libpc80mk2_print.asm": {
+        "CTRL0D": "shared",  # _TXADR work
+        "VTOS":   "shared",  # HL register
+        "SETATR": "shared",  # hl register
+    },
+    "libpc80mk2_sound.asm": {
+        "SND_SYNC": "shared",  # SND.BLANKFLG work
+    },
+    "libpc80mk2xbios_base.asm": {
+        "SLANGINIT":   "local",
+        "MEMMODE":     "shared",  # HL register
+        "CMDSCREEN":   "shared",  # XBIOS.PORT31 work
+        "SD_UTIL":     "shared",  # XBIOS.PORT31 work
+        "KANJILOCATE": "shared",
+        "KANJIPUT":    "shared",
+        "SET_PORT31":  "shared",  # XBIOS.PORT31 work
+    },
+    "libpc80mk2xbios_input.asm": {
+        "GETLIN": "shared",
+        "INPUT":  "shared",
+    },
+    "libpc80mk2xbios_print.asm": {
+        "WIDTH":  "shared",  # AT_WIDTH work
+        "PRMODE": "local",   # PRT+1 を patch する真の self-mod
+    },
+    "libp88_base.asm": {
+        "SLANGINIT": "local",
+        "PSET":      "local",   # PSETADR/PSETCOLOR の operand を patch する真の self-mod
+        "SETGRP":    "shared",  # IO32H は @works
+        "P88INT":    "shared",  # IO32H は @works
+    },
+    "libp88_print.asm": {
+        # P88PCOMMON data carrier 経由で LOCX/LOCY を共有
+        "LOCATE": "shared",
+        "PRT":    "shared",
+    },
+
+    # x1 SGL (sosx1 用、libx1_sgl_lsx と同パターン)
+    "libx1_sgl.asm": {
+        "X1SGLINCLUDE":   "shared",
+        "SGL_SPRDESTROY": "shared",
+        "SGL_SPRDISP":    "shared",
+        "SGL_FPSMODE":    "shared",
+    },
+
+    # VGS-Zero
+    "libvgs0_base.asm": {
+        "SLANGINIT":       "local",
+        "vgs0_oam_set16":  "shared",  # HL register false-positive
+        "vgs0_oam_set":    "shared",
+    },
+    "libvgs0_print.asm": {
+        # LOCX/LOCY/TXTATR/TXTPLANE は work 相当のシステム var
+        "LOCATE":    "shared",
+        "PRT":       "shared",
+        "COLOR":     "shared",
+        "TEXTPLANE": "shared",
+    },
+
+    # ZX Spectrum Next
+    "libzxn_base.asm": {
+        "SLANGINIT":      "local",
+        # 以下は ULA_CTRL/EULA_CTRL/L2_ACCESS/TILE_CTRL/SPL_SYS の HW register
+        # I/O port 風アクセスへの書き込みのみ (= 真の self-mod ではない)
+        "ULA_VISIBLE":    "shared",
+        "SET_PAL":        "shared",
+        "SET_PALALL":     "shared",
+        "SET_PAL9":       "shared",
+        "SET_PAL9ALL":    "shared",
+        "L2_VISIBLE":     "shared",
+        "TILE_INIT":      "shared",
+        "TILE_VISIBLE":   "shared",
+        "LAYER_PRIORITY": "shared",
+        "SPR_VISIBLE":    "shared",
+    },
+    "libzxn_print.asm": {
+        "LOCATE": "shared",
+        "PRT":    "shared",
+        "COLOR":  "shared",
+    },
 }
 
 


### PR DESCRIPTION
## Summary

**新規機能は無い、PR-C1 (#149) の resident annotation を残り 10 env (msxlsx / msx2 / msxrom / sos / sosx1 / pc80mk2 / pc80mk2x / pc88mk2sr / vgs0 / zxn) に横展開するだけ**。

新規ファイル / 新規テスト / 新規ロジック追加なし。`tools/resident-apply.py` の OVERRIDES マップに 30 ファイル分の判定を追加し、env ごとに 1 commit で適用。

## ベース

- base: `feature/runtime-resident-attrs` (PR-C1 #149)
- 依存: PR-C1 で導入した `tools/resident-audit.py` / `tools/resident-apply.py` / `RuntimePolicy` / `RuntimePlanner` / `RESIDENT` ポリシー

## 内訳 (env ごと)

| env | 対象 .asm | shared | local | smoke |
|---|---|---|---|---|
| msxlsx | libmsxlsx_base, libmsx_psg, libmsx_iot, libmsx_grp, libmsx_spdrv | 81 | 1 (SLANGINIT) | `slangc -E msxlsx examples/MSXLSX.SL` ✓ |
| msx2 | libmsx2_file | 9 | 0 | `slangc -E msx2 examples/STARS.SL` ✓ |
| msxrom | libmsxrom_base, libmsxrom_print, libmsxrom_input | 31 | 1 (SLANGINIT) | `slangc -E msxrom examples/MSXROM.SL` ✓ |
| sos | libsos_base, libsos_input, libsos_print, libsos_file | 42 | 2 (SLANGINIT, PRMODE) | `slangc -E sos examples/STARS.SL` ✓ |
| sosx1 | libsosx1_base, libsos_pcg, libx1_sgl | 19 | 1 (SLANGINIT) | `slangc -E sosx1 examples/STARS_X1.SL` ✓ |
| pc80mk2 | libpc80mk2_base, libpc80mk2_print, libpc80mk2_sound | 59 | 1 (SLANGINIT) | `slangc -E pc80mk2 examples/PC80mk2.SL` + `AILZ80ASM` ✓ (0 err/warn) |
| pc80mk2x | libpc80mk2xbios_base, libpc80mk2xbios_print, libpc80mk2xbios_input | 57 | 2 (SLANGINIT, PRMODE) | `slangc -E pc80mk2x examples/STARS.SL` + `AILZ80ASM` ✓ (0 err/warn) |
| pc88mk2sr | libp88_base, libp88_print, libp88_file | 36 | 2 (SLANGINIT, PSET) | `slangc -E pc88mk2sr examples/STARS.SL` ✓ (AILZ80ASM は pre-existing なユーザー側 `GAMEVSYNC`/`INKEY` 未定義のみ、本変更による新規エラーなし) |
| vgs0 | libvgs0_base, libvgs0_print | 81 | 1 (SLANGINIT) | `slangc -E vgs0 examples/STARS.SL` ✓ |
| zxn | libzxn_base, libzxn_print, libzxn_input, libzxn_file, libzxn_nextdaw | 100 | 1 (SLANGINIT) | `slangc -E zxn examples/STARS.SL` ✓ |
| **PR-C2 計** | **30 ファイル** | **shared 515** | **local 12** | **計 527 関数** |

PR-C1 (lsx/x1) と合わせた **全 env 累計: shared 773 + local 14 = 787 関数**。

## local 化した関数 (PR-C2 で新規)

| 関数 | 理由 |
|---|---|
| `libsos_print.PRMODE` | `LD (PRT+1),HL` で印字モード切替の operand patch (真の self-mod) |
| `libpc80mk2xbios_print.PRMODE` | 同上 |
| `libp88_base.PSET` | `LD (PSETADR+1),A` / `LD (PSETCOLOR+1),A` の operand patch |
| 各 base の `SLANGINIT` × 8 | main inline 専用 (`RuntimePlanner.MainInlineFunctions` 経由で固定) |

その他 100 件以上の audit `local_forced` は false positive (work 変数書き込み / レジスタ間接 / module-prefixed work / HW register) と判定して shared に override。詳細は `tools/resident-apply.py` の OVERRIDES マップにコメント付きで集約。

## 検証

- 全テスト **190 / 190 合格** (`dotnet test`、PR-C1 と同じ test base、回帰なし)
- env ごとに `slangc -E <env>` のスモークテストが上の表の通り通過
- pc80mk2 / pc80mk2x は `AILZ80ASM` までのフルアセンブルで `0 error/warn` (#145 系統のため厚めに)
- pc88mk2sr の `AILZ80ASM` 未通過は **pre-existing** (ROM env がユーザー側 `GAMEVSYNC`/`INKEY` 定義を要求する仕様)

## 実機検証

PR-C1 の `examples/MODTEST_RESIDENT.SL` 同等のサンプルは本 PR では追加せず。各 env の overlay swap loader 仕組みは個別に異なるため、実機サンプル整備は別 PR とする。

## Commit 構成

```
992c69a docs: CHANGELOG に PR-C2 (他 10 env 横展開) を追記
29bd0c3 runtime: zxn 環境に @resident 付与 (PR-C2)
7f7e241 runtime: vgs0 環境に @resident 付与 (PR-C2)
8873610 runtime: pc88mk2sr 環境に @resident 付与 (PR-C2)
d8c1e34 runtime: pc80mk2x 環境に @resident 付与 (PR-C2)
04f0886 runtime: pc80mk2 環境に @resident 付与 (PR-C2)
069ad0e runtime: sosx1 環境に @resident 付与 (PR-C2)
006738e runtime: sos 環境に @resident 付与 (PR-C2)
6ac3dc2 runtime: msxrom 環境に @resident 付与 (PR-C2)
ffff8d0 runtime: msx2 環境に @resident 付与 (PR-C2)
cdca251 runtime: msxlsx 環境に @resident 付与 (PR-C2)
e4650af tools/resident-apply.py: PR-C2 横展開用 OVERRIDES を追加  ← 判定マトリクス集約
```

## Test plan

- [x] OVERRIDES マップに 30 ファイル分の判定を追加 (1 commit)
- [x] env ごとに apply + smoke + commit (10 commits)
- [x] CHANGELOG 追記 (1 commit)
- [x] `dotnet test` 190/190 合格
- [x] 各 env で `slangc -E <env> examples/...` 成功確認
- [x] pc80mk2 / pc80mk2x は AILZ80ASM 段までフル通過確認
- [ ] レビュー後マージ順: PR-C1 (#149) → 本 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
