### PR TITLE
fix(slangbuild): overlay glob を _m<digits>.ASM 厳密一致に (--keep-asm 後の無限ループ修正)

### DIFF
--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -98,7 +98,15 @@ public class Driver
             if (File.Exists(incPath)) intermediates.Add(incPath);
 
             // overlay ASM の検出 (`<prefix>._mN.ASM`、outputDir 内)
+            // case-insensitive な FS (macOS APFS / Windows) では `_m*.ASM` パターンが
+            // 旧 `--keep-asm` 残骸の `.dummy.imports.asm` / `.imports.asm` まで拾い、
+            // 次回以降のビルドで filename チェーン爆発を起こす。
+            // `_m<digits>.ASM` 厳密一致の regex でフィルタする。
+            var overlayPattern = new System.Text.RegularExpressions.Regex(
+                $"^{System.Text.RegularExpressions.Regex.Escape(prefix)}\\._m\\d+\\.ASM$",
+                System.Text.RegularExpressions.RegexOptions.IgnoreCase);
             var overlayAsms = Directory.GetFiles(outputDir, prefix + "._m*.ASM")
+                                       .Where(p => overlayPattern.IsMatch(Path.GetFileName(p)))
                                        .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
                                        .ToList();
             foreach (var p in overlayAsms) intermediates.Add(p);


### PR DESCRIPTION
## 症状

```bash
./slangbuild --keep-asm --verbose -E x1 examples/MODTEST.SL  # 1 回目: 成功、残骸あり
./slangbuild --keep-asm --verbose -E x1 examples/MODTEST.SL  # 2 回目: 無限ループ
```

verbose 出力で AILZ80ASM 呼び出しのファイル名が `MODTEST._m0.dummy.imports.imports.imports.dummy.imports.dummy.imports.asm` のように `dummy.imports` を繰り返して伸び続け、終わらない。

## 原因

`Driver.cs:101` の `Directory.GetFiles(outputDir, "<prefix>._m*.ASM")` が **case-insensitive な filesystem (macOS APFS / Windows)** では、`.asm` (lowercase) で書かれた `--keep-asm` 残骸ファイル (`<prefix>._m0.dummy.imports.asm` / `.imports.asm`) まで一致してしまう。

これらが overlay 候補として `PrelinkPlan` に投入され、Pass 1 で更に新しい dummy/imports suffix が付与され、それも次の build run で overlay 扱いされ… と再帰的にチェーンが伸びる。

## 修正

`Where` で post-filter して **`^<prefix>._m\d+\.ASM$` 厳密一致** のものだけを残す。`Directory.GetFiles` の glob 自体は変えないので既存挙動と互換。

```csharp
var overlayPattern = new Regex(
    $"^{Regex.Escape(prefix)}\\._m\\d+\\.ASM$",
    RegexOptions.IgnoreCase);
var overlayAsms = Directory.GetFiles(outputDir, prefix + "._m*.ASM")
                           .Where(p => overlayPattern.IsMatch(Path.GetFileName(p)))
                           .OrderBy(...).ToList();
```

## 検証

- 修正前: `--keep-asm` 連続 2 回目で必ず無限ループ
- 修正後: 残骸付きで `--keep-asm` を 3 回連続実行しても全て <15s で成功完了、ファイル数 21 個固定 (チェーン爆発なし)
- `dotnet test` 192/192 合格

## Test plan

- [x] `--keep-asm` 連続実行が成功すること
- [x] 残骸 `<prefix>._m0.dummy.imports.asm` 存在下でも overlay 候補に拾われないこと
- [x] `dotnet test` 192/192 合格
- [ ] レビュー後マージ → 既存 `feature/overlay-loader-sample` (PR #151) は本 PR マージ後に rebase しておく (Driver.cs の競合は無いはず)

🤖 Generated with [Claude Code](https://claude.com/claude-code)