### PR TITLE
Windows での overlay 取り込み対応 + CHANGELOG (v0.23.0 候補) の整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - `#MODULE $addr RESIDENT` を追加 — overlay 間で共有するランタイム関数を main に集約してメモリ節約
   - 既存の `#MODULE $addr` (省略時) は従来通り Local モード (overlay 内に runtime 複製)。`RESIDENT` 指定で共有化が起動
-  - 全 12 環境 (lsx / x1 / msxlsx / msx2 / msxrom / sos / sosx1 / pc80mk2 / pc80mk2x / pc88mk2sr / vgs0 / zxn / cpm) の runtime ライブラリに `; @resident shared|local` 属性を付与済 (= 共有 773 関数 / overlay-local 14 関数)
+  - 全 13 環境 (lsx / x1 / msxlsx / msx2 / msxrom / sos / sosx1 / pc80mk2 / pc80mk2x / pc88mk2sr / vgs0 / zxn / cpm) の runtime ライブラリに `; @resident shared|local` 属性を付与済 (= 共有 773 関数 / overlay-local 14 関数)
   - 実測 (`examples/MODTEST_RESIDENT.SL`): overlay バイナリが Local 248B → RESIDENT 57B (-77%)。overlay を増やすほど節約効果が大きい
 
 - 二段アセンブル driver `slangbuild` を新ドライバとして追加

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,95 +2,40 @@
 
 ## Unreleased (v0.23.0 候補)
 
-- `runtime/libcpm_file.asm` の scope B 拡張: 汎用 file API として動作可能に
-  - `FREAD` / `FWRITE` を **record-aligned multi-record loop** 化 (size パラメータを honor、返り値 = 実際に読み/書きできた records × 128)
-  - `FGETC` / `FPUTC` を **single-active-buffer 方式** で実装 (128 byte 内部バッファ + 1 active fnum + read/write mode 排他)
-  - 新規 `examples/CPMIOTEST.SL` を追加し RunCPM 上で end-to-end 検証 (FGETC/FPUTC 200 byte round-trip + FREAD multi-record + FREAD partial 動作確認)
-  - **制約 (重要)**:
-    - `FREAD` / `FWRITE` は record-aligned (128 byte 単位)、size の 128 未満端数は切り捨て (sub-record 精度なし)。任意 byte 単位が必要なら `FGETC` / `FPUTC` を使う
-    - 同一 fnum で `FGETC` / `FPUTC` の **read/write mode 切替は未サポート** — `FCLOSE` → `FOPEN` で reopen 必須 (= サイレント誤動作を防ぐため、未サポート組合せは $FF を返す)
-    - 同一 open file で `FGETC` / `FPUTC` と `FREAD` / `FWRITE` / `FSEEK` を混在させるのは未サポート — 後者の呼び出し時に active buffer は invalidate される
-    - lsx 完全互換ではない (lsx の FREAD は CP/M 3+ の variable record size を使い、任意 byte 数を正確に R/W できる)
-    - 128 byte 境界整数倍ファイルなら `FREAD` / `FWRITE` で正確にコピー可能。slcopy.sl を cpm で動かす場合は対象ファイルが 128B 境界であることを caller が保証するか、`FGETC` を loop する必要がある
-  - `FPUTC` は write mode 入口時 / flush 後に ACTBUF を 0 で初期化 (= partial record の tail が stale data 漏れせず確定 0 になる)
-  - work 領域増加: 132 byte (ACTBUF + state)。cpm 全体で ~858 → ~990 byte
-  - bug fix (実装中に発見): `FPUTC` 初期化時の `LDIR` (ACTBUF 0 クリア) が DE レジスタを破壊し、初回 byte が garbage 値で書かれる問題を修正 (`PUSH DE` / `POP DE` で chr 引数を保護)
-
-- cpm 環境向け file ライブラリ `runtime/libcpm_file.asm` を新設
-  - `liblsx_file.asm` のコピー + CP/M 2.2 互換書き換え (random access `_RDRND` $21 / `_WRRND` $22 ベース、`liblsx_file` の CP/M 3+ `_RDBLK` $27 / `_WRBLK` $26 が RunCPM で動作しない問題を解消)
-  - `runtime/env/cpm.env` の参照を `liblsx_file.yml` → `libcpm_file.yml` に切り替え。lsx / x1 等他 env は引き続き `liblsx_file.asm` を使用、影響なし
-  - **scope A (本 PR 範囲)**: `FREAD` / `FWRITE` は 1 record (128 byte) 固定実装、`size` パラメータは無視。FCB+33..36 (random record) は成功時に内部 helper `FCBRECINC` で +1 され、sequential semantics (連続 FREAD で次 record を読む) を維持。`FSEEK` も整合 (FCB+33..36 を直接更新)。`FGETC` / `FPUTC` はスタブ ($FF return)
-  - **scope B (follow-up)**: `FREAD` / `FWRITE` の multi-record loop 化、`FGETC` / `FPUTC` の 128 byte 内部バッファ化
-  - 動作確認: `make ENV=cpm TARGET=examples/MODTEST_RESIDENT run` で RunCPM 上 "Module value: 100 / Main value: 10" の end-to-end 動作 (PR #151 で lsx/x1 がカバーされていなかった cpm を追加でカバー)
-
-- `examples/MODTEST_RESIDENT.SL` に overlay loader (FOPEN/FREAD/FCLOSE) を実装、`Makefile.dist` を拡張して `make ENV=lsx|x1 TARGET=examples/MODTEST_RESIDENT disk_image` が D88 イメージに `PROG.com` + `M0.BIN` を書き込むようにした
-  - `tools/disk-add-overlays.sh` (POSIX) を新設、`PROG._m*.bin` を staging 経由で `M0.BIN`/`M1.BIN`/... として d88 へ書き込む。古い `M*.BIN` (前回ビルド残骸) は事前削除。一時 staging dir (`examples/.staging/`) は trap で都度削除
-  - エミュレータ (X Millennium / Cocoa1 等) で d88 起動 → "Module value: 100 / Main value: 10" の end-to-end 動作を確認 (LSX-Dodgers の FILES API 経由)
-  - `tools/runcpm.sh` も同じ命名規則 (`M<N>.BIN`) で staging するように拡張。当初 RunCPM (CP/M 2.2 互換) では FREAD が CP/M 3+ の BDOS `_RDBLK` ($27) を使うため動作しなかったが、後続で `runtime/libcpm_file.asm` (CP/M 2.2 互換実装) を新設して解消、cpm 環境でも end-to-end 動作する
-  - 汎用 loader 機構ではなく **サンプル限定の最小実装** で、命名規則は `M<N>.BIN` (= overlay インデックスと一致)、loader は overlay 0 が 128 byte 以内であることを前提。他 env (sos/msx/pc88/vgs0/zxn) は別 loader API のため本変更の対象外
-  - Windows 環境の disk_image 拡張は本 PR では対応せず (Makefile.dist の `ifneq ($(OS),Windows_NT)` で skip)。POSIX shell スクリプトのため、Windows ユーザーは手動で M0.BIN を d88 に追加する必要あり
-
-- `cpm` 環境を独立した env として明示化 (#145)
-  - `runtime/env/cpm.env` を新設 (env_type/os_type は lsx と同じ 0/0、libraries は lsx 互換)。条件コンパイル `#IF (ENV_TYPE<=1)` 等の意味は変わらない
-  - `Makefile.dist` の `ENV=cpm` で `SLANGENV=cpm` を参照
-  - これまで `-E cpm` 指定時は env file が見つからず「全 runtime/*.asm を fallback ロード」していたため、`libpc80mk2_print` の `@works WORK10:10` と `liblsx_print` 等の local `WORK10:` ラベルが AILZ80ASM 段階で衝突していた (Issue #145)。cpm.env 追加により lsx 互換セットのみがロードされ衝突解消
-
-- env 解決を一本化、未定義 env を即エラー化 (**breaking change**)
-  - 従来: `slangc -E xxx` で `xxx.env` が見つからなかった場合、Preprocessor 用と Runtime ロード用に env 解決が **二重に走り**、後段が見つからない場合は `runtime/*.asm` を **全部 fallback ロード** していた (これが Issue #145 の根本原因)
-  - 新動作: 起動直後に **1 回だけ** env を解決。見つからない env は `Error: Unknown environment 'xxx'` で **即終了 (exit 1)**。fallback 経路は廃止
-  - ファイル不在 (`Unknown environment '<name>'`) と YAML 破損 (`Failed to load env file for '<name>'`) を別エラーで報告
-  - 既存の有効 env (`-E lsx` / `-E x1` / `-E sos` / `-E msxrom` / `-E cpm` 等) を指定するワークフローへの影響無し。`-E` を typo した場合や、独自に env 名を作っていて env file を用意していなかった場合のみ挙動が変わる
-
-- 残り 10 環境 (msxlsx / msx2 / msxrom / sos / sosx1 / pc80mk2 / pc80mk2x / pc88mk2sr / vgs0 / zxn) の runtime にも `; @resident shared|local` を付与 (PR-C2) — PR-C1 の手順を機械的に横展開
-  - 対象 30 ファイル / 527 関数の追加付与 (env ごとに 1 commit)
-  - 真の self-mod として `local` 化した関数 (PR-C2 で新規):
-    - `libsos_print.PRMODE` / `libpc80mk2xbios_print.PRMODE` (PRT+1 の operand patch)
-    - `libp88_base.PSET` (PSETADR / PSETCOLOR の operand patch)
-    - 各 base ファイルの `SLANGINIT` (8 件、main inline 専用)
-  - **全 env 累計**: shared 773 関数 / local 14 関数 (10 base SLANGINIT + M8ALOAD + 3 PRMODE/PSET)
-  - smoke 検証 (env ごと): `slangc -E <env> examples/<sample>.SL` で SLANG 段の compile 成功確認。pc80mk2 / pc80mk2x は `AILZ80ASM` までのフルアセンブルも `0 error/warn` (#145 系統のため厚めに)
-  - 全テスト 190 / 190 合格 (PR-C1 と同じ test base、回帰なし)
-- lsx / x1 環境の runtime ライブラリに `; @resident shared|local` を全関数付与 (PR-C1) — `#MODULE $addr RESIDENT` で実バイナリでメモリ節約効果
-  - 対象 17 ファイル (lsx.env / x1.env が参照する .asm を `tools/resident-audit.py --env` で機械的に列挙) / 260 関数
-  - 内訳: **shared 258 関数 / local 2 関数** (`SLANGINIT` = main inline 専用, `M8ALOAD` = 命令オペランド書き換えあり)
-  - `tools/resident-audit.py` (関数別 self-mod ヒューリスティック判定 + env-aware 走査) と `tools/resident-apply.py` (override map + 一括付与 / dry-run / idempotent) を追加。手書き列挙の漏れを排除
-  - 効果実測: `examples/MODTEST.SL` (Local) と `examples/MODTEST_RESIDENT.SL` (新設、`#MODULE $3000 RESIDENT`) を比較 → overlay バイナリが **248B → 57B (-77%)** に縮小 (MPRNT/P10/PCRONE が main 集約され、overlay 内 EXTERN 参照に変換)。複数 overlay を並べる用途では効果がさらに大きい
-  - サンプル分割の意図: `MODTEST.SL` は引き続き「overlay 基本例 (Local モード)」、`MODTEST_RESIDENT.SL` は「resident runtime デモ」と役割を分離 (Codex レビュー指摘反映)
-  - 既存 IntegrationTest `Overlay_RuntimePolicy_Resident_DefaultRuntimes_StillLocal` を `..._SharedRuntimes_PromotedToMain` に書き換え (PR-A 時点で「runtime 側未対応」として placeholder 化していたものを、本 PR で正の挙動アサートに転換)
-  - 既存 examples (MANDEL / FMANDEL / STARS など overlay 未使用) はバイナリ変化なし。`#MODULE` を使わない SL は影響を受けない
-- `slangbuild` に prelink 二段アセンブル機構を追加 (PR-B2) — main / overlay 間で **任意の SLANG 関数の相互呼び出し** をサポート
-  - cross-reference 検出時に自動的に prelink モードへ (Pass 1: 各 target を dummy imports でアセンブル → Pass 2: 全 target の Exports セクションから ExportedFunctionTable 構築 → Pass 3: combined imports で本番アセンブル)
-  - サポート範囲: main → overlay 関数 / overlay → main 関数 / overlay → overlay 関数 (関数シンボルのみ)
-  - **仕様**: 解決するのはアドレスだけ。swap 制御・呼び先 overlay のロード状態確認は ユーザー責任 (低レベル言語の責務分担)
-  - compiler 側 (`CodeGenerator`) で各 ASM に `; === Exported User Functions ===` (= 自分が定義する関数) + `; === User Function References ===` (= 自分が呼ぶ他ファイル関数) の 2 セクションを出力
-  - driver 側に `AsmSectionParser` / `ExportedFunctionTable` / `PrelinkPlan` 新設。`-nsa` は prelink Pass 1/3 のみ付与 (既存単段フローには影響なし)
-  - PR-A バグ修正: `Preprocessor` が `#END` を「stray」として skip してしまい、`#MODULE` 内 `#END` が Parser に届いていなかった問題を解消 (これにより 2 つ以上の `#MODULE` が正しく個別 overlay として認識される)
-  - PR-A バグ修正: `#MODULE` ネスト禁止 (= `#END` 不足検出も兼ねた parse エラー)
-  - 失敗時は `--keep-asm` 指定なしでも中間 ASM を残す (AILZ80ASM のエラー行追跡用、PR-B 既存)
-  - 新規テスト: `AsmSectionParserTests` (4) + `ExportedFunctionTableTests` (4) + `PrelinkPlanTests` (5) + `BuildIntegrationTests` 拡張 (4 件 prelink E2E + -o 相対パス回帰 2 件、合計 17 件追加)
-- 二段アセンブル toolchain `slangbuild` を新ドライバとして追加 (PR-B)
-  - `src/SLANGCompiler.Build/` を新規 .NET 8 プロジェクトとして追加。`slangc` は改修せず、`slangbuild` が orchestration (slangc → AILZ80ASM main → AILZ80ASM overlay) を担う GCC 的責務分離
-  - **二段フロー**: main を `-sm minimal-equ` でアセンブルして `.sym` を生成 → 各 overlay について overlay ASM 内の `; EXTERN` リストと main.sym の交集合だけを抽出した `<overlay>.imports.asm` (filtered EQU) を作成 → `imports.asm + overlay.ASM` を AILZ80ASM に投入。raw main.sym をそのまま渡すと compiler 内部ラベル衝突が起きるため必ず filter する
-  - `OverlayImportsBuilder` が PR-A で出力された 3 つの固定セクション (`Shared Runtime References` / `Shared Symbols` / `String references`) 内の `; EXTERN` 行のみを regex で抽出 (誤検出防止)
-  - `ToolResolver` で slangc / AILZ80ASM のパス解決順を仕様化 (`--slangc` / `--asm` → 同梱 bin → PATH → dev fallback)。配布スクリプト (Makefile.dist / publish.sh) では明示指定で再現性確保
-  - `Makefile.dist` を `slangbuild` 経由に切替。overlay 不要 (`#MODULE` 未使用) の SL でも単段フローで動く
-  - `publish.sh` に slangbuild の 4 platform publish + zip 同梱を追加
-  - 新規テスト: `SymFileReaderTests` (5 件) + `OverlayImportsBuilderTests` (4 件) + `BuildIntegrationTests` (6 件 E2E) = 計 15 件
-  - **注意**: 本 PR は **toolchain 機構** のみ。実バイナリでメモリ節約効果が出るには別 PR (PR-C) で `runtime/lsx*.asm` 等への `@resident shared` 付与が必要。本 PR マージ直後は全 overlay が default Local で従来挙動互換
-- `#MODULE` (オーバーレイ) をモジュール専用ワーク対応に拡張
-  - モジュール直下の `VAR` / `ARRAY` を **モジュール私有ワークエリア `__WORK_M<N>__`** に配置。ASM ラベルは `_V_M<N>_<NAME>` で名前空間分離されるため、main と同名の変数を宣言しても物理メモリ上同居せず、各 overlay の swap 先でメモリを再利用できる
-  - `#MODULE` 内に `WORK <定数式>` を書くことでモジュール専用ワークの ORG を明示可能 (未指定時は overlay コード末尾に連続配置)
+- `#MODULE` (オーバーレイ) のモジュール専用ワーク対応 (#142)
+  - モジュール直下の `VAR` / `ARRAY` を **モジュール私有ワークエリア `__WORK_M<N>__`** に配置。main と同名の変数を宣言しても物理メモリ上同居せず、各 overlay の swap 先でメモリを再利用できる
+  - `#MODULE` 内に `WORK <定数式>` でモジュール専用ワークの ORG を明示可能 (未指定時は overlay コード末尾に連続配置)
   - `WORK` / `ORG` / `OFFSET` の各ディレクティブが定数式 (`CONST WA = $9000; WORK WA` など) を受けるように拡張
-  - モジュール直下の初期値付き変数 / 固定アドレス指定 / トップレベル `#ASM` はコンパイルエラー化 (関数本体内の `#ASM` / ローカル変数は従来どおり)
-  - 関数定義 / `MACHINE` / `CONST` は従来互換で global に登録 — main から overlay 関数を呼ぶ既存運用は変わらず
-- `#MODULE` ランタイム集約ポリシーの **内部設計** を導入 (PR-A)
-  - ヘッダ位置に optional のポリシー識別子を追加: `#MODULE $8000 RESIDENT` (省略時は Local = 現状互換)
-  - ランタイム関数側に `; @resident shared|local` 属性を追加。RESIDENT モード × 関数 Shared の交点で main 集約 (overlay 内 EXTERN 参照) になる
-  - `@resident local` (明示) は #MODULE RESIDENT でも常に勝つ (self-modifying / overlay-specific WORK 等の安全側挙動)
-  - 新規 `RuntimePlanner` で集約決定 (alias 正規化 / 依存閉包 / SLANGINIT inline 仕様化を担当)
-  - CodeGenerator の runtime 参照 7 箇所 (overlay resolve / SLANGINIT exclude / main runtime emit / RUNTIME_INIT / @works 集約) を Plan 経由に統一。shared 関数の `@init_code` / `@works` が main 側 `RUNTIME_INIT` / `__WORK__` に正しく集約される
-  - `#MODULE $addr SELFCONTAIN` / `AUTO` は enum 予約済み、現時点はコンパイルエラー
-  - **注意**: 本 PR は **内部設計のみ**。実バイナリでの shared runtime リンクは別 PR (PR-B = main → `.sym` → overlay EQU 注入の二段アセンブル toolchain) が必要。既存 runtime ライブラリにもまだ `@resident shared` を付与していないため、`RESIDENT` を書いても現時点では何も共有されず、動作は完全に現状互換
+  - モジュール直下の初期値付き変数 / 固定アドレス指定 / トップレベル `#ASM` はコンパイルエラー化
+
+- `#MODULE $addr RESIDENT` を追加 — overlay 間で共有するランタイム関数を main に集約してメモリ節約
+  - 既存の `#MODULE $addr` (省略時) は従来通り Local モード (overlay 内に runtime 複製)。`RESIDENT` 指定で共有化が起動
+  - 全 12 環境 (lsx / x1 / msxlsx / msx2 / msxrom / sos / sosx1 / pc80mk2 / pc80mk2x / pc88mk2sr / vgs0 / zxn / cpm) の runtime ライブラリに `; @resident shared|local` 属性を付与済 (= 共有 773 関数 / overlay-local 14 関数)
+  - 実測 (`examples/MODTEST_RESIDENT.SL`): overlay バイナリが Local 248B → RESIDENT 57B (-77%)。overlay を増やすほど節約効果が大きい
+
+- 二段アセンブル driver `slangbuild` を新ドライバとして追加
+  - `slangc` は ASM 生成までを担当、`slangbuild` が main / overlay の AILZ80ASM 実行を orchestrate (GCC 的責務分離)
+  - `Makefile.dist` を `slangbuild` 経由に切替。overlay 不要 (`#MODULE` 未使用) の SL は単段フローで動く
+  - **prelink モード**: main / overlay 間で **任意の SLANG 関数の相互呼び出し** をサポート (cross-ref 検出時に自動有効化)。解決するのはアドレスのみで、swap 制御・呼び先 overlay のロード状態確認はユーザー責任
+
+- overlay バイナリのディスクイメージ取り込みサンプルを追加
+  - `tools/disk-add-overlays.sh` (POSIX) と `tools/disk-add-overlays.bat` (Windows) を新設、`make ENV=lsx|x1 TARGET=examples/MODTEST_RESIDENT disk_image` が `PROG.com` + `M0.BIN` を d88 に書き込む
+  - `examples/MODTEST_RESIDENT.SL` で LSX-Dodgers のファイル API (`FOPEN` / `FREAD`) 経由 overlay ロード → 実機エミュレータ (X Millennium / Cocoa1 等) で動作確認
+  - **サンプル限定の最小実装**: 命名は `M<N>.BIN` 固定、overlay 0 が 128 byte 以内であることを前提
+
+- `cpm` 環境を独立 env として明示化 + 専用 file ライブラリ追加 (#145)
+  - `runtime/env/cpm.env` を新設。これまで `-E cpm` は env file 不在で全 `runtime/*.asm` を fallback ロードしており、他環境のラベル衝突 (例: `libpc80mk2_print` の `WORK10`) を起こしていた
+  - cpm 専用 `runtime/libcpm_file.asm` を新設。CP/M 2.2 互換 BDOS 関数 (`_RDRND` / `_WRRND`) ベースで RunCPM 上で動作 (lsx の `liblsx_file.asm` は CP/M 3+ 専用関数を使うため非互換だった)
+  - `FREAD` / `FWRITE` は record-aligned (128 byte 単位)、`FGETC` / `FPUTC` は単一 active fnum + 128 byte 内部バッファ (lsx 完全互換ではない、制約は `runtime/libcpm_file.asm` ヘッダコメント参照)
+  - `examples/CPMIOTEST.SL` + `examples/MODTEST_RESIDENT.SL` (cpm 経由) で RunCPM 実機動作を確認
+
+- env 解決を厳格化 — 不明 env は即エラー化 (**breaking change**)
+  - 従来は `slangc -E xxx` で env file 不在時に「全 `runtime/*.asm` を fallback ロード」して進行 → 後段で謎エラー
+  - 新動作: 起動直後に env 解決失敗で `Error: Unknown environment 'xxx'` で即終了 (`exit 1`)
+  - 既存の有効 env (`lsx` / `x1` / `sos` / `msxrom` / `cpm` 等) を指定するワークフローへの影響なし。`-E` typo や独自 env 名で env file 未配置のケースのみ挙動が変わる
+
+- `slangbuild` の overlay 検出 glob を厳密化 — `--keep-asm` 残骸付きで次回 build が無限ループする問題を修正 (#152)
+  - case-insensitive な FS (macOS APFS / Windows) で `_m*.ASM` パターンが旧 `--keep-asm` 残骸の `.dummy.imports.asm` 等まで拾い、prelink Pass 1 で再帰的に dummy/imports suffix が積まれる現象を `_m<digits>.ASM` 厳密一致 regex で post-filter
 
 ## Version 0.22.0
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -180,7 +180,9 @@ else
 disk_image: $(IMGPROG)
 	- $(NDC) D $(DISK_IMAGE) 0 PROG$(BIN_EXT_ENV)
 	$(NDC) P $(DISK_IMAGE) 0 $(IMGPROG)
-ifneq ($(OS),Windows_NT)
+ifeq ($(OS),Windows_NT)
+	@tools\disk-add-overlays.bat "$(NDC)" "$(DISK_IMAGE)" "$(dir $(TARGET))"
+else
 	@./tools/disk-add-overlays.sh $(NDC) $(DISK_IMAGE) $(dir $(TARGET))
 endif
 endif
@@ -217,6 +219,8 @@ build: $(OUTPROG)
 clean:
 ifeq ($(OS),Windows_NT)
 	-del /Q /F $(subst /,\,$(TARGET)$(ASM_EXT)) $(subst /,\,$(TARGET)$(BIN_EXT)) $(subst /,\,$(dir $(TARGET))PROG.bin) $(subst /,\,$(dir $(TARGET))PROG.com) 2>nul
+	@REM disk-add-overlays.bat の staging dir は通常自動削除されるが念押し
+	-rmdir /S /Q $(subst /,\,$(dir $(TARGET)).staging) 2>nul
 else
 	rm -f $(TARGET)$(ASM_EXT) $(TARGET)$(BIN_EXT) $(TARGET)$(BIN_EXT_ENV) $(dir $(TARGET))PROG.bin $(dir $(TARGET))PROG.com
 	@# disk-add-overlays.sh の staging dir は通常 trap で消えるが念押し

--- a/tools/disk-add-overlays.bat
+++ b/tools/disk-add-overlays.bat
@@ -37,14 +37,32 @@ if not exist "%STAGE_DIR%" mkdir "%STAGE_DIR%"
 
 for %%f in ("%PREFIX_DIR%PROG._m*.bin") do (
     if exist "%%f" (
-        set "BASE=%%~nf"
-        REM Extract digits after "_m" — "PROG._m0" → "0"
-        set "N=!BASE:*_m=!"
-        copy /Y "%%f" "%STAGE_DIR%\M!N!.BIN" >nul
-        "%NDC%" P "%D88%" 0 "%STAGE_DIR%\M!N!.BIN"
+        call :stage_one "%%f"
+        if errorlevel 1 (
+            rmdir /S /Q "%STAGE_DIR%" 2>nul
+            exit /b 1
+        )
     )
 )
 
 REM Cleanup staging dir
 rmdir /S /Q "%STAGE_DIR%" 2>nul
+exit /b 0
+
+:stage_one
+REM Stage and write a single overlay file. Args: %1 = source bin path.
+REM Returns 0 on success, 1 if copy or NDC P fails.
+set "BASE=%~n1"
+REM Extract digits after "_m" — "PROG._m0" → "0"
+set "N=!BASE:*_m=!"
+copy /Y "%~1" "%STAGE_DIR%\M!N!.BIN" >nul
+if errorlevel 1 (
+    echo Error: copy failed for %~1 1>&2
+    exit /b 1
+)
+"%NDC%" P "%D88%" 0 "%STAGE_DIR%\M!N!.BIN"
+if errorlevel 1 (
+    echo Error: NDC P failed for M!N!.BIN 1>&2
+    exit /b 1
+)
 exit /b 0

--- a/tools/disk-add-overlays.bat
+++ b/tools/disk-add-overlays.bat
@@ -1,0 +1,50 @@
+@echo off
+REM disk-add-overlays.bat — Windows companion to disk-add-overlays.sh
+REM
+REM Usage: disk-add-overlays.bat <ndc> <d88> <target-prefix-dir>
+REM
+REM Looks for <target-prefix-dir>PROG._m*.bin (output from slangbuild) and
+REM stages each as M<N>.BIN under <target-prefix-dir>\.staging\, then writes
+REM them to the d88 via NDC P. Old M0..M9.BIN are deleted from the d88 first
+REM (sample limited: assumes overlay count <= 10).
+REM
+REM This is a *sample-only* helper for examples/MODTEST_RESIDENT.SL etc.
+
+setlocal enabledelayedexpansion
+
+if "%~3"=="" (
+    echo Usage: %~nx0 ^<ndc^> ^<d88^> ^<target-prefix-dir^> 1>&2
+    exit /b 1
+)
+
+set "NDC=%~1"
+set "D88=%~2"
+set "PREFIX_DIR=%~3"
+
+REM Normalize forward slashes to backslashes (make passes "examples/")
+set "PREFIX_DIR=%PREFIX_DIR:/=\%"
+set "STAGE_DIR=%PREFIX_DIR%.staging"
+
+REM Delete leftover M0..M9.BIN from previous builds (sample-limited range).
+REM Errors (file not in d88) are suppressed.
+for /L %%n in (0,1,9) do (
+    "%NDC%" D "%D88%" 0 M%%n.BIN >nul 2>&1
+)
+
+REM Stage and add overlay files. No-op if no PROG._m*.bin exists (= sample
+REM doesn't use #MODULE).
+if not exist "%STAGE_DIR%" mkdir "%STAGE_DIR%"
+
+for %%f in ("%PREFIX_DIR%PROG._m*.bin") do (
+    if exist "%%f" (
+        set "BASE=%%~nf"
+        REM Extract digits after "_m" — "PROG._m0" → "0"
+        set "N=!BASE:*_m=!"
+        copy /Y "%%f" "%STAGE_DIR%\M!N!.BIN" >nul
+        "%NDC%" P "%D88%" 0 "%STAGE_DIR%\M!N!.BIN"
+    )
+)
+
+REM Cleanup staging dir
+rmdir /S /Q "%STAGE_DIR%" 2>nul
+exit /b 0

--- a/tools/disk-add-overlays.sh
+++ b/tools/disk-add-overlays.sh
@@ -9,8 +9,7 @@
 # (sample limited: assumes overlay count <= 10).
 #
 # This is a *sample-only* helper for examples/MODTEST_RESIDENT.SL etc.
-# Windows users currently have no equivalent — Makefile.dist on Windows
-# only writes the main .bin, and overlay disk staging must be done manually.
+# Windows users have an equivalent at tools/disk-add-overlays.bat.
 
 set -e
 

--- a/tools/runcpm.bat
+++ b/tools/runcpm.bat
@@ -51,6 +51,20 @@ for %%F in ("%COM_PATH%") do set BASE=%%~nF
 REM Copy as A\0\<STEM>.COM (CP/M requires .COM extension)
 copy /Y "%COM_PATH%" "%STAGE%\A\0\%BASE%.COM" >nul
 
+REM Stage overlay binaries (sample-only support, see examples/MODTEST_RESIDENT.SL).
+REM Looks for <com_dir>\<original-stem>._m*.bin (slangbuild output naming) and
+REM copies each as M0.BIN, M1.BIN, ... under A\0\. No-op when sample doesn't
+REM use #MODULE.
+for %%F in ("%COM_PATH%") do set COM_DIR=%%~dpF
+for %%g in ("%COM_DIR%%BASE%._m*.bin") do (
+    if exist "%%g" (
+        set "OVBASE=%%~ng"
+        REM Extract digits after "_m" — "PROG._m0" → "0"
+        set "N=!OVBASE:*_m=!"
+        copy /Y "%%g" "%STAGE%\A\0\M!N!.BIN" >nul
+    )
+)
+
 REM Bundle SUBMIT.COM and EXIT.COM so the CCP can chain commands.
 copy /Y "%CPM_UTILS_DIR%\SUBMIT.COM" "%STAGE%\A\0\SUBMIT.COM" >nul
 copy /Y "%CPM_UTILS_DIR%\EXIT.COM"   "%STAGE%\A\0\EXIT.COM"   >nul

--- a/tools/runcpm.bat
+++ b/tools/runcpm.bat
@@ -58,10 +58,11 @@ REM use #MODULE.
 for %%F in ("%COM_PATH%") do set COM_DIR=%%~dpF
 for %%g in ("%COM_DIR%%BASE%._m*.bin") do (
     if exist "%%g" (
-        set "OVBASE=%%~ng"
-        REM Extract digits after "_m" — "PROG._m0" → "0"
-        set "N=!OVBASE:*_m=!"
-        copy /Y "%%g" "%STAGE%\A\0\M!N!.BIN" >nul
+        call :stage_overlay "%%g"
+        if errorlevel 1 (
+            rmdir /S /Q "%STAGE%" >nul 2>&1
+            exit /b 1
+        )
     )
 )
 
@@ -88,4 +89,18 @@ popd
 rmdir /S /Q "%STAGE%" >nul 2>&1
 
 endlocal
+exit /b 0
+
+
+:stage_overlay
+REM Stage a single overlay file. Args: %1 = source bin path.
+REM Returns 0 on success, 1 if copy fails.
+set "OVBASE=%~n1"
+REM Extract digits after "_m" — "PROG._m0" → "0"
+set "N=!OVBASE:*_m=!"
+copy /Y "%~1" "%STAGE%\A\0\M!N!.BIN" >nul
+if errorlevel 1 (
+    echo Error: copy failed for %~1 1>&2
+    exit /b 1
+)
 exit /b 0


### PR DESCRIPTION
## Summary

調整系 PR を 2 トピックまとめて:

1. **Windows サポート**: 直前の PR #151 で overlay 取り込みは POSIX shell のみ対応 (`Makefile.dist` の `ifneq ($(OS),Windows_NT)` で skip) だった。Windows ユーザーが `make ENV=lsx ... disk_image` を実行すると d88 に main は入るが overlay (M0.BIN) が入らず、サンプル loader が `Open failed: 255` で停止していた。本 PR で `.bat` 同等品を追加して Windows でも動作可能に
2. **CHANGELOG (v0.23.0 候補) の整理**: 詳細すぎる Unreleased セクション (~90 行) を user-facing な情報中心に圧縮 (~35 行)

## 変更内容

### Windows サポート
- `tools/disk-add-overlays.bat` を新設 (POSIX shell 版の cmd.exe 同等品)
  - `PROG._m*.bin` → `M<N>.BIN` として d88 に書き込み
  - 旧 `M0..M9.BIN` を事前削除 (sample-limited range)
  - 一時 staging dir (`<target-prefix-dir>\.staging\`) を毎回 cleanup
  - forward slash → backslash 自動変換 (`%PREFIX_DIR:/=\%`)
- `tools/runcpm.bat` に overlay staging を追加 (= runcpm.sh と同じ動作)
- `Makefile.dist` の `disk_image` を `ifeq ($(OS),Windows_NT)` で `.bat` 呼び出しに分岐
- `clean` ターゲットでも Windows 側で `.staging` dir を削除

### CHANGELOG 整理
- Unreleased (v0.23.0 候補) セクションを 7 トピックに整理:
  - `#MODULE` 私有ワーク (#142)
  - `#MODULE $addr RESIDENT` (overlay 間 runtime 共有)
  - `slangbuild` driver (二段アセンブル + prelink)
  - overlay loader sample (`MODTEST_RESIDENT.SL` + `disk-add-overlays.{sh,bat}`)
  - cpm 環境整備 (#145、`cpm.env` + `libcpm_file.asm`)
  - env 解決厳格化 (breaking change)
  - `slangbuild` の overlay glob 修正 (#152)
- 内部実装詳細 (PR-A/B/B2/C0/C0b/C1/C2 の番号、scope A/B 用語、新規テスト数等) を除去 — commit log / PR で追える情報は CHANGELOG から省略
- v0.22.0 以前は手付かず

## 検証

- macOS で既存挙動維持: `make ENV=lsx TARGET=examples/MODTEST_RESIDENT disk_image` で d88 内容変化なし (PROG.COM=759B / M0.BIN=57B)
- macOS で `make ENV=cpm ... run` も継続動作 (RunCPM 上 `MODTEST_RESIDENT` の `Module value: 100`)
- `dotnet test` 192/192 合格
- Windows での実機確認は実施できず (= reviewer 側で確認推奨)。`.bat` の syntax は cmd.exe 標準機能のみ使用 (`for /L`, `setlocal enabledelayedexpansion`, `%VAR:*_m=%` パラメータ展開)

## Test plan

- [x] macOS で `make disk_image` 既存挙動維持 + dotnet test 192/192
- [ ] Windows で `make ENV=lsx TARGET=examples/MODTEST_RESIDENT disk_image` を実行、d88 に PROG.COM + M0.BIN が入ること
- [ ] Windows で `make ENV=cpm TARGET=examples/MODTEST_RESIDENT run` で RunCPM 上動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)