### PR TITLE
libcpm_file scope B: FREAD/FWRITE multi-record + FGETC/FPUTC active-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased (v0.23.0 候補)
 
+- `runtime/libcpm_file.asm` の scope B 拡張: 汎用 file API として動作可能に
+  - `FREAD` / `FWRITE` を **record-aligned multi-record loop** 化 (size パラメータを honor、返り値 = 実際に読み/書きできた records × 128)
+  - `FGETC` / `FPUTC` を **single-active-buffer 方式** で実装 (128 byte 内部バッファ + 1 active fnum + read/write mode 排他)
+  - 新規 `examples/CPMIOTEST.SL` を追加し RunCPM 上で end-to-end 検証 (FGETC/FPUTC 200 byte round-trip + FREAD multi-record + FREAD partial 動作確認)
+  - **制約 (重要)**:
+    - `FREAD` / `FWRITE` は record-aligned (128 byte 単位)、size の 128 未満端数は切り捨て (sub-record 精度なし)。任意 byte 単位が必要なら `FGETC` / `FPUTC` を使う
+    - 同一 fnum で `FGETC` / `FPUTC` の **read/write mode 切替は未サポート** — `FCLOSE` → `FOPEN` で reopen 必須 (= サイレント誤動作を防ぐため、未サポート組合せは $FF を返す)
+    - 同一 open file で `FGETC` / `FPUTC` と `FREAD` / `FWRITE` / `FSEEK` を混在させるのは未サポート — 後者の呼び出し時に active buffer は invalidate される
+    - lsx 完全互換ではない (lsx の FREAD は CP/M 3+ の variable record size を使い、任意 byte 数を正確に R/W できる)
+    - 128 byte 境界整数倍ファイルなら `FREAD` / `FWRITE` で正確にコピー可能。slcopy.sl を cpm で動かす場合は対象ファイルが 128B 境界であることを caller が保証するか、`FGETC` を loop する必要がある
+  - `FPUTC` は write mode 入口時 / flush 後に ACTBUF を 0 で初期化 (= partial record の tail が stale data 漏れせず確定 0 になる)
+  - work 領域増加: 132 byte (ACTBUF + state)。cpm 全体で ~858 → ~990 byte
+  - bug fix (実装中に発見): `FPUTC` 初期化時の `LDIR` (ACTBUF 0 クリア) が DE レジスタを破壊し、初回 byte が garbage 値で書かれる問題を修正 (`PUSH DE` / `POP DE` で chr 引数を保護)
+
 - cpm 環境向け file ライブラリ `runtime/libcpm_file.asm` を新設
   - `liblsx_file.asm` のコピー + CP/M 2.2 互換書き換え (random access `_RDRND` $21 / `_WRRND` $22 ベース、`liblsx_file` の CP/M 3+ `_RDBLK` $27 / `_WRBLK` $26 が RunCPM で動作しない問題を解消)
   - `runtime/env/cpm.env` の参照を `liblsx_file.yml` → `libcpm_file.yml` に切り替え。lsx / x1 等他 env は引き続き `liblsx_file.asm` を使用、影響なし

--- a/examples/CPMIOTEST.SL
+++ b/examples/CPMIOTEST.SL
@@ -12,6 +12,9 @@
     - 期待: 256 が返る
   Test 4: FREAD partial (200B = 1.56 records)
     - 期待: 128 が返る (= floor(200/128) * 128)
+  Test 5: 別 fnum 切替 (active buffer の fnum 切替パスを exercise)
+    - fnum 0 に FPUTC → fnum 1 に FPUTC で切替時 flush
+    - HL/DE が ACTBUF_FLUSH で保護されることを確認
 
   ★ 整合仕様準拠: 各テスト間で必ず FCLOSE → FOPEN している
     (= 同一 open file 内で FGETC/FPUTC と FREAD/FWRITE/FSEEK の混在は
@@ -53,4 +56,31 @@ MAIN()
 	READ_COUNT = FREAD(0, $5100, 200);
 	PRINT("FREAD(200) returned ", READ_COUNT, /);  /* expected: 128 */
 	FCLOSE(0);
+
+	/* === Test 5: 別 fnum 切替 (HL/DE 保護パス) === */
+	FOPEN(0, "AAA.DAT", 3);
+	FOPEN(1, "BBB.DAT", 3);
+	FPUTC(0, $41);                                /* 'A' to fnum 0 */
+	FPUTC(1, $42);                                /* 'B' to fnum 1, fnum 切替時に
+	                                                  fnum 0 の dirty buffer を flush */
+	FCLOSE(0);
+	FCLOSE(1);
+	/* 検証: AAA.DAT の先頭が 'A' であること */
+	FOPEN(0, "AAA.DAT", 0);
+	READ_VAL = FGETC(0);
+	IF READ_VAL != $41 THEN BEGIN
+		PRINT("Test 5 FAIL: AAA.DAT[0]=", READ_VAL, /);
+		FCLOSE(0);
+		RETURN;
+	END;
+	FCLOSE(0);
+	FOPEN(1, "BBB.DAT", 0);
+	READ_VAL = FGETC(1);
+	IF READ_VAL != $42 THEN BEGIN
+		PRINT("Test 5 FAIL: BBB.DAT[0]=", READ_VAL, /);
+		FCLOSE(1);
+		RETURN;
+	END;
+	FCLOSE(1);
+	PRINT("Test 5 fnum switch OK", /);
 }

--- a/examples/CPMIOTEST.SL
+++ b/examples/CPMIOTEST.SL
@@ -1,0 +1,56 @@
+/*
+  cpm 環境 file I/O 検証 sample (libcpm_file scope B 用)
+
+  Test 1: FPUTC で 200 byte 書く
+    - I=128 で auto-flush 1 record
+    - FCLOSE で残り 72 byte が dirty として flush
+    - 残り 56 byte は ACTBUF の 0 padding (= stale data 漏れなし)
+  Test 2: 同 fnum を reopen し FGETC で 200 byte 読む
+    - read mode で再 open (write→read 切替は close 経由のみ)
+    - 期待: 0..199 の値を順に読み出せる
+  Test 3: FREAD multi-record (record-aligned 動作確認、256B = 2 records)
+    - 期待: 256 が返る
+  Test 4: FREAD partial (200B = 1.56 records)
+    - 期待: 128 が返る (= floor(200/128) * 128)
+
+  ★ 整合仕様準拠: 各テスト間で必ず FCLOSE → FOPEN している
+    (= 同一 open file 内で FGETC/FPUTC と FREAD/FWRITE/FSEEK の混在は
+    未サポート、reopen で切替)。
+*/
+
+VAR I, READ_VAL, READ_COUNT;
+
+MAIN()
+{
+	/* === Test 1: FPUTC × 200 + close で flush === */
+	FOPEN(0, "TEST.DAT", 3);   /* mode 3 = create */
+	FOR I=0 TO 199 BEGIN
+		FPUTC(0, I & $FF);
+	END;
+	FCLOSE(0);
+
+	/* === Test 2: FGETC × 200 で同じ値が読める === */
+	FOPEN(0, "TEST.DAT", 0);
+	FOR I=0 TO 199 BEGIN
+		READ_VAL = FGETC(0);
+		IF READ_VAL != (I & $FF) THEN BEGIN
+			PRINT("FGETC mismatch at ", I, ": got ", READ_VAL, /);
+			FCLOSE(0);
+			RETURN;
+		END;
+	END;
+	FCLOSE(0);
+	PRINT("FGETC/FPUTC OK", /);
+
+	/* === Test 3: FREAD multi-record (256 byte = 2 records) === */
+	FOPEN(0, "TEST.DAT", 0);
+	READ_COUNT = FREAD(0, $5000, 256);
+	PRINT("FREAD(256) returned ", READ_COUNT, /);  /* expected: 256 */
+	FCLOSE(0);
+
+	/* === Test 4: FREAD partial (200B = floor → 128) === */
+	FOPEN(0, "TEST.DAT", 0);
+	READ_COUNT = FREAD(0, $5100, 200);
+	PRINT("FREAD(200) returned ", READ_COUNT, /);  /* expected: 128 */
+	FCLOSE(0);
+}

--- a/runtime/libcpm_file.asm
+++ b/runtime/libcpm_file.asm
@@ -3,25 +3,39 @@
 ; liblsx_file.asm のコピー + 以下の差分:
 ;   - FREAD/FWRITE: CP/M 3+ の _RDBLK ($27) / _WRBLK ($26) を CP/M 2.2 互換の
 ;                   random access (_RDRND $21 / _WRRND $22) に置換
-;                   (= 1 record/128 byte 固定、FCB+33..36 の random record を honor)
+;                   (= record-aligned multi-record loop、FCB+33..36 の random
+;                   record を honor)
 ;   - FCBRECINC: 内部 helper、FREAD/FWRITE 成功時に FCB+33..36 を +1 して
 ;                sequential semantics を維持 (_RDRND/_WRRND は auto-increment しない)
-;   - FGETC/FPUTC: スタブ ($FF return) — scope B で 128 byte 内部バッファ実装予定
+;   - FGETC/FPUTC: 単一 active fnum の 128 byte 内部バッファ方式
+;   - ACTBUF_FLUSH: 内部 helper、dirty バッファを書き戻す + 0 クリア
 ;   - FREADWRITE: 廃止 (set record size 1 は CP/M 3+ 機能)
 ;
 ; 同名関数 (FOPEN/FREAD 等) と work 変数 (LSXFCB/LSXFMODE/LSXFCBS) は liblsx_file
 ; と完全に同じ。env では cpm.env のみがこのファイルを参照、liblsx_file は他 env
 ; が継続使用するので衝突しない。
 ;
-; scope A 制約 (本 PR 範囲):
-;   FREAD: 1 record (128 byte) 固定 read、size パラメータは無視
-;   FWRITE: 1 record 固定 write
-;   FSEEK: FCB+33..36 を更新、FREAD/FWRITE と整合 (= seek 後の 1 record I/O が動作)
-;   FGETC/FPUTC: 未実装 ($FF を return)
+; ★ FREAD/FWRITE は record-aligned (128 byte 単位)。返り値は実際に読み/書き
+;   できた bytes (= records × 128)。size の「128 未満の端数」は切り捨て、
+;   sub-record 精度が必要なら caller は FGETC/FPUTC を使う。EOF は HL=0、
+;   error は HL=$FFFF。
 ;
-; scope B (follow-up PR):
-;   FREAD/FWRITE を size に応じて multi-record loop 化、FGETC/FPUTC を 128 byte
-;   buffer + offset 管理で実装
+; ★ FGETC/FPUTC の制約:
+;   - 単一アクティブバッファ方式。同 fnum + 同 mode (連続 FGETC または連続
+;     FPUTC) は OK。別 fnum へ切替時は自動 (read=reload, write=auto flush)
+;   - **同一 fnum で read/write mode 切替は未サポート** — FCLOSE → FOPEN で
+;     reopen 必須。サイレント誤動作を防ぐため未サポート組合せは $FF を返す
+;   - FPUTC は write mode 入口時 / flush 後に ACTBUF を 0 で初期化
+;     (= partial record でも残り部分は 0 で埋まる、stale data 漏れなし)
+;
+; ★ 同一 open file で FGETC/FPUTC と FREAD/FWRITE/FSEEK を混在させるのは
+;   未サポート。FREAD/FWRITE/FSEEK 呼び出し時に active buffer は invalidate
+;   される。混在したい場合は FCLOSE → FOPEN で reopen する。
+;
+; ★ lsx 完全互換ではない。lsx の FREAD は CP/M 3+ の variable record size を
+;   使うので任意 byte 数を正確に R/W できるが、cpm は record-aligned + active
+;   buffered byte I/O の組み合わせ。128B 境界整数倍ファイル + 単一 active
+;   fnum 用途で実用的。
 
 ; @name LSXFILE
 ; @resident shared
@@ -273,8 +287,10 @@ RET
 
 ; @name FSEEK
 ; @resident shared
-; @calls LSXCALLS,FWORK,LSXFILE,NEGHL
+; @calls LSXCALLS,FWORK,LSXFILE,NEGHL,ACTBUF_INVALIDATE
 ; HL=fnum DE=offset BC=mode(0=head, 1=current, 2=tail)
+;
+; 同 fnum が active buffer なら invalidate (= seek 後の論理位置ズレ防止)。
 CALL LSXFCHECKNUM
 JP C,.fseek1
 ; return $FF
@@ -282,6 +298,22 @@ LD HL,255
 RET
 
 .fseek1
+; active buffer 整合: 同 fnum ならフラッシュ + 状態クリア
+PUSH HL
+PUSH DE
+PUSH BC
+LD A,(ACTBUFMODE)
+OR A
+JR Z,.fseek_skip_inv
+LD A,(ACTBUFFNUM)
+CP L
+JR NZ,.fseek_skip_inv
+CALL ACTBUF_INVALIDATE
+.fseek_skip_inv
+POP BC
+POP DE
+POP HL
+
 ; LSXFCB=fnum*37+LSXFCBS
 CALL LSXCALCFCB
 LD (LSXFCB),HL
@@ -369,34 +401,204 @@ RET
 
 ; @name FGETC
 ; @resident shared
-; @calls LSXCALLS,FWORK,LSXFILE
+; @calls LSXCALLS,FWORK,LSXFILE,FCBRECINC,ACTBUF_FLUSH
 ; HL=fnum
 ;
-; scope A スタブ: 常に $FF (失敗) を返す。
-; scope B で 128 byte 内部バッファ + offset 管理で実装予定。
-; (CP/M 2.2 は record size = 1 byte の連続 read をサポートしないため、
-;  buffered read に切り替える必要がある。)
+; 単一アクティブバッファ方式 (read mode)。同 fnum + read mode なら ACTBUF
+; から続きを返す、必要なら _RDRND で次 record を ACTBUF へ補充。
+; 異 fnum なら自動切替 (write 時は前 fnum の dirty を flush)。
+; 同 fnum + 異 mode (write→read) は未サポート → $FF01 を返す。
 
-LD HL,255
+CALL LSXFCHECKNUM
+JP C,.fgetc1
+LD HL,$FF01            ; bad fnum
+SCF
+RET
+
+.fgetc1
+; mode 切替判定
+LD A,(ACTBUFMODE)
+OR A
+JR Z,.fgetc_init       ; mode==0 → 初期化
+; mode != 0
+LD A,(ACTBUFFNUM)
+CP L
+JR NZ,.fgetc_switch    ; 別 fnum → 切替
+; 同 fnum
+LD A,(ACTBUFMODE)
+CP 1
+JR Z,.fgetc_serve      ; 同 fnum + read → 続行
+; 同 fnum + write → 未サポート
+LD HL,$FF01
+SCF
+RET
+
+.fgetc_switch
+; 別 fnum: 既存 active を flush (write の場合)
+CALL ACTBUF_FLUSH
+.fgetc_init
+; ACTBUFFNUM = L (fnum)
+LD A,L
+LD (ACTBUFFNUM),A
+LD A,1                 ; read mode
+LD (ACTBUFMODE),A
+LD A,128               ; force reload sentinel
+LD (ACTBUFOFS),A
+XOR A
+LD (ACTBUFDIRTY),A
+; LSXFCB を当該 fnum に設定 (reload で必要)
+CALL LSXCALCFCB
+LD (LSXFCB),HL
+
+.fgetc_serve
+; ACTBUFOFS == 128 なら reload
+LD A,(ACTBUFOFS)
+CP 128
+JR NZ,.fgetc_return
+; reload: ACTBUFFNUM の current random record から ACTBUF へ
+LD A,(ACTBUFFNUM)
+LD L,A
+LD H,0
+CALL LSXCALCFCB
+LD (LSXFCB),HL
+; SETDTA = ACTBUF
+LD DE,ACTBUF
+LD C,$1A
+PUSH IY
+CALL BDOS
+POP IY
+; _RDRND
+LD DE,(LSXFCB)
+LD C,$21
+PUSH IY
+CALL BDOS
+POP IY
+OR A
+JR NZ,.fgetc_eof_or_err
+; success: advance random record, reset offset
+CALL FCBRECINC
+XOR A
+LD (ACTBUFOFS),A
+
+.fgetc_return
+; return ACTBUF[ACTBUFOFS], ACTBUFOFS++
+LD A,(ACTBUFOFS)
+LD E,A
+LD D,0
+LD HL,ACTBUF
+ADD HL,DE
+LD A,(HL)              ; A = byte
+; ACTBUFOFS++
+LD HL,ACTBUFOFS
+INC (HL)
+LD L,A                 ; HL = 0..$FF
+LD H,0
+RET
+
+.fgetc_eof_or_err
+LD HL,$FF01            ; EOF / error
+SCF
 RET
 
 
 ; @name FPUTC
 ; @resident shared
-; @calls LSXCALLS,FWORK,LSXFILE
+; @calls LSXCALLS,FWORK,LSXFILE,FCBRECINC,ACTBUF_FLUSH
 ; HL=fnum DE=chr
 ;
-; scope A スタブ: 常に $FF (失敗) を返す。
-; scope B で 128 byte 内部バッファ + flush で実装予定。
+; 単一アクティブバッファ方式 (write mode)。同 fnum + write mode なら
+; ACTBUF[ACTBUFOFS]=chr、ACTBUFOFS == 128 で auto-flush。
+; 異 fnum なら自動切替、同 fnum + 異 mode (read→write) は未サポート → $FF。
 
+CALL LSXFCHECKNUM
+JP C,.fputc1
 LD HL,255
+RET
+
+.fputc1
+; mode 切替判定
+LD A,(ACTBUFMODE)
+OR A
+JR Z,.fputc_init       ; mode==0 → 初期化
+LD A,(ACTBUFFNUM)
+CP L
+JR NZ,.fputc_switch    ; 別 fnum → 切替
+LD A,(ACTBUFMODE)
+CP 2
+JR Z,.fputc_serve      ; 同 fnum + write → 続行
+; 同 fnum + read → 未サポート
+LD HL,255
+RET
+
+.fputc_switch
+; 別 fnum: 既存 active を flush (write の場合)
+CALL ACTBUF_FLUSH
+.fputc_init
+; chr (DE) を保存 (LDIR で DE が破壊されるため)
+PUSH DE
+; ACTBUFFNUM = L (fnum)
+LD A,L
+LD (ACTBUFFNUM),A
+LD A,2                 ; write mode
+LD (ACTBUFMODE),A
+XOR A
+LD (ACTBUFOFS),A
+LD (ACTBUFDIRTY),A
+; LSXFCB を当該 fnum に設定
+CALL LSXCALCFCB
+LD (LSXFCB),HL
+; ACTBUF を 0 で 128 byte クリア (= partial record の tail を 0 padding)
+LD HL,ACTBUF
+LD DE,ACTBUF+1
+LD BC,127
+LD (HL),0
+LDIR
+; chr 復元
+POP DE
+
+.fputc_serve
+; ACTBUF[ACTBUFOFS] = chr (E)
+LD A,(ACTBUFOFS)
+LD L,A
+LD H,0
+LD BC,ACTBUF
+ADD HL,BC
+LD (HL),E              ; store chr
+; ACTBUFOFS++
+LD HL,ACTBUFOFS
+INC (HL)
+; ACTBUFDIRTY = 1
+LD A,1
+LD (ACTBUFDIRTY),A
+; if ACTBUFOFS == 128 then flush
+LD A,(ACTBUFOFS)
+CP 128
+JR NZ,.fputc_done
+CALL ACTBUF_FLUSH
+.fputc_done
+LD HL,0
 RET
 
 
 ; @name FCLOSE
 ; @resident shared
-; @calls LSXCALLS,FWORK,LSXFILE
+; @calls LSXCALLS,FWORK,LSXFILE,ACTBUF_INVALIDATE
 ; HL=fnum
+;
+; もし当該 fnum が active buffer (FGETC/FPUTC) と一致するなら、
+; close 前に flush + invalidate して書き残しを保存する。
+
+PUSH HL
+LD A,(ACTBUFMODE)
+OR A
+JR Z,.fclose_skip_inv
+LD A,(ACTBUFFNUM)
+CP L
+JR NZ,.fclose_skip_inv
+CALL ACTBUF_INVALIDATE
+.fclose_skip_inv
+POP HL
+
 CALL LSXCALCFCB
 EX DE,HL
 LD C,$10  ; _FCLOSE
@@ -410,54 +612,108 @@ RET
 
 ; @name FREAD
 ; @resident shared
-; @calls LSXCALLS,FWORK,LSXFILE,FCBRECINC
+; @calls LSXCALLS,FWORK,LSXFILE,FCBRECINC,ACTBUF_INVALIDATE
 ; HL=fnum DE=address BC=size
 ;
-; CP/M 2.2 (RunCPM) 制約: 1 record (128 byte) 固定 read。size パラメータは
-; 現状無視 — overlay <= 128B 用途で十分。scope B で multi-record loop に
-; 拡張予定 (BC を 128 ずつ消費するループ + EOF 処理)。
+; record-aligned multi-record read。返り値 HL = bytes_read = records × 128。
+; size を 128 で割って floor(size/128) records を読む試み。
+; - 全 record 成功: HL = floor(size/128) * 128
+; - EOF mid-loop: HL = 既読 records × 128 (= 0 含む)
+; - error: HL = $FFFF, CY=1
+; - size < 128: 0 records, HL = 0 (= caller は FGETC を使うべき)
+; size パラメータの 128 未満端数は切り捨て (sub-record 精度なし)。
 ;
-; random access (_RDRND $21) を使用、FCB+33..36 の random record を見て読む。
-; FOPEN 直後は FCB+33..36=0 (= 先頭 record)、FSEEK で位置移動可能。
-; _RDRND は record 番号を auto-increment しないため、成功時に FCBRECINC で
-; +1 して sequential semantics を維持する (= 連続 FREAD で次の record を読む)。
+; 同一 fnum が active buffer (FGETC/FPUTC) なら invalidate (= 整合仕様)。
 
 CALL LSXFCHECKNUM
 JP C,.fread1
-; return $FF (bad fnum)
-LD HL,255
+LD HL,255             ; bad fnum
 RET
 
 .fread1
-; LSXFCB=fnum*37+LSXFCBS
+; active buffer 整合: 同 fnum なら invalidate
+PUSH HL
+PUSH DE
+PUSH BC
+LD A,(ACTBUFMODE)
+OR A
+JR Z,.fread_skip_inv
+LD A,(ACTBUFFNUM)
+CP L
+JR NZ,.fread_skip_inv
+CALL ACTBUF_INVALIDATE
+.fread_skip_inv
+POP BC
+POP DE
+POP HL
+
+; LSXFCB setup
 CALL LSXCALCFCB
 LD (LSXFCB),HL
 
-; SET DTA = address (DE)
-LD C,$1A      ; _SETDTA
-PUSH IY
-CALL BDOS
-POP IY
+; save original size (BC) for total computation at end
+PUSH BC
 
-; _RDRND (random read, CP/M 2.2 互換)
-LD DE,(LSXFCB)
-LD C,$21      ; _RDRND
-PUSH IY
-CALL BDOS
-POP IY
-
-; A=0 success / A=1 EOF / A=4 record範囲外 / A=5 random read error
-; scope A は EOF も成功扱い (overlay は EOF 寸前まで読み切れば OK)。
+.fread_loop
+; if BC < 128: done (= caller's remaining is sub-record)
+LD A,B
 OR A
-JR Z,.fread_ok
+JR NZ,.fread_chunk    ; B>0 → BC >= 256 >= 128
+LD A,C
+CP 128
+JR C,.fread_done      ; B==0 && C<128 → stop
+.fread_chunk
+
+; SETDTA = DE (preserve BC, DE)
+PUSH BC
+PUSH DE
+LD C,$1A
+PUSH IY
+CALL BDOS
+POP IY
+; _RDRND
+LD DE,(LSXFCB)
+LD C,$21
+PUSH IY
+CALL BDOS
+POP IY                ; A = result
+POP DE                ; restore address
+POP BC                ; restore BC
+
+; A=0 success, A=1 EOF, A>=2 error
+OR A
+JR Z,.fread_advance
 CP 2
 JR NC,.fread_err
-.fread_ok
-CALL FCBRECINC      ; 成功時のみ next record へ進める
-LD HL,0
+; A=1 EOF: stop with current total
+JR .fread_done
+
+.fread_advance
+CALL FCBRECINC        ; advance random record
+; advance DE += 128
+PUSH HL               ; HL is dirty, save (used for FCB calc by FCBRECINC)
+LD HL,128
+ADD HL,DE
+EX DE,HL              ; DE += 128
+POP HL
+; BC -= 128
+LD A,C
+SUB 128
+LD C,A
+LD A,B
+SBC A,0
+LD B,A
+JP .fread_loop
+
+.fread_done
+; total_read = original_size - BC_remaining
+POP HL                ; HL = saved original size
+OR A
+SBC HL,BC
 RET
 
 .fread_err
+POP HL                ; discard saved
 LD HL,$FFFF
 SCF
 RET
@@ -465,45 +721,155 @@ RET
 
 ; @name FWRITE
 ; @resident shared
-; @calls LSXCALLS,FWORK,LSXFILE,FCBRECINC
+; @calls LSXCALLS,FWORK,LSXFILE,FCBRECINC,ACTBUF_INVALIDATE
 ; HL=fnum DE=address BC=size
 ;
-; CP/M 2.2 (RunCPM) 制約: 1 record (128 byte) 固定 write。size パラメータは
-; 現状無視 — scope B で multi-record loop に拡張予定。
-;
-; random access (_WRRND $22) を使用、FCB+33..36 の random record に書く。
-; FREAD と同様、auto-increment しないため成功時に FCBRECINC で +1。
+; record-aligned multi-record write。返り値 HL = bytes_written = records × 128。
+; FREAD と対称、size の 128 未満端数は切り捨て。
+; - 全 record 成功: HL = floor(size/128) * 128
+; - error mid-loop: 部分書込み後 HL=$FFFF, CY=1
 
 CALL LSXFCHECKNUM
 JP C,.fwrite1
-; return $FF (bad fnum)
 LD HL,255
 RET
 
 .fwrite1
-; LSXFCB=fnum*37+LSXFCBS
+; active buffer 整合: 同 fnum なら invalidate
+PUSH HL
+PUSH DE
+PUSH BC
+LD A,(ACTBUFMODE)
+OR A
+JR Z,.fwrite_skip_inv
+LD A,(ACTBUFFNUM)
+CP L
+JR NZ,.fwrite_skip_inv
+CALL ACTBUF_INVALIDATE
+.fwrite_skip_inv
+POP BC
+POP DE
+POP HL
+
 CALL LSXCALCFCB
 LD (LSXFCB),HL
 
-; SET DTA = address (DE)
-LD C,$1A      ; _SETDTA
-PUSH IY
-CALL BDOS
-POP IY
+PUSH BC               ; save original size
 
-; _WRRND (random write, CP/M 2.2 互換)
-LD DE,(LSXFCB)
-LD C,$22      ; _WRRND
+.fwrite_loop
+LD A,B
+OR A
+JR NZ,.fwrite_chunk
+LD A,C
+CP 128
+JR C,.fwrite_done
+.fwrite_chunk
+
+; SETDTA = DE
+PUSH BC
+PUSH DE
+LD C,$1A
 PUSH IY
 CALL BDOS
 POP IY
+; _WRRND
+LD DE,(LSXFCB)
+LD C,$22
+PUSH IY
+CALL BDOS
+POP IY                ; A = result
+POP DE
+POP BC
 
 OR A
-JR NZ,.fwrite_done
-CALL FCBRECINC      ; 成功時のみ next record へ進める
+JR NZ,.fwrite_err     ; A != 0 = error (CP/M write には EOF concept なし)
+
+CALL FCBRECINC
+PUSH HL
+LD HL,128
+ADD HL,DE
+EX DE,HL
+POP HL
+LD A,C
+SUB 128
+LD C,A
+LD A,B
+SBC A,0
+LD B,A
+JP .fwrite_loop
+
 .fwrite_done
+POP HL
+OR A
+SBC HL,BC
+RET
+
+.fwrite_err
+POP HL
+LD HL,$FFFF
+SCF
+RET
+
+
+; @name ACTBUF_FLUSH
+; @resident shared
+; @calls FWORK,FCBRECINC
+;
+; ACTBUFDIRTY が立っていれば、ACTBUF を ACTBUFFNUM の current random record
+; に書き、advance、ACTBUF を 0 で埋め直し、ACTBUFOFS=0, ACTBUFDIRTY=0。
+; ACTBUFMODE / ACTBUFFNUM は維持 (= active 状態継続)。
+
+LD A,(ACTBUFDIRTY)
+OR A
+RET Z
+
+; FCB アドレス計算
+LD A,(ACTBUFFNUM)
 LD L,A
 LD H,0
+CALL LSXCALCFCB
+LD (LSXFCB),HL
+
+; SETDTA = ACTBUF
+LD DE,ACTBUF
+LD C,$1A
+PUSH IY
+CALL BDOS
+POP IY
+
+; _WRRND
+LD DE,(LSXFCB)
+LD C,$22
+PUSH IY
+CALL BDOS
+POP IY
+
+CALL FCBRECINC
+
+; ACTBUFOFS=0, ACTBUFDIRTY=0
+XOR A
+LD (ACTBUFOFS),A
+LD (ACTBUFDIRTY),A
+
+; zero ACTBUF (128 byte)
+LD HL,ACTBUF
+LD DE,ACTBUF+1
+LD BC,127
+LD (HL),0
+LDIR
+RET
+
+
+; @name ACTBUF_INVALIDATE
+; @resident shared
+; @calls FWORK,ACTBUF_FLUSH
+;
+; active buffer を完全クリア。dirty なら ACTBUF_FLUSH してから ACTBUFMODE=0。
+; FREAD/FWRITE/FSEEK 入口で同 fnum の active を強制 invalidate するのに使う。
+
+CALL ACTBUF_FLUSH
+XOR A
+LD (ACTBUFMODE),A
 RET
 
 
@@ -532,7 +898,12 @@ RET
 
 ; @name FWORK
 ; @resident shared
-; @works LSXFCBS:296,LSXFCB:2,LSXFMODE:2
+; @works LSXFCBS:296,LSXFCB:2,LSXFMODE:2,ACTBUF:128,ACTBUFFNUM:1,ACTBUFOFS:1,ACTBUFMODE:1,ACTBUFDIRTY:1
 ;
+; ACTBUF: FGETC/FPUTC 用 1 record バッファ (128 byte)
+; ACTBUFFNUM: アクティブ fnum (0..7)、$FF = none
+; ACTBUFOFS: ACTBUF 内の current offset (0..127、128 = sentinel for forced reload)
+; ACTBUFMODE: 0=none, 1=read (FGETC), 2=write (FPUTC)
+; ACTBUFDIRTY: 1 = write 内容が flush されていない、0 = clean
 
 

--- a/runtime/libcpm_file.asm
+++ b/runtime/libcpm_file.asm
@@ -309,10 +309,22 @@ LD A,(ACTBUFFNUM)
 CP L
 JR NZ,.fseek_skip_inv
 CALL ACTBUF_INVALIDATE
+OR A
+JR NZ,.fseek_inv_err          ; flush 失敗 → error
 .fseek_skip_inv
 POP BC
 POP DE
 POP HL
+JR .fseek2
+
+.fseek_inv_err
+POP BC
+POP DE
+POP HL
+LD HL,255
+RET
+
+.fseek2
 
 ; LSXFCB=fnum*37+LSXFCBS
 CALL LSXCALCFCB
@@ -435,7 +447,12 @@ RET
 
 .fgetc_switch
 ; 別 fnum: 既存 active を flush (write の場合)
+; ACTBUF_FLUSH は HL/DE/BC を破壊するので fnum (HL) を保護
+PUSH HL
 CALL ACTBUF_FLUSH
+POP HL
+OR A
+JR NZ,.fgetc_eof_or_err   ; flush 失敗 → error 伝播
 .fgetc_init
 ; ACTBUFFNUM = L (fnum)
 LD A,L
@@ -532,7 +549,14 @@ RET
 
 .fputc_switch
 ; 別 fnum: 既存 active を flush (write の場合)
+; ACTBUF_FLUSH は HL/DE/BC を破壊するので fnum (HL) と chr (DE) を保護
+PUSH HL
+PUSH DE
 CALL ACTBUF_FLUSH
+POP DE
+POP HL
+OR A
+JR NZ,.fputc_err          ; flush 失敗 → error 伝播
 .fputc_init
 ; chr (DE) を保存 (LDIR で DE が破壊されるため)
 PUSH DE
@@ -557,6 +581,17 @@ LDIR
 POP DE
 
 .fputc_serve
+; 前回 FPUTC の flush 失敗で OFS=128 に詰まっている場合は retry
+LD A,(ACTBUFOFS)
+CP 128
+JR NZ,.fputc_doStore
+PUSH DE
+CALL ACTBUF_FLUSH
+POP DE
+OR A
+JR NZ,.fputc_err
+
+.fputc_doStore
 ; ACTBUF[ACTBUFOFS] = chr (E)
 LD A,(ACTBUFOFS)
 LD L,A
@@ -574,9 +609,17 @@ LD (ACTBUFDIRTY),A
 LD A,(ACTBUFOFS)
 CP 128
 JR NZ,.fputc_done
+; chr (DE) を保護してから flush 試行
+PUSH DE
 CALL ACTBUF_FLUSH
+POP DE
+OR A
+JR NZ,.fputc_err           ; flush 失敗 → error
 .fputc_done
 LD HL,0
+RET
+.fputc_err
+LD HL,255
 RET
 
 
@@ -588,6 +631,8 @@ RET
 ; もし当該 fnum が active buffer (FGETC/FPUTC) と一致するなら、
 ; close 前に flush + invalidate して書き残しを保存する。
 
+; B = invalidate 結果保存 (0 = OK)
+LD B,0
 PUSH HL
 LD A,(ACTBUFMODE)
 OR A
@@ -596,17 +641,26 @@ LD A,(ACTBUFFNUM)
 CP L
 JR NZ,.fclose_skip_inv
 CALL ACTBUF_INVALIDATE
+LD B,A             ; 保存
 .fclose_skip_inv
 POP HL
 
 CALL LSXCALCFCB
 EX DE,HL
+PUSH BC            ; B (invalidate result) を保護
 LD C,$10  ; _FCLOSE
 PUSH IY
 CALL BDOS
 POP IY
+POP BC
+; A = _FCLOSE 結果, B = invalidate 結果。
+; invalidate が失敗していたら $FF を返す (= flush 失敗を優先)。
 LD L,A
 LD H,0
+LD A,B
+OR A
+RET Z              ; invalidate OK → _FCLOSE 結果を返す
+LD HL,255
 RET
 
 
@@ -642,11 +696,23 @@ LD A,(ACTBUFFNUM)
 CP L
 JR NZ,.fread_skip_inv
 CALL ACTBUF_INVALIDATE
+OR A
+JR NZ,.fread_inv_err          ; flush 失敗 → error
 .fread_skip_inv
 POP BC
 POP DE
 POP HL
+JR .fread2
 
+.fread_inv_err
+POP BC
+POP DE
+POP HL
+LD HL,$FFFF
+SCF
+RET
+
+.fread2
 ; LSXFCB setup
 CALL LSXCALCFCB
 LD (LSXFCB),HL
@@ -746,11 +812,23 @@ LD A,(ACTBUFFNUM)
 CP L
 JR NZ,.fwrite_skip_inv
 CALL ACTBUF_INVALIDATE
+OR A
+JR NZ,.fwrite_inv_err          ; flush 失敗 → error
 .fwrite_skip_inv
 POP BC
 POP DE
 POP HL
+JR .fwrite2
 
+.fwrite_inv_err
+POP BC
+POP DE
+POP HL
+LD HL,$FFFF
+SCF
+RET
+
+.fwrite2
 CALL LSXCALCFCB
 LD (LSXFCB),HL
 
@@ -818,10 +896,14 @@ RET
 ; ACTBUFDIRTY が立っていれば、ACTBUF を ACTBUFFNUM の current random record
 ; に書き、advance、ACTBUF を 0 で埋め直し、ACTBUFOFS=0, ACTBUFDIRTY=0。
 ; ACTBUFMODE / ACTBUFFNUM は維持 (= active 状態継続)。
+;
+; 戻り値: A = BDOS _WRRND の結果。0 = 成功、!= 0 = error (disk full / etc)
+;        error 時は dirty を保持 (= ACTBUFOFS / ACTBUFDIRTY / ACTBUF 不変)
+;        するので caller は再試行可能。FCBRECINC も実行されない。
 
 LD A,(ACTBUFDIRTY)
 OR A
-RET Z
+RET Z              ; not dirty: A=0 で OK
 
 ; FCB アドレス計算
 LD A,(ACTBUFFNUM)
@@ -844,6 +926,11 @@ PUSH IY
 CALL BDOS
 POP IY
 
+; A = _WRRND result。0=success、それ以外は error
+OR A
+RET NZ             ; error: dirty 保持、caller に伝播
+
+; success path
 CALL FCBRECINC
 
 ; ACTBUFOFS=0, ACTBUFDIRTY=0
@@ -857,6 +944,7 @@ LD DE,ACTBUF+1
 LD BC,127
 LD (HL),0
 LDIR
+XOR A              ; success: return A=0
 RET
 
 
@@ -866,10 +954,14 @@ RET
 ;
 ; active buffer を完全クリア。dirty なら ACTBUF_FLUSH してから ACTBUFMODE=0。
 ; FREAD/FWRITE/FSEEK 入口で同 fnum の active を強制 invalidate するのに使う。
+;
+; 戻り値: A = ACTBUF_FLUSH の結果。0 = 成功、!= 0 = flush error (= dirty 保持、
+;        ACTBUFMODE もそのまま)。caller は再試行 / abort を判断できる。
 
 CALL ACTBUF_FLUSH
-XOR A
-LD (ACTBUFMODE),A
+OR A
+RET NZ             ; flush 失敗: dirty 保持、MODE もそのまま、error 伝播
+LD (ACTBUFMODE),A  ; A=0
 RET
 
 

--- a/runtime/libcpm_file.asm
+++ b/runtime/libcpm_file.asm
@@ -891,7 +891,7 @@ RET
 
 ; @name ACTBUF_FLUSH
 ; @resident shared
-; @calls FWORK,FCBRECINC
+; @calls FWORK,FCBRECINC,LSXFILE
 ;
 ; ACTBUFDIRTY が立っていれば、ACTBUF を ACTBUFFNUM の current random record
 ; に書き、advance、ACTBUF を 0 で埋め直し、ACTBUFOFS=0, ACTBUFDIRTY=0。


### PR DESCRIPTION
## Summary

PR #153 (scope A) で `runtime/libcpm_file.asm` を新設し cpm 環境で MODTEST_RESIDENT が動くようにしたが、scope A は最小実装 (1 record 固定 FREAD/FWRITE + FGETC/FPUTC スタブ) で、汎用 file API としては不十分だった。

本 PR で scope B を実装し、cpm 環境を **record-aligned + 単一 active byte I/O** API として実用レベルに引き上げる。

## 変更内容

### 1. FREAD/FWRITE multi-record loop 化
- record-aligned 単位 (= 128 byte) で `size` パラメータを honor
- 返り値 = 実際に読み/書きできた `records × 128`
- `size` の 128 未満端数は切り捨て (= sub-record 精度なし)
- EOF/error 処理: EOF mid-loop は `HL=既読 bytes`、error は `HL=$FFFF`

### 2. FGETC/FPUTC single-active-buffer 方式
- 128 byte 内部バッファ + 状態 (`ACTBUFFNUM` / `ACTBUFOFS` / `ACTBUFMODE` / `ACTBUFDIRTY`) を新規 `@works` に確保 (132 byte 増)
- 同 fnum + 同 mode の連続呼びは効率的 (バッファ内で完結)
- 別 fnum 切替時は自動 (read=reload, write=auto flush)
- **同一 fnum で read/write mode 切替は未サポート** — `FCLOSE` → `FOPEN` で reopen 必須 (= サイレント誤動作を防ぐため、未サポート組合せは `$FF` を返す)
- `FPUTC` は write mode 入口時 / flush 後に `ACTBUF` を 0 で初期化 (= partial record の tail が stale data 漏れせず確定 0 になる)

### 3. FREAD/FWRITE/FSEEK/FCLOSE の active buffer 整合
- 入口で `if ACTBUFFNUM == fnum && ACTBUFMODE != 0: ACTBUF_INVALIDATE` を呼んで dirty を flush + 状態クリア
- これにより同一 open file で API 種別 (1byte vs record) を混ぜようとしても、書き残しを失わずに転換できる (= 整合性は保たれるが性能は落ちるので docs で混在は非推奨と明記)

### 4. 新規 internal helpers
- `ACTBUF_FLUSH`: dirty なら `ACTBUF` を `_WRRND` で書き出し + `FCBRECINC` + 0 クリア
- `ACTBUF_INVALIDATE`: `ACTBUF_FLUSH` + `ACTBUFMODE=0`

### 5. 検証 sample 新設
`examples/CPMIOTEST.SL` で RunCPM 実機検証:
- Test 1: `FPUTC × 200 byte` (= 1 record auto-flush + close で残り flush)
- Test 2: 同ファイルを reopen し `FGETC × 200 byte` で round-trip 確認
- Test 3: `FREAD(256)` → `256` (= 2 records、record-aligned 完全読み)
- Test 4: `FREAD(200)` → `128` (= floor(200/128) × 128、partial 切り捨て)

## 動作確認 (RunCPM 実機)

```bash
make ENV=cpm TARGET=examples/CPMIOTEST run
# 実測出力:
#   FGETC/FPUTC OK
#   FREAD(256) returned 256
#   FREAD(200) returned 128
```

## 制約 (重要)

| 制約 | 詳細 |
|---|---|
| **record-aligned API** | `FREAD`/`FWRITE` は 128 byte 単位、端数切り捨て。任意 byte 単位は `FGETC`/`FPUTC` 必須 |
| **read/write mode 排他 (同一 fnum)** | `FGETC` → `FPUTC` または `FPUTC` → `FGETC` は `$FF` を返す。reopen 必須 |
| **API 混在未サポート (同一 open file)** | `FGETC`/`FPUTC` と `FREAD`/`FWRITE`/`FSEEK` の混在で active buffer が invalidate される |
| **lsx 完全互換ではない** | lsx の FREAD は CP/M 3+ の variable record size を使うので任意 byte 数を正確に R/W できる |
| **slcopy.sl** | 128 byte 境界整数倍ファイルなら正確にコピー可能。任意サイズなら caller が境界を保証するか `FGETC` loop が必要 |

## 影響範囲

- `runtime/libcpm_file.asm` のみ変更 (= cpm 環境専用)
- `runtime/liblsx_file.asm` は **手付かず** → lsx / x1 / msx2 / msxlsx 等他 env への影響なし
- `MODTEST_RESIDENT.SL` の RunCPM 動作も継続 (= scope A 用途は scope B 後も動く)
- work 領域: cpm 全体で ~858 → ~990 byte (+132 byte の ACTBUF state)

## Bug fix (実装中に発見)

`FPUTC` 初期化時の `LDIR` (ACTBUF 0 クリア) が `DE` レジスタを破壊し、初回 byte が garbage 値で書かれる問題を発見・修正。`PUSH DE` / `POP DE` で chr 引数を保護。

## Test plan

- [x] `dotnet test` 192/192 合格
- [x] `make ENV=cpm TARGET=examples/CPMIOTEST run` で全テスト合格を確認 (RunCPM 実機)
- [x] `make ENV=cpm TARGET=examples/MODTEST_RESIDENT run` で MODTEST_RESIDENT が引き続き動作 (scope A 互換)
- [x] `make ENV=lsx TARGET=examples/MODTEST_RESIDENT disk_image` で d88 出力サイズが変化なし (PROG.COM=759B, M0.BIN=57B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)