### PR TITLE
slangbuild --emit disk Phase 2: sos/sosx1 統合 + install / template override / setup-tools 整合 (#157 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
   - `tools/disk-add-overlays.py` は legacy helper として残置 (旧経路ユーザー保護、新規利用は非推奨)
   - **動作環境**: `make setup-tools && make install` 後の installed 環境 (`~/.config/SLANG/`)、配布 zip 解凍直後、開発時の repo 直下、いずれでも動作 (Phase 1 の「installed 環境では template 不在で使えない」制約は Phase 2 の `install-lib` 拡張で解消済)。Linux/macOS の sos 系では `mono` (HuDisk.exe 起動用) と setupenv での S-OS template 取得が前提
 
+- `make install` の default を `~/.local/bin` (= XDG Base Dir Spec) に変更 (Linux/macOS、Windows は元々 `%LOCALAPPDATA%\Programs\SLANG` でユーザーローカル)
+  - 旧 default `/usr/local/bin` は sudo 必須で、かつ sudo 起動だと `$(HOME)/.config/SLANG` の `$HOME` が `/root` に取られて lib が user dir に入らない問題があった
+  - 新 default はユーザーローカル完結 (sudo 不要)。install 完了メッセージで `~/.local/bin` を PATH に通す案内を表示
+  - 従来通りシステムワイドにしたい場合は `sudo make install PREFIX=/usr/local CONFIG_DIR=/usr/local/share/slang` のように `CONFIG_DIR` も明示
+
 - `cpm` 環境を独立 env として明示化 + 専用 file ライブラリ追加 (#145)
   - `runtime/env/cpm.env` を新設。これまで `-E cpm` は env file 不在で全 `runtime/*.asm` を fallback ロードしており、他環境のラベル衝突 (例: `libpc80mk2_print` の `WORK10`) を起こしていた
   - cpm 専用 `runtime/libcpm_file.asm` を新設。CP/M 2.2 互換 BDOS 関数 (`_RDRND` / `_WRRND`) ベースで RunCPM 上で動作 (lsx の `liblsx_file.asm` は CP/M 3+ 専用関数を使うため非互換だった)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,7 @@
     - **配布物の HuDisk** は ho-ogino/HuDisk fork の `feature/write-ascii-mode` ブランチ (= ASCII 書き込み可能版、setup-tools が curl で取得済)
   - `Makefile.dist` の `disk_image` ターゲットは **lsx / x1 / sos / sosx1** で `slangbuild --emit disk` 経路。それ以外の d88 系 env (msx2 / msxlsx / pc80mk2 / pc88mk2sr 等) は従来の `tools/disk-add-overlays.py` 経路を維持 (Phase 3+ で順次移行予定)
   - `tools/disk-add-overlays.py` は legacy helper として残置 (旧経路ユーザー保護、新規利用は非推奨)
-  - **配布 zip / repo layout 前提**: `make install` 経由 (`~/.config/SLANG/runtime/` のみ展開) では `images/LSXPROG.D88` が無いため `--emit disk` は使えない。配布 zip 内 `images/` 同梱がある場合のみ動作
-  - `tools/disk-add-overlays.py` は新規利用は非推奨 (legacy helper)。旧経路 (= 独自 Makefile / shell スクリプト) からの呼び出し用に残置
+  - **動作環境**: `make setup-tools && make install` 後の installed 環境 (`~/.config/SLANG/`)、配布 zip 解凍直後、開発時の repo 直下、いずれでも動作 (Phase 1 の「installed 環境では template 不在で使えない」制約は Phase 2 の `install-lib` 拡張で解消済)。Linux/macOS の sos 系では `mono` (HuDisk.exe 起動用) と setupenv での S-OS template 取得が前提
 
 - `cpm` 環境を独立 env として明示化 + 専用 file ライブラリ追加 (#145)
   - `runtime/env/cpm.env` を新設。これまで `-E cpm` は env file 不在で全 `runtime/*.asm` を fallback ロードしており、他環境のラベル衝突 (例: `libpc80mk2_print` の `WORK10`) を起こしていた

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,18 @@
   - `examples/MODTEST_RESIDENT.SL` で LSX-Dodgers のファイル API (`FOPEN` / `FREAD`) 経由 overlay ロード → 実機エミュレータ (X Millennium / Cocoa1 等) で動作確認
   - **サンプル限定の最小実装**: 命名は `M<N>.BIN` 固定、overlay 0 が 128 byte 以内であることを前提
 
-- `slangbuild --emit disk` で D88 ディスクイメージまで一気通貫ビルド (#157 Phase 1)
-  - 新オプション `--emit disk` / `--disk-image <path>` / `--ndc <path>` を追加。`slangbuild input.SL -E lsx --emit disk --disk-image out.d88` 1 コマンドで slangc → AILZ80ASM → ndc P まで完結 (z88dk + appmake 相当)
+- `slangbuild --emit disk` で D88 ディスクイメージまで一気通貫ビルド (#157 Phase 1 + Phase 2)
+  - **Phase 1**: 新オプション `--emit disk` / `--disk-image <path>` / `--ndc <path>` を追加。`slangbuild input.SL -E lsx --emit disk --disk-image out.d88` 1 コマンドで slangc → AILZ80ASM → ndc P まで完結 (z88dk + appmake 相当)
   - env file (lsx / x1) に新規 `disk:` セクション追加 (`format: d88` / `template: ../../images/templates/LSXPROG.D88` / `tool: ndc` / `main_name: PROG.COM` / `overlay_name: M{index}.BIN`)。pristine template (`images/templates/LSXPROG.D88`) はビルドごとに `$(DISK_IMAGE)` 既定 = `images/LSXPROG.d88` 等の出力先にコピーしてから書き込み、template 自体は不変 (CI で SHA-256 比較で検証)
-  - `Makefile.dist` の `disk_image` ターゲットは **lsx / x1** のみ `slangbuild --emit disk` 経路に切替。それ以外の d88 系 env (msx2 / msxlsx / pc80mk2 / pc88mk2sr 等) は従来の `tools/disk-add-overlays.py` 経路を維持 (= Phase 1 では挙動変えない)。Phase 2+ で env ごとに `disk:` セクションを追加して順次新経路へ移行予定
+  - **Phase 2**: 以下の機能を追加
+    - **sos / sosx1 (HuDisk)** を `--emit disk` 経路に統合。`disk:` schema を `tool: hudisk` + `main_load` / `main_exec` / `overlay_load` (`$3000` / `0x3000` / 10進対応) で拡張。`Makefile.dist` の sos / sosx1 disk_image を `slangbuild --emit disk --hudisk` に書換
+    - **`--disk-template <path>`** で env の `disk.template` を CLI 上書き (installed 環境の代替策 + 実験用)
+    - **`--hudisk <path>`** option 追加。`HUDISK_PATH` 環境変数 / bundled `tools/HuDisk.exe` / installed `~/.config/SLANG/tools/HuDisk.exe` / PATH の順で解決。Linux/macOS では mono 経由起動 (Windows は直接実行)
+    - **`make install` で images/ + tools/ を `~/.config/SLANG/` 配下に配置** (Phase 1 制約解消)。`ToolResolver` の解決順に `~/.config/SLANG/tools/` を追加。これで installed 環境でも `slangbuild --emit disk` が動作
+    - **setup-tools が S-OS template を `images/templates/SOSPROG.D88` に配置** (LSX と整合)
+    - **配布物の HuDisk** は ho-ogino/HuDisk fork の `feature/write-ascii-mode` ブランチ (= ASCII 書き込み可能版、setup-tools が curl で取得済)
+  - `Makefile.dist` の `disk_image` ターゲットは **lsx / x1 / sos / sosx1** で `slangbuild --emit disk` 経路。それ以外の d88 系 env (msx2 / msxlsx / pc80mk2 / pc88mk2sr 等) は従来の `tools/disk-add-overlays.py` 経路を維持 (Phase 3+ で順次移行予定)
+  - `tools/disk-add-overlays.py` は legacy helper として残置 (旧経路ユーザー保護、新規利用は非推奨)
   - **配布 zip / repo layout 前提**: `make install` 経由 (`~/.config/SLANG/runtime/` のみ展開) では `images/LSXPROG.D88` が無いため `--emit disk` は使えない。配布 zip 内 `images/` 同梱がある場合のみ動作
   - `tools/disk-add-overlays.py` は新規利用は非推奨 (legacy helper)。旧経路 (= 独自 Makefile / shell スクリプト) からの呼び出し用に残置
 

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -132,12 +132,16 @@ ifeq ($(DETECTED_OS),Windows)
 	-$(MKDIR) "$(CONFIG_DIR)"
 	-$(MKDIR) "$(CONFIG_DIR)\include"
 	-$(MKDIR) "$(CONFIG_DIR)\runtime"
+	-$(MKDIR) "$(CONFIG_DIR)\images"
+	-$(MKDIR) "$(CONFIG_DIR)\images\templates"
 	$(XCOPY) include "$(CONFIG_DIR)\include"
 	$(XCOPY) runtime "$(CONFIG_DIR)\runtime"
+	$(XCOPY) images "$(CONFIG_DIR)\images"
 else
 	$(MKDIR) $(CONFIG_DIR)
 	$(XCOPY) include $(CONFIG_DIR)/
 	$(XCOPY) runtime $(CONFIG_DIR)/
+	$(XCOPY) images $(CONFIG_DIR)/
 endif
 
 # アンインストール

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -62,7 +62,10 @@ SLANGC = bin/slangc$(EXE_EXT)
 SLANGBUILD = bin/slangbuild$(EXE_EXT)
 ASM = tools/AILZ80ASM$(EXE_EXT)
 NDC = tools/ndc$(EXE_EXT)
-HUDISK = tools/HuDisk$(EXE_EXT)
+# HuDisk は ho-ogino/HuDisk fork の .NET assembly (HuDisk.exe)。
+# Linux/macOS では mono 経由で起動するが、その分岐は slangbuild の ToolResolver
+# 側に閉じている (= Makefile からは OS によらず .exe 拡張子で渡す)。
+HUDISK = tools/HuDisk.exe
 
 OUTPROG = $(dir $(TARGET))PROG.bin
 ASM_OPT =
@@ -77,6 +80,10 @@ else ifeq ($(ENV), x1)
   DISK_IMAGE = images/LSXPROG.D88
   BIN_EXT_ENV = .com
 else ifeq ($(ENV), sos)
+  EMU = @echo "Set EMU variable for your emulator" \#
+  DISK_IMAGE = images/SOSPROG.D88
+  BIN_EXT_ENV = $(BIN_EXT)
+else ifeq ($(ENV), sosx1)
   EMU = @echo "Set EMU variable for your emulator" \#
   DISK_IMAGE = images/SOSPROG.D88
   BIN_EXT_ENV = $(BIN_EXT)
@@ -134,14 +141,17 @@ ifeq ($(DETECTED_OS),Windows)
 	-$(MKDIR) "$(CONFIG_DIR)\runtime"
 	-$(MKDIR) "$(CONFIG_DIR)\images"
 	-$(MKDIR) "$(CONFIG_DIR)\images\templates"
+	-$(MKDIR) "$(CONFIG_DIR)\tools"
 	$(XCOPY) include "$(CONFIG_DIR)\include"
 	$(XCOPY) runtime "$(CONFIG_DIR)\runtime"
 	$(XCOPY) images "$(CONFIG_DIR)\images"
+	$(XCOPY) tools "$(CONFIG_DIR)\tools"
 else
 	$(MKDIR) $(CONFIG_DIR)
 	$(XCOPY) include $(CONFIG_DIR)/
 	$(XCOPY) runtime $(CONFIG_DIR)/
 	$(XCOPY) images $(CONFIG_DIR)/
+	$(XCOPY) tools $(CONFIG_DIR)/
 endif
 
 # アンインストール
@@ -182,9 +192,19 @@ disk_image: $(OUTPROG)
 else ifeq ($(ENV), msxrom)
 disk_image: $(OUTPROG)
 else ifeq ($(ENV), sos)
-disk_image: $(IMGPROG)
-	$(HUDISK) -d $(DISK_IMAGE) PROG.bin
-	$(HUDISK) -a $(DISK_IMAGE) $(IMGPROG) -r 3000 -g 3000
+# Issue #157 Phase 2: sos も slangbuild --emit disk + HuDisk 経路に統合。
+# template (= images/templates/SOSPROG.D88) は setup-tools で生成済 (= 素 boot
+# disk + AUTOEXEC.BAT)。slangbuild が template をコピーしてから main + overlay
+# を書き込む (template 自体は不変、Linux/macOS は HuDisk.exe を mono 経由で起動)。
+disk_image: $(TARGET)$(SRC_EXT)
+	$(SLANGBUILD) $< -E $(SLANGENV) -I include \
+		--slangc $(SLANGC) --asm $(ASM) --hudisk $(HUDISK) \
+		-o $(dir $(TARGET))PROG --emit disk --disk-image $(DISK_IMAGE)
+else ifeq ($(ENV), sosx1)
+disk_image: $(TARGET)$(SRC_EXT)
+	$(SLANGBUILD) $< -E $(SLANGENV) -I include \
+		--slangc $(SLANGC) --asm $(ASM) --hudisk $(HUDISK) \
+		-o $(dir $(TARGET))PROG --emit disk --disk-image $(DISK_IMAGE)
 else ifeq ($(ENV), lsx)
 # Issue #157 Phase 1: `slangbuild --emit disk` に統合 (lsx / x1 のみ)。
 # 1 コマンドで slangc → AILZ80ASM → template d88 を $(DISK_IMAGE) にコピー →

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -6,12 +6,18 @@
 # make clean        - サンプルのビルド成果物を削除
 
 # インストール設定
+# default はユーザーローカル (= sudo 不要)。Linux/macOS 共に XDG Base Dir Spec の
+# ~/.local/bin に bin、~/.config/SLANG に lib/runtime/images/tools を入れる。
+# システムワイドにしたい場合は `make install PREFIX=/usr/local` で上書き可能だが、
+# その場合は sudo が必要 + CONFIG_DIR=$(HOME)/.config/SLANG が sudo 起動の HOME=/root
+# に取られる問題があるため、`sudo make install PREFIX=/usr/local CONFIG_DIR=/usr/local/share/slang`
+# のように CONFIG_DIR も明示する運用を docs で案内 (system-wide は上級ユーザー向け)。
 ifeq ($(OS),Windows_NT)
     PREFIX ?= $(LOCALAPPDATA)\Programs\SLANG
     BINDIR = $(PREFIX)
     CONFIG_DIR = $(USERPROFILE)\.config\SLANG
 else
-    PREFIX ?= /usr/local
+    PREFIX ?= $(HOME)/.local
     BINDIR = $(PREFIX)/bin
     CONFIG_DIR = $(HOME)/.config/SLANG
 endif
@@ -119,6 +125,14 @@ install: install-bin install-lib
 	@echo "Installation complete!"
 	@echo "  Binaries: $(BINDIR)"
 	@echo "  Libraries: $(CONFIG_DIR)"
+ifeq ($(OS),Windows_NT)
+	@echo ""
+	@echo "Note: Please ensure '$(BINDIR)' is in your PATH."
+else
+	@echo ""
+	@echo "Note: If '$(BINDIR)' is not on your PATH, add this to your shell rc:"
+	@echo "  export PATH=\"$(BINDIR):\$$PATH\""
+endif
 
 install-bin:
 ifeq ($(DETECTED_OS),Windows)

--- a/README.md
+++ b/README.md
@@ -282,6 +282,9 @@ SLANG Compilerは、Makefileを使ってWindows/macOS/Linuxでクロスプラッ
 - **Python 3.x** (一部の機能で必要)
   - PCG / フォント変換ツール (`tools/png_to_asm.py`, `tools/charmap-encode.py`)
   - これらを使わない通常のコンパイル / 単一バイナリ実行には不要
+- **mono** (Linux / macOS で `make setup-tools` を実行する場合に必須)
+  - `setupenv.sh` が S-OS template 生成のため `HuDisk.exe` を mono 経由で実行する。Windows は .NET Framework で直接実行されるため不要
+  - sos / sosx1 環境で `slangbuild --emit disk` を使う場合も同じく mono が必要 (HuDisk.exe 起動)。lsx / x1 の ndc 経路だけ使うなら mono 不要
 
 ### ビルドとインストール
 

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -947,12 +947,18 @@ make ENV=cpm TARGET=examples/MODTEST_RESIDENT run
 ```
 
 実装は env ごとに分担:
-- **lsx / x1** (D88): `Makefile.dist` の `disk_image` ターゲットが `slangbuild --emit disk` を呼ぶ。slangbuild が env file (`runtime/env/lsx.env` / `x1.env`) の `disk:` セクション (`template`, `main_name: PROG.COM`, `overlay_name: M{index}.BIN`) を読み、template d88 を **コピーしてから** `ndc P` で `PROG.COM` + `M0.BIN` 群を書き込む (template 自体は不変)
+- **lsx / x1** (D88, ndc): `Makefile.dist` の `disk_image` ターゲットが `slangbuild --emit disk` を呼ぶ。slangbuild が env file の `disk:` セクション (`template`, `tool: ndc`, `main_name: PROG.COM`, `overlay_name: M{index}.BIN`) を読み、template d88 を **コピーしてから** `ndc P` で `PROG.COM` + `M0.BIN` 群を書き込む (template 自体は不変)
+- **sos / sosx1** (D88, HuDisk): 同じく `slangbuild --emit disk --hudisk` を呼ぶ。env file は `tool: hudisk` + `main_load: "$3000"` / `main_exec: "$3000"` / `overlay_load: "$3000"` を持ち、HuDisk を `-a <d88> <file> -r <load> -g <exec>` で起動 (Linux/macOS では mono 経由)
 - **cpm** (RunCPM): `tools/runcpm.{sh,bat}` が staging dir に `PROG._m*.bin` を `M<N>.BIN` としてコピーしてから RunCPM を起動
 
 `slangbuild input.SL -E lsx --emit disk --disk-image out.d88` の形で直接呼び
-出すこともできる (Makefile.dist 経由はこの 1 行への薄い wrapper)。
+出すこともできる (Makefile.dist 経由はこの 1 行への薄い wrapper)。env file の
+`disk.template` は `--disk-template <path>` で CLI 上書き可能 (= installed 環境
+の代替策 + 実験用)。
+
 旧 `tools/disk-add-overlays.py` は legacy helper として残置 (新規利用は非推奨)。
+msx2 / msxlsx / pc80mk2 / pc88mk2sr 等の d88 系 env は Phase 3+ で順次
+`--emit disk` 経路に移行予定。
 
 サンプル限定の最小実装で、overlay 命名は `M<N>.BIN` 固定、各 overlay は
 128 byte 以内であることを前提としている (より大きい overlay は loader 拡張

--- a/runtime/env/sos.env
+++ b/runtime/env/sos.env
@@ -10,3 +10,12 @@ libraries:
   - libsos_file.yml
   - libcompress.yml
   - libsoroban.yml
+disk:
+  format: d88
+  template: ../../images/templates/SOSPROG.D88
+  tool: hudisk
+  main_name: PROG.bin
+  main_load: "$3000"
+  main_exec: "$3000"
+  overlay_name: M{index}.BIN
+  overlay_load: "$3000"

--- a/runtime/env/sosx1.env
+++ b/runtime/env/sosx1.env
@@ -18,3 +18,12 @@ libraries:
   - libsoroban.yml
   - libx1_magic.yml
   - libx1_sgl.yml
+disk:
+  format: d88
+  template: ../../images/templates/SOSPROG.D88
+  tool: hudisk
+  main_name: PROG.bin
+  main_load: "$3000"
+  main_exec: "$3000"
+  overlay_name: M{index}.BIN
+  overlay_load: "$3000"

--- a/setupenv.bat
+++ b/setupenv.bat
@@ -13,6 +13,7 @@ IF not %errorlevel%==0 goto ERROR
 SET TOOLPATH=%~dp0tools\
 
 mkdir images
+mkdir images\templates
 mkdir tools
 
 mkdir temp
@@ -46,13 +47,15 @@ REM (Old CP/M emulator cpm.exe is no longer downloaded; RunCPM is bundled
 REM under tools\runcpm\ instead. See tools\runcpm\README.md.)
 
 REM REM S-OS(X1)���_�E�����[�h
+REM ��I�I�� images\templates\SOSPROG.D88 �ɒu�� (= slangbuild --emit disk ��
+REM �Q�Ƃ��� pristine template�ALSX �� templates/ �p�^�[���Ɛ���)
 curl http://www.retropc.net/ohishi/s-os/SWXCV110.zip -OL
 unzip -xo SWXCV110.zip
 REM AUTOEXEC.BAT��ǉ�
-REN SWXCV110.d88 SOSPROG.d88
-%TOOLPATH%HuDisk SOSPROG.d88 -a ..\env\S-OS\AUTOEXEC.BAT --ascii
-copy SOSPROG.d88 ..\images\
-DEL SOSPROG.d88
+REN SWXCV110.d88 SOSPROG.D88
+%TOOLPATH%HuDisk SOSPROG.D88 -a ..\env\S-OS\AUTOEXEC.BAT --ascii
+copy SOSPROG.D88 ..\images\templates\
+DEL SOSPROG.D88
 DEL SWXCV110.zip
 
 REM LSX-Dodgers�͓���t�H�[�}�b�g�̂��ߎ擾���ĉ��H���鎖���o���Ȃ�(NDC�ŃA�N�Z�X�s��)���ߑΉ����Ȃ�

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -57,6 +57,7 @@ fi
 
 TOOLPATH=$(cd $(dirname $0);pwd)/tools/
 mkdir images
+mkdir -p images/templates
 mkdir tools
 mkdir temp
 cd temp
@@ -108,13 +109,15 @@ rm AILZ80ASM
 rm $FILENAME
 
 # S-OS(X1)をダウンロード
+# 最終的に images/templates/SOSPROG.D88 に置く (= slangbuild --emit disk が
+# 参照する pristine template、LSX の templates/ パターンと整合)。
 curl http://www.retropc.net/ohishi/s-os/SWXCV110.zip -OL
 unzip -xo SWXCV110.zip
 # AUTOEXEC.BATを追加
-mv SWXCV110.d88 SOSPROG.d88
-mono $TOOLPATH/HuDisk.exe SOSPROG.d88 -a ../env/S-OS/AUTOEXEC.BAT --ascii
-cp SOSPROG.d88 ../images/
-rm SOSPROG.d88
+mv SWXCV110.d88 SOSPROG.D88
+mono $TOOLPATH/HuDisk.exe SOSPROG.D88 -a ../env/S-OS/AUTOEXEC.BAT --ascii
+cp SOSPROG.D88 ../images/templates/
+rm SOSPROG.D88
 rm SWXCV110.zip
 
 # LSX-Dodgersは特殊フォーマットのため取得して加工する事が出来ない(NDCでアクセス不可の)ため対応しない

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -9,26 +9,26 @@ fi
 # mac or linux
 TARGETENV=$1
 
-function Error()
-{
+# POSIX sh 互換 (= Linux の /bin/sh = dash でも動く形)。
+# 旧版の `function name() { ... }` は bash 拡張で dash で syntax error になる。
+Error() {
   echo Error!
-  echo 
+  echo
   cd $CURPATH
   exit 1
 }
 
-function CmdError() {
+CmdError() {
   echo !
   echo             _________________
   echo --------------------------------------------
   echo Error! $CMDNAME がインストールされていません
-  echo 
+  echo
   cd $CURPATH
   exit 1
 }
 
 CURPATH=$(cd $(dirname $0);pwd)/
-PROGPATH=`readlink -f $1`
 
 # コマンドがあるかチェック
 CMDNAME=curl
@@ -64,10 +64,10 @@ cd temp
 
 # NDCをダウンロード
 
-# Mac
-if [ $TARGETENV == "mac" ]; then
+# Mac (POSIX sh では `==` ではなく `=`)
+if [ "$TARGETENV" = "mac" ]; then
   DLPATH=https://euee.web.fc2.com/tool/ndcm0a08arm.tgz
-elif [ $TARGETENV == "linux" ]; then
+elif [ "$TARGETENV" = "linux" ]; then
   DLPATH=https://euee.web.fc2.com/tool/ndcl0a08x64.tgz
 else
   Error
@@ -90,9 +90,9 @@ cp HuDisk.exe $TOOLPATH
 rm HuDisk.exe
 
 # AILZ80ASMをダウンロード
-if [ $TARGETENV == "mac" ]; then
+if [ "$TARGETENV" = "mac" ]; then
   DLPATH=https://github.com/AILight/AILZ80ASM/releases/download/v1.0.31/AILZ80ASM.osx-x64.v1.0.31.zip
-elif [ $TARGETENV == "linux" ]; then
+elif [ "$TARGETENV" = "linux" ]; then
   DLPATH=https://github.com/AILight/AILZ80ASM/releases/download/v1.0.31/AILZ80ASM.linux-x64.v1.0.31.zip
 else
   Error

--- a/src/SLANGCompiler.Build/DiskImageBuilder.cs
+++ b/src/SLANGCompiler.Build/DiskImageBuilder.cs
@@ -23,27 +23,27 @@ namespace SLANGCompiler.Build;
 public class DiskImageBuilder
 {
     private readonly DiskConfig _disk;
-    private readonly string? _ndcPath;
-    private readonly string? _hudiskPath;
+    private readonly ResolvedTool? _ndc;
+    private readonly ResolvedTool? _hudisk;
     private readonly string? _templateOverride;
     private readonly bool _verbose;
 
     /// <summary>
     /// </summary>
     /// <param name="disk">env file の disk: セクション</param>
-    /// <param name="ndcPath">tool == "ndc" 時の ndc 実行ファイル絶対パス。それ以外は null 可</param>
-    /// <param name="hudiskPath">tool == "hudisk" 時の HuDisk 実行ファイル絶対パス。それ以外は null 可</param>
+    /// <param name="ndc">tool == "ndc" 時の ResolvedTool。それ以外は null 可</param>
+    /// <param name="hudisk">tool == "hudisk" 時の ResolvedTool (Linux/macOS では MonoRun でラップ済)。それ以外は null 可</param>
     /// <param name="verbose">subprocess の I/O を stderr に流す</param>
     /// <param name="templateOverride">--disk-template による env.Disk.Template の上書き</param>
     public DiskImageBuilder(DiskConfig disk,
-                            string? ndcPath = null,
-                            string? hudiskPath = null,
+                            ResolvedTool? ndc = null,
+                            ResolvedTool? hudisk = null,
                             bool verbose = false,
                             string? templateOverride = null)
     {
         _disk = disk;
-        _ndcPath = ndcPath;
-        _hudiskPath = hudiskPath;
+        _ndc = ndc;
+        _hudisk = hudisk;
         _verbose = verbose;
         _templateOverride = templateOverride;
     }
@@ -84,20 +84,20 @@ public class DiskImageBuilder
             return 1;
         }
 
-        // tool ごとに必要な実行ファイル path がセットされていることを確認
+        // tool ごとに必要な ResolvedTool がセットされていることを確認
         switch (_disk.Tool)
         {
             case "ndc":
-                if (string.IsNullOrEmpty(_ndcPath))
+                if (_ndc == null)
                 {
-                    Console.Error.WriteLine("slangbuild: ndc path not provided for tool: ndc");
+                    Console.Error.WriteLine("slangbuild: ndc not provided for tool: ndc");
                     return 1;
                 }
                 break;
             case "hudisk":
-                if (string.IsNullOrEmpty(_hudiskPath))
+                if (_hudisk == null)
                 {
-                    Console.Error.WriteLine("slangbuild: HuDisk path not provided for tool: hudisk");
+                    Console.Error.WriteLine("slangbuild: HuDisk not provided for tool: hudisk");
                     return 1;
                 }
                 break;
@@ -179,10 +179,10 @@ public class DiskImageBuilder
     private int WriteEntryNdc(string entryName, string staged, string d88)
     {
         // 旧 entry 削除 (= 失敗無視; entry が無い場合 ndc D は non-zero 終了)
-        RunTool(_ndcPath!, new[] { "D", d88, "0", entryName }, ignoreFailure: true);
+        RunTool(_ndc!, new[] { "D", d88, "0", entryName }, ignoreFailure: true);
 
         // 新 entry 書き込み
-        var rc = RunTool(_ndcPath!, new[] { "P", d88, "0", staged }, ignoreFailure: false);
+        var rc = RunTool(_ndc!, new[] { "P", d88, "0", staged }, ignoreFailure: false);
         if (rc != 0)
             Console.Error.WriteLine($"slangbuild: ndc P failed for {entryName} (exit {rc})");
         return rc;
@@ -199,45 +199,63 @@ public class DiskImageBuilder
     private int WriteEntryHudisk(string entryName, string staged, string d88, bool isMain)
     {
         // 旧 entry 削除 (= 失敗無視)
-        RunTool(_hudiskPath!, new[] { "-d", d88, entryName }, ignoreFailure: true);
+        RunTool(_hudisk!, new[] { "-d", d88, entryName }, ignoreFailure: true);
 
         // 新 entry 追加: -a <d88> <file> [-r <load>] [-g <exec>]
+        // HuDisk は `-r` / `-g` の値を Convert.ToInt32(s, 16) で hex parse する
+        // (`$` prefix は受理せず FormatException)。Makefile.dist の旧 sos 経路
+        // `$(HUDISK) -a ... -r 3000 -g 3000` と同じく `$` 無し hex 文字列で渡す。
         var args = new List<string> { "-a", d88, staged };
         var load = isMain ? _disk.MainLoad : _disk.OverlayLoad;
         if (load.HasValue)
         {
             args.Add("-r");
-            args.Add($"${load.Value:X}"); // ⚠ upstream HuDisk の受理形式要確認
+            args.Add($"{load.Value:X}");
         }
         if (isMain && _disk.MainExec.HasValue)
         {
             args.Add("-g");
-            args.Add($"${_disk.MainExec.Value:X}"); // ⚠ 同上
+            args.Add($"{_disk.MainExec.Value:X}");
         }
-        var rc = RunTool(_hudiskPath!, args.ToArray(), ignoreFailure: false);
+        var rc = RunTool(_hudisk!, args.ToArray(), ignoreFailure: false);
         if (rc != 0)
             Console.Error.WriteLine($"slangbuild: HuDisk -a failed for {entryName} (exit {rc})");
         return rc;
     }
 
     /// <summary>
-    /// subprocess 実行 (ndc / HuDisk 共通)。pipe バッファ詰まり対策で stdout/stderr を
-    /// async で吸い、WaitForExit の timeout が確実に効くようにする (= 同期 ReadToEnd
-    /// を先に呼ぶと child が hang した時に永遠に block する)。
+    /// subprocess 実行 (ndc / HuDisk 共通)。
+    /// ResolvedTool.Kind に応じて起動方法を切り替える:
+    /// - DirectExe: そのまま起動
+    /// - MonoRun: `mono &lt;assembly&gt; &lt;args...&gt;` で起動 (Linux/macOS の HuDisk.exe)
+    /// - DotnetRun: 本ビルダーでは未使用 (slangc 側のみ)
+    ///
+    /// pipe バッファ詰まり対策で stdout/stderr を async で吸い、WaitForExit の
+    /// timeout が確実に効くようにする (= 同期 ReadToEnd を先に呼ぶと child が
+    /// hang した時に永遠に block する)。
     /// </summary>
-    private int RunTool(string exePath, string[] args, bool ignoreFailure)
+    private int RunTool(ResolvedTool tool, string[] args, bool ignoreFailure)
     {
         var psi = new ProcessStartInfo
         {
-            FileName = exePath,
+            FileName = tool.Path,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+
+        if (tool.Kind == ResolutionKind.MonoRun)
+        {
+            // mono <assembly.exe> <args...>
+            psi.ArgumentList.Add(tool.ProjectPath!);
+        }
         foreach (var a in args) psi.ArgumentList.Add(a);
 
         if (_verbose)
-            Console.Error.WriteLine($"+ {exePath} {string.Join(" ", args)}");
+        {
+            var argLine = string.Join(" ", psi.ArgumentList);
+            Console.Error.WriteLine($"+ {tool.Path} {argLine}");
+        }
 
         using var proc = Process.Start(psi)!;
         var stdoutTask = proc.StandardOutput.ReadToEndAsync();
@@ -246,7 +264,8 @@ public class DiskImageBuilder
         {
             try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
             Console.Error.WriteLine(
-                $"slangbuild: tool timed out after 30s: {exePath} {string.Join(" ", args)}");
+                $"slangbuild: tool timed out after 30s: {tool.Path} "
+                + string.Join(" ", psi.ArgumentList));
             return 1;
         }
         var stdout = stdoutTask.GetAwaiter().GetResult();

--- a/src/SLANGCompiler.Build/DiskImageBuilder.cs
+++ b/src/SLANGCompiler.Build/DiskImageBuilder.cs
@@ -9,47 +9,63 @@ namespace SLANGCompiler.Build;
 /// フロー:
 ///   1) template d88 を output へ <b>コピー</b> (= template の direct mutate 禁止)
 ///   2) 一時 staging dir に main bin を <c>disk.main_name</c> (= "PROG.COM") の
-///      名前で copy → ndc D で旧 entry 削除 → ndc P で書き込み
+///      名前で copy → <c>disk.tool</c> (ndc / hudisk) の delete → put で書き込み
 ///   3) overlay 0..N について、<c>disk.overlay_name</c> ("M{index}.BIN") に
-///      置換した名前で同様に copy → D → P
+///      置換した名前で同様に copy → delete → put
 ///   4) finally で staging dir を必ず削除
 ///
-/// Phase 1 制約 (= EnvironmentLoader 側でも一応 validate):
-///   - format = "d88" のみ
-///   - tool = "ndc" のみ
+/// tool 別コマンド形式:
+///   - ndc    : <c>ndc D &lt;d88&gt; 0 &lt;name&gt;</c> / <c>ndc P &lt;d88&gt; 0 &lt;file&gt;</c>
+///   - hudisk : <c>HuDisk -d &lt;d88&gt; &lt;name&gt;</c> /
+///              <c>HuDisk -a &lt;d88&gt; &lt;file&gt; [-r &lt;load&gt;] [-g &lt;exec&gt;]</c>
+///              (main は -r main_load -g main_exec、overlay は -r overlay_load のみ)
 /// </summary>
 public class DiskImageBuilder
 {
     private readonly DiskConfig _disk;
-    private readonly string _ndcPath;
+    private readonly string? _ndcPath;
+    private readonly string? _hudiskPath;
+    private readonly string? _templateOverride;
     private readonly bool _verbose;
 
-    public DiskImageBuilder(DiskConfig disk, string ndcPath, bool verbose = false)
+    /// <summary>
+    /// </summary>
+    /// <param name="disk">env file の disk: セクション</param>
+    /// <param name="ndcPath">tool == "ndc" 時の ndc 実行ファイル絶対パス。それ以外は null 可</param>
+    /// <param name="hudiskPath">tool == "hudisk" 時の HuDisk 実行ファイル絶対パス。それ以外は null 可</param>
+    /// <param name="verbose">subprocess の I/O を stderr に流す</param>
+    /// <param name="templateOverride">--disk-template による env.Disk.Template の上書き</param>
+    public DiskImageBuilder(DiskConfig disk,
+                            string? ndcPath = null,
+                            string? hudiskPath = null,
+                            bool verbose = false,
+                            string? templateOverride = null)
     {
         _disk = disk;
         _ndcPath = ndcPath;
+        _hudiskPath = hudiskPath;
         _verbose = verbose;
+        _templateOverride = templateOverride;
     }
 
     /// <summary>
     /// disk image を組み立てる。成功時 0、失敗時 non-zero を返す。
     /// </summary>
-    /// <param name="mainBinPath">main bin の絶対パス (slangbuild が生成した PROG.bin)</param>
-    /// <param name="overlayBinPaths">overlay bin の絶対パスを index 順 (0..N) に並べたもの</param>
-    /// <param name="outputDiskPath">出力 disk image の絶対パス</param>
     public int Build(string mainBinPath, IList<string> overlayBinPaths, string outputDiskPath)
     {
         // === 事前チェック ===
-        if (string.IsNullOrEmpty(_disk.Template) || !File.Exists(_disk.Template))
+        var templatePath = !string.IsNullOrEmpty(_templateOverride)
+            ? _templateOverride
+            : _disk.Template;
+        if (string.IsNullOrEmpty(templatePath) || !File.Exists(templatePath))
         {
             Console.Error.WriteLine(
-                $"slangbuild: disk template not found: {_disk.Template}");
+                $"slangbuild: disk template not found: {templatePath}");
             return 1;
         }
 
-        var templateAbs = Path.GetFullPath(_disk.Template);
+        var templateAbs = Path.GetFullPath(templatePath);
         var outputAbs = Path.GetFullPath(outputDiskPath);
-        // template を直接書き換える事故を防ぐ
         if (string.Equals(templateAbs, outputAbs, StringComparison.OrdinalIgnoreCase))
         {
             Console.Error.WriteLine(
@@ -68,7 +84,30 @@ public class DiskImageBuilder
             return 1;
         }
 
-        // 出力 dir を作成
+        // tool ごとに必要な実行ファイル path がセットされていることを確認
+        switch (_disk.Tool)
+        {
+            case "ndc":
+                if (string.IsNullOrEmpty(_ndcPath))
+                {
+                    Console.Error.WriteLine("slangbuild: ndc path not provided for tool: ndc");
+                    return 1;
+                }
+                break;
+            case "hudisk":
+                if (string.IsNullOrEmpty(_hudiskPath))
+                {
+                    Console.Error.WriteLine("slangbuild: HuDisk path not provided for tool: hudisk");
+                    return 1;
+                }
+                break;
+            default:
+                Console.Error.WriteLine(
+                    $"slangbuild: unsupported disk.tool: {_disk.Tool}");
+                return 1;
+        }
+
+        // 出力 dir 作成
         var outputDir = Path.GetDirectoryName(outputAbs);
         if (!string.IsNullOrEmpty(outputDir) && !Directory.Exists(outputDir))
             Directory.CreateDirectory(outputDir);
@@ -79,17 +118,17 @@ public class DiskImageBuilder
         File.Copy(templateAbs, outputAbs, overwrite: true);
 
         // === staging dir ===
-        // staging は output と同じ dir に置く (= cross-device の File.Copy 失敗を避ける)
         var stagingDir = outputAbs + ".staging";
         try
         {
             Directory.CreateDirectory(stagingDir);
 
-            // main bin を MainName 名で copy → 書き込み
-            int rc = WriteEntry(mainBinPath, _disk.MainName, outputAbs, stagingDir);
+            // main: MainName 名で copy → 書き込み
+            int rc = WriteEntry(mainBinPath, _disk.MainName, isMain: true,
+                                outputAbs, stagingDir);
             if (rc != 0) return rc;
 
-            // overlay bin を overlay_name 名で copy → 書き込み
+            // overlay: overlay_name 名で copy → 書き込み
             for (int i = 0; i < overlayBinPaths.Count; i++)
             {
                 if (string.IsNullOrEmpty(_disk.OverlayName))
@@ -99,7 +138,8 @@ public class DiskImageBuilder
                     return 1;
                 }
                 var entryName = _disk.OverlayName.Replace("{index}", i.ToString());
-                rc = WriteEntry(overlayBinPaths[i], entryName, outputAbs, stagingDir);
+                rc = WriteEntry(overlayBinPaths[i], entryName, isMain: false,
+                                outputAbs, stagingDir);
                 if (rc != 0) return rc;
             }
 
@@ -118,34 +158,70 @@ public class DiskImageBuilder
     }
 
     /// <summary>
-    /// 1 entry を D88 へ書き込む (= 旧 entry 削除 → P で staging copy を書き込み)。
-    /// staging に entryName 名で copy してから ndc P することで、D88 内の
-    /// ファイル名が source bin の元名 (= PROG.BIN) ではなく entryName (= PROG.COM) になる。
+    /// 1 entry を staging copy → tool 別の delete + put で D88 へ書き込む。
+    /// staging に entryName 名で copy してから put することで、D88 内のファイル名が
+    /// source bin の元名 (= PROG.BIN) ではなく entryName (= PROG.COM) になる。
     /// </summary>
-    private int WriteEntry(string sourceBin, string entryName, string d88, string stagingDir)
+    private int WriteEntry(string sourceBin, string entryName, bool isMain,
+                           string d88, string stagingDir)
     {
         var staged = Path.Combine(stagingDir, entryName);
         File.Copy(sourceBin, staged, overwrite: true);
 
-        // 旧 entry 削除 (= 失敗無視; entry が無い場合 ndc D は non-zero 終了)
-        RunNdc(new[] { "D", d88, "0", entryName }, ignoreFailure: true);
-
-        // 新 entry 書き込み
-        var rc = RunNdc(new[] { "P", d88, "0", staged }, ignoreFailure: false);
-        if (rc != 0)
+        return _disk.Tool switch
         {
-            Console.Error.WriteLine(
-                $"slangbuild: ndc P failed for {entryName} (exit {rc})");
-            return rc;
-        }
-        return 0;
+            "ndc"    => WriteEntryNdc(entryName, staged, d88),
+            "hudisk" => WriteEntryHudisk(entryName, staged, d88, isMain),
+            _        => 1, // Build() 側で validation 済 (= unreachable)
+        };
     }
 
-    private int RunNdc(string[] args, bool ignoreFailure)
+    private int WriteEntryNdc(string entryName, string staged, string d88)
+    {
+        // 旧 entry 削除 (= 失敗無視; entry が無い場合 ndc D は non-zero 終了)
+        RunTool(_ndcPath!, new[] { "D", d88, "0", entryName }, ignoreFailure: true);
+
+        // 新 entry 書き込み
+        var rc = RunTool(_ndcPath!, new[] { "P", d88, "0", staged }, ignoreFailure: false);
+        if (rc != 0)
+            Console.Error.WriteLine($"slangbuild: ndc P failed for {entryName} (exit {rc})");
+        return rc;
+    }
+
+    private int WriteEntryHudisk(string entryName, string staged, string d88, bool isMain)
+    {
+        // 旧 entry 削除 (= 失敗無視)
+        RunTool(_hudiskPath!, new[] { "-d", d88, entryName }, ignoreFailure: true);
+
+        // 新 entry 追加: -a <d88> <file> [-r <load>] [-g <exec>]
+        var args = new List<string> { "-a", d88, staged };
+        var load = isMain ? _disk.MainLoad : _disk.OverlayLoad;
+        if (load.HasValue)
+        {
+            args.Add("-r");
+            args.Add($"${load.Value:X}");
+        }
+        if (isMain && _disk.MainExec.HasValue)
+        {
+            args.Add("-g");
+            args.Add($"${_disk.MainExec.Value:X}");
+        }
+        var rc = RunTool(_hudiskPath!, args.ToArray(), ignoreFailure: false);
+        if (rc != 0)
+            Console.Error.WriteLine($"slangbuild: HuDisk -a failed for {entryName} (exit {rc})");
+        return rc;
+    }
+
+    /// <summary>
+    /// subprocess 実行 (ndc / HuDisk 共通)。pipe バッファ詰まり対策で stdout/stderr を
+    /// async で吸い、WaitForExit の timeout が確実に効くようにする (= 同期 ReadToEnd
+    /// を先に呼ぶと child が hang した時に永遠に block する)。
+    /// </summary>
+    private int RunTool(string exePath, string[] args, bool ignoreFailure)
     {
         var psi = new ProcessStartInfo
         {
-            FileName = _ndcPath,
+            FileName = exePath,
             RedirectStandardOutput = true,
             RedirectStandardError = true,
             UseShellExecute = false,
@@ -153,22 +229,18 @@ public class DiskImageBuilder
         foreach (var a in args) psi.ArgumentList.Add(a);
 
         if (_verbose)
-            Console.Error.WriteLine($"+ {_ndcPath} {string.Join(" ", args)}");
+            Console.Error.WriteLine($"+ {exePath} {string.Join(" ", args)}");
 
         using var proc = Process.Start(psi)!;
-        // pipe バッファが埋まると child が write block するので、stdout/stderr は
-        // async で吸い続ける。同期 ReadToEnd() を先に呼ぶと WaitForExit の timeout
-        // が効かない (child が hang していても pipe close を待ち続けるため)。
         var stdoutTask = proc.StandardOutput.ReadToEndAsync();
         var stderrTask = proc.StandardError.ReadToEndAsync();
         if (!proc.WaitForExit(30_000))
         {
             try { proc.Kill(entireProcessTree: true); } catch { /* best effort */ }
             Console.Error.WriteLine(
-                $"slangbuild: ndc timed out after 30s: {_ndcPath} {string.Join(" ", args)}");
+                $"slangbuild: tool timed out after 30s: {exePath} {string.Join(" ", args)}");
             return 1;
         }
-        // process 終了後なので read は即座に完了する
         var stdout = stdoutTask.GetAwaiter().GetResult();
         var stderr = stderrTask.GetAwaiter().GetResult();
 

--- a/src/SLANGCompiler.Build/DiskImageBuilder.cs
+++ b/src/SLANGCompiler.Build/DiskImageBuilder.cs
@@ -188,14 +188,13 @@ public class DiskImageBuilder
         return rc;
     }
 
-    // ---- HuDisk 経路 (skeleton: 実 binary なしで未検証) ----
+    // ---- HuDisk 経路 (sos / sosx1) ----
     //
-    // ⚠ Phase 2 時点では HuDisk の upstream binary 入手 + ライセンス確認が
-    // 未完了のため、本メソッドは sos.env への disk: 追加を伴う統合 commit
-    // (PR 後段) で実機検証する。特に -r / -g に渡すアドレスを `$XXXX`
-    // 形式 (= Makefile.dist の旧 sos 経路と同形式) で渡しているが、upstream
-    // HuDisk が `0x` / 10 進 / `$` のどれを受理するかは要確認。受理形式が
-    // 異なる場合は本箇所を修正する。
+    // 配布の HuDisk (= ho-ogino/HuDisk fork の feature/write-ascii-mode 版) を
+    // setup-tools で取得済前提。Linux/macOS では mono 経由で起動 (= ToolResolver
+    // が ResolutionKind.MonoRun でラップ)、Windows は .exe 直接起動。
+    // 実機 smoke (macOS): images/SOSPROG.D88 → out.d88 内に PROG.bin
+    // (Load: 3000, Exec: 3000) が入り、template SHA-256 不変を確認済。
     private int WriteEntryHudisk(string entryName, string staged, string d88, bool isMain)
     {
         // 旧 entry 削除 (= 失敗無視)
@@ -203,8 +202,8 @@ public class DiskImageBuilder
 
         // 新 entry 追加: -a <d88> <file> [-r <load>] [-g <exec>]
         // HuDisk は `-r` / `-g` の値を Convert.ToInt32(s, 16) で hex parse する
-        // (`$` prefix は受理せず FormatException)。Makefile.dist の旧 sos 経路
-        // `$(HUDISK) -a ... -r 3000 -g 3000` と同じく `$` 無し hex 文字列で渡す。
+        // (`$XXXX` prefix は FormatException、実機検証で確認済)。Makefile.dist の旧
+        // sos 経路 `$(HUDISK) -a ... -r 3000 -g 3000` と同じ「`$` 無し hex 文字列」で渡す。
         var args = new List<string> { "-a", d88, staged };
         var load = isMain ? _disk.MainLoad : _disk.OverlayLoad;
         if (load.HasValue)

--- a/src/SLANGCompiler.Build/DiskImageBuilder.cs
+++ b/src/SLANGCompiler.Build/DiskImageBuilder.cs
@@ -188,6 +188,14 @@ public class DiskImageBuilder
         return rc;
     }
 
+    // ---- HuDisk 経路 (skeleton: 実 binary なしで未検証) ----
+    //
+    // ⚠ Phase 2 時点では HuDisk の upstream binary 入手 + ライセンス確認が
+    // 未完了のため、本メソッドは sos.env への disk: 追加を伴う統合 commit
+    // (PR 後段) で実機検証する。特に -r / -g に渡すアドレスを `$XXXX`
+    // 形式 (= Makefile.dist の旧 sos 経路と同形式) で渡しているが、upstream
+    // HuDisk が `0x` / 10 進 / `$` のどれを受理するかは要確認。受理形式が
+    // 異なる場合は本箇所を修正する。
     private int WriteEntryHudisk(string entryName, string staged, string d88, bool isMain)
     {
         // 旧 entry 削除 (= 失敗無視)
@@ -199,12 +207,12 @@ public class DiskImageBuilder
         if (load.HasValue)
         {
             args.Add("-r");
-            args.Add($"${load.Value:X}");
+            args.Add($"${load.Value:X}"); // ⚠ upstream HuDisk の受理形式要確認
         }
         if (isMain && _disk.MainExec.HasValue)
         {
             args.Add("-g");
-            args.Add($"${_disk.MainExec.Value:X}");
+            args.Add($"${_disk.MainExec.Value:X}"); // ⚠ 同上
         }
         var rc = RunTool(_hudiskPath!, args.ToArray(), ignoreFailure: false);
         if (rc != 0)

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -388,19 +388,23 @@ public class Driver
             : outputBase + ".d88";
 
         // tool ごとに必要な実行ファイルだけ resolve (= 不要な resolver で fail させない)
-        string? ndcPath = null;
-        string? hudiskPath = null;
+        ResolvedTool? ndc = null;
+        ResolvedTool? hudisk = null;
         if (envConfig.Disk.Tool == "ndc")
         {
-            var ndc = _resolver.ResolveNdc(_opts.NdcPath);
-            ndcPath = ndc.Path;
+            ndc = _resolver.ResolveNdc(_opts.NdcPath);
             if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: using ndc: {ndc.Path}");
         }
         else if (envConfig.Disk.Tool == "hudisk")
         {
-            var hudisk = _resolver.ResolveHudisk(_opts.HudiskPath);
-            hudiskPath = hudisk.Path;
-            if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: using HuDisk: {hudisk.Path}");
+            hudisk = _resolver.ResolveHudisk(_opts.HudiskPath);
+            if (_opts.Verbose)
+            {
+                var via = hudisk.Kind == ResolutionKind.MonoRun
+                    ? $"mono {hudisk.ProjectPath}"
+                    : hudisk.Path;
+                Console.Error.WriteLine($"slangbuild: using HuDisk: {via}");
+            }
         }
 
         // --disk-template が指定されていれば env の disk.template を override
@@ -410,7 +414,7 @@ public class Driver
         if (_opts.Verbose && templateOverride != null)
             Console.Error.WriteLine($"slangbuild: disk template override: {templateOverride}");
 
-        var builder = new DiskImageBuilder(envConfig.Disk, ndcPath, hudiskPath,
+        var builder = new DiskImageBuilder(envConfig.Disk, ndc, hudisk,
                                            _opts.Verbose, templateOverride);
         return builder.Build(mainBin, overlayBins, diskOut);
     }

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -23,6 +23,7 @@ public class Driver
         public string? AsmPath { get; set; }
         public string? SlangcPath { get; set; }
         public string? NdcPath { get; set; }
+        public string? HudiskPath { get; set; }
         public bool KeepAsm { get; set; }
         public bool Verbose { get; set; }
         /// <summary>slangc に pass-through する `-I &lt;path&gt;` の値リスト</summary>
@@ -35,6 +36,9 @@ public class Driver
         /// <summary>`--disk-image &lt;path&gt;`。EmitMode == "disk" 時のみ意味を持つ。
         /// null の場合は &lt;output_prefix&gt;.d88 を使う。</summary>
         public string? DiskImagePath { get; set; }
+        /// <summary>`--disk-template &lt;path&gt;`。env file の disk.template を CLI で
+        /// override する。EmitMode == "disk" 時のみ意味を持つ。null/空なら env 値を使う。</summary>
+        public string? DiskTemplatePath { get; set; }
     }
 
     private readonly Options _opts;
@@ -364,17 +368,17 @@ public class Driver
             return 1;
         }
 
-        // Phase 1 制約 (format / tool)
+        // 制約 check (Phase 2: format=d88 のみ、tool=ndc/hudisk 許容)
         if (envConfig.Disk.Format != "d88")
         {
             Console.Error.WriteLine(
-                $"slangbuild: Phase 1 supports only disk.format: d88 (got: {envConfig.Disk.Format})");
+                $"slangbuild: only disk.format: d88 supported (got: {envConfig.Disk.Format})");
             return 1;
         }
-        if (envConfig.Disk.Tool != "ndc")
+        if (envConfig.Disk.Tool != "ndc" && envConfig.Disk.Tool != "hudisk")
         {
             Console.Error.WriteLine(
-                $"slangbuild: Phase 1 supports only disk.tool: ndc (got: {envConfig.Disk.Tool})");
+                $"slangbuild: only disk.tool: ndc or hudisk supported (got: {envConfig.Disk.Tool})");
             return 1;
         }
 
@@ -383,10 +387,31 @@ public class Driver
             ? Path.GetFullPath(_opts.DiskImagePath)
             : outputBase + ".d88";
 
-        var ndc = _resolver.ResolveNdc(_opts.NdcPath);
-        if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: using ndc: {ndc.Path}");
+        // tool ごとに必要な実行ファイルだけ resolve (= 不要な resolver で fail させない)
+        string? ndcPath = null;
+        string? hudiskPath = null;
+        if (envConfig.Disk.Tool == "ndc")
+        {
+            var ndc = _resolver.ResolveNdc(_opts.NdcPath);
+            ndcPath = ndc.Path;
+            if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: using ndc: {ndc.Path}");
+        }
+        else if (envConfig.Disk.Tool == "hudisk")
+        {
+            var hudisk = _resolver.ResolveHudisk(_opts.HudiskPath);
+            hudiskPath = hudisk.Path;
+            if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: using HuDisk: {hudisk.Path}");
+        }
 
-        var builder = new DiskImageBuilder(envConfig.Disk, ndc.Path, _opts.Verbose);
+        // --disk-template が指定されていれば env の disk.template を override
+        var templateOverride = !string.IsNullOrEmpty(_opts.DiskTemplatePath)
+            ? Path.GetFullPath(_opts.DiskTemplatePath)
+            : null;
+        if (_opts.Verbose && templateOverride != null)
+            Console.Error.WriteLine($"slangbuild: disk template override: {templateOverride}");
+
+        var builder = new DiskImageBuilder(envConfig.Disk, ndcPath, hudiskPath,
+                                           _opts.Verbose, templateOverride);
         return builder.Build(mainBin, overlayBins, diskOut);
     }
 

--- a/src/SLANGCompiler.Build/Program.cs
+++ b/src/SLANGCompiler.Build/Program.cs
@@ -50,11 +50,17 @@ internal class Program
                 case "--ndc" when i + 1 < args.Length:
                     opts.NdcPath = args[++i];
                     break;
+                case "--hudisk" when i + 1 < args.Length:
+                    opts.HudiskPath = args[++i];
+                    break;
                 case "--emit" when i + 1 < args.Length:
                     opts.EmitMode = args[++i];
                     break;
                 case "--disk-image" when i + 1 < args.Length:
                     opts.DiskImagePath = args[++i];
+                    break;
+                case "--disk-template" when i + 1 < args.Length:
+                    opts.DiskTemplatePath = args[++i];
                     break;
                 case "-I" when i + 1 < args.Length:
                     opts.IncludePaths.Add(args[++i]);
@@ -97,6 +103,12 @@ internal class Program
                 "slangbuild: --disk-image requires --emit disk");
             return 1;
         }
+        if (opts.EmitMode != "disk" && !string.IsNullOrEmpty(opts.DiskTemplatePath))
+        {
+            Console.Error.WriteLine(
+                "slangbuild: --disk-template requires --emit disk");
+            return 1;
+        }
 
         try
         {
@@ -122,9 +134,11 @@ internal class Program
         Console.Error.WriteLine("  -L <path>       Library search path passed to slangc (repeatable)");
         Console.Error.WriteLine("  --asm <path>    AILZ80ASM executable path (override resolution)");
         Console.Error.WriteLine("  --slangc <path> slangc executable path (override resolution)");
-        Console.Error.WriteLine("  --ndc <path>    ndc executable path (override resolution; --emit disk)");
+        Console.Error.WriteLine("  --ndc <path>    ndc executable path (override resolution; --emit disk + tool=ndc)");
+        Console.Error.WriteLine("  --hudisk <path> HuDisk executable path (override resolution; --emit disk + tool=hudisk)");
         Console.Error.WriteLine("  --emit <mode>   Output mode: 'bin' (default) or 'disk' (build d88)");
         Console.Error.WriteLine("  --disk-image <p> Output disk image path (default: <output_prefix>.d88)");
+        Console.Error.WriteLine("  --disk-template <p> Override env's disk.template path (--emit disk)");
         Console.Error.WriteLine("  --keep-asm      Keep intermediate ASM / sym files");
         Console.Error.WriteLine("  --verbose       Show subprocess (slangc / AILZ80ASM) output");
         Console.Error.WriteLine("  -h, --help      Show this help");
@@ -134,5 +148,6 @@ internal class Program
         Console.Error.WriteLine("  slangc:    --slangc → bundled bin → PATH → dotnet run (dev)");
         Console.Error.WriteLine("  AILZ80ASM: --asm → AILZ80ASM_PATH env → PATH → bundled tools/ → repo root (dev)");
         Console.Error.WriteLine("  ndc:       --ndc → NDC_PATH env → bundled tools/ → PATH → repo root (dev)");
+        Console.Error.WriteLine("  HuDisk:    --hudisk → HUDISK_PATH env → bundled tools/ → PATH → repo root (dev)");
     }
 }

--- a/src/SLANGCompiler.Build/ToolResolver.cs
+++ b/src/SLANGCompiler.Build/ToolResolver.cs
@@ -242,6 +242,45 @@ public class ToolResolver
             + "Specify --ndc <path> explicitly.");
     }
 
+    /// <summary>
+    /// HuDisk (S-OS hu-basic 系 .dsk/.d88 操作ツール) を解決。`--emit disk` の
+    /// tool: hudisk 経路で必要 (sos / sosx1 等)。解決順は ResolveNdc と同じ:
+    /// 1) cliOverride (--hudisk)
+    /// 2) HUDISK_PATH 環境変数
+    /// 3) {baseDir}/tools/HuDisk(.exe)
+    /// 4) {baseDir}/../tools/HuDisk(.exe)
+    /// 5) PATH 上の HuDisk
+    /// 6) repo root 基準 tools/HuDisk(.exe) (dev fallback)
+    /// </summary>
+    public ResolvedTool ResolveHudisk(string? cliOverride)
+    {
+        if (!string.IsNullOrEmpty(cliOverride) && File.Exists(cliOverride))
+            return new ResolvedTool(cliOverride, ResolutionKind.DirectExe);
+
+        var envPath = Environment.GetEnvironmentVariable("HUDISK_PATH");
+        if (!string.IsNullOrEmpty(envPath) && File.Exists(envPath))
+            return new ResolvedTool(envPath, ResolutionKind.DirectExe);
+
+        var name = $"HuDisk{ExeSuffix}";
+
+        var bundledSibling = Path.Combine(_baseDir, "tools", name);
+        if (File.Exists(bundledSibling)) return new ResolvedTool(bundledSibling, ResolutionKind.DirectExe);
+        var bundledParent = Path.Combine(_baseDir, "..", "tools", name);
+        if (File.Exists(bundledParent))
+            return new ResolvedTool(Path.GetFullPath(bundledParent), ResolutionKind.DirectExe);
+
+        var onPath = FindOnPath(name);
+        if (onPath != null) return new ResolvedTool(onPath, ResolutionKind.DirectExe);
+
+        var repoTools = LocateRepoFile($"tools/{name}");
+        if (repoTools != null) return new ResolvedTool(repoTools, ResolutionKind.DirectExe);
+
+        throw new FileNotFoundException(
+            "HuDisk not found. Tried: --hudisk, $HUDISK_PATH, bundled "
+            + "{baseDir}/tools, {baseDir}/../tools, PATH, and repo root. "
+            + "Specify --hudisk <path> explicitly.");
+    }
+
     private string? ResolveExecutable(string? cliOverride, string fileName, bool includeBundledTools)
     {
         if (!string.IsNullOrEmpty(cliOverride) && File.Exists(cliOverride))

--- a/src/SLANGCompiler.Build/ToolResolver.cs
+++ b/src/SLANGCompiler.Build/ToolResolver.cs
@@ -230,6 +230,13 @@ public class ToolResolver
         if (File.Exists(bundledParent))
             return new ResolvedTool(Path.GetFullPath(bundledParent), ResolutionKind.DirectExe);
 
+        // install dir (~/.config/SLANG/tools/, $SLANG_HOME/tools/) — make install 後の経路
+        foreach (var installDir in GetInstallToolDirs())
+        {
+            var p = Path.Combine(installDir, name);
+            if (File.Exists(p)) return new ResolvedTool(p, ResolutionKind.DirectExe);
+        }
+
         var onPath = FindOnPath(name);
         if (onPath != null) return new ResolvedTool(onPath, ResolutionKind.DirectExe);
 
@@ -238,47 +245,111 @@ public class ToolResolver
 
         throw new FileNotFoundException(
             "ndc not found. Tried: --ndc, $NDC_PATH, bundled "
-            + "{baseDir}/tools, {baseDir}/../tools, PATH, and repo root. "
-            + "Specify --ndc <path> explicitly.");
+            + "{baseDir}/tools, {baseDir}/../tools, install dir tools/, PATH, and repo root. "
+            + "Run `make setup-tools` to download, or specify --ndc <path> explicitly.");
     }
 
     /// <summary>
     /// HuDisk (S-OS hu-basic 系 .dsk/.d88 操作ツール) を解決。`--emit disk` の
-    /// tool: hudisk 経路で必要 (sos / sosx1 等)。解決順は ResolveNdc と同じ:
+    /// tool: hudisk 経路で必要 (sos / sosx1 等)。
+    ///
+    /// 配布物の HuDisk は ho-ogino/HuDisk fork (= ASCII 書き込み可能版) の
+    /// .NET assembly (HuDisk.exe)。Windows では .exe を直接実行できるが
+    /// Linux/macOS では mono 必須 → 後者では <see cref="ResolutionKind.MonoRun"/>
+    /// として返す (= setupenv.sh も同等の前提で mono 必須チェック済)。
+    ///
+    /// 解決順 (ndc とほぼ同じ、bundled に install dir も含める):
     /// 1) cliOverride (--hudisk)
     /// 2) HUDISK_PATH 環境変数
     /// 3) {baseDir}/tools/HuDisk(.exe)
     /// 4) {baseDir}/../tools/HuDisk(.exe)
-    /// 5) PATH 上の HuDisk
-    /// 6) repo root 基準 tools/HuDisk(.exe) (dev fallback)
+    /// 5) install dir (= ~/.config/SLANG/tools/HuDisk(.exe), $SLANG_HOME/tools/...)
+    /// 6) PATH 上の HuDisk
+    /// 7) repo root 基準 tools/HuDisk(.exe) (dev fallback)
     /// </summary>
     public ResolvedTool ResolveHudisk(string? cliOverride)
     {
+        // HuDisk は Windows: 直接 .exe、Linux/macOS: mono 経由が正解。
+        // 両方を見て、見つかった path を OS 判定で kind 振り分け。
+        // 配布の HuDisk.exe は .NET assembly なので拡張子は OS 問わず .exe
+        // (setupenv が curl で .exe を取得する)。よってここでは ".exe" 固定で探索。
+        const string assemblyName = "HuDisk.exe";
+        // 念のため Windows native (= 拡張子なしの HuDisk) も後方互換で探索
+        var fallbackName = $"HuDisk{ExeSuffix}";
+
         if (!string.IsNullOrEmpty(cliOverride) && File.Exists(cliOverride))
-            return new ResolvedTool(cliOverride, ResolutionKind.DirectExe);
+            return MakeHudiskResolved(cliOverride);
 
         var envPath = Environment.GetEnvironmentVariable("HUDISK_PATH");
         if (!string.IsNullOrEmpty(envPath) && File.Exists(envPath))
-            return new ResolvedTool(envPath, ResolutionKind.DirectExe);
+            return MakeHudiskResolved(envPath);
 
-        var name = $"HuDisk{ExeSuffix}";
+        foreach (var name in new[] { assemblyName, fallbackName })
+        {
+            var bundledSibling = Path.Combine(_baseDir, "tools", name);
+            if (File.Exists(bundledSibling))
+                return MakeHudiskResolved(bundledSibling);
+            var bundledParent = Path.Combine(_baseDir, "..", "tools", name);
+            if (File.Exists(bundledParent))
+                return MakeHudiskResolved(Path.GetFullPath(bundledParent));
 
-        var bundledSibling = Path.Combine(_baseDir, "tools", name);
-        if (File.Exists(bundledSibling)) return new ResolvedTool(bundledSibling, ResolutionKind.DirectExe);
-        var bundledParent = Path.Combine(_baseDir, "..", "tools", name);
-        if (File.Exists(bundledParent))
-            return new ResolvedTool(Path.GetFullPath(bundledParent), ResolutionKind.DirectExe);
+            // install dir (~/.config/SLANG/tools/, $SLANG_HOME/tools/)
+            foreach (var installDir in GetInstallToolDirs())
+            {
+                var p = Path.Combine(installDir, name);
+                if (File.Exists(p)) return MakeHudiskResolved(p);
+            }
 
-        var onPath = FindOnPath(name);
-        if (onPath != null) return new ResolvedTool(onPath, ResolutionKind.DirectExe);
+            var onPath = FindOnPath(name);
+            if (onPath != null) return MakeHudiskResolved(onPath);
 
-        var repoTools = LocateRepoFile($"tools/{name}");
-        if (repoTools != null) return new ResolvedTool(repoTools, ResolutionKind.DirectExe);
+            var repoTools = LocateRepoFile($"tools/{name}");
+            if (repoTools != null) return MakeHudiskResolved(repoTools);
+        }
 
         throw new FileNotFoundException(
             "HuDisk not found. Tried: --hudisk, $HUDISK_PATH, bundled "
-            + "{baseDir}/tools, {baseDir}/../tools, PATH, and repo root. "
-            + "Specify --hudisk <path> explicitly.");
+            + "{baseDir}/tools, {baseDir}/../tools, install dir tools/, PATH, and repo root. "
+            + "Run `make setup-tools` to download, or specify --hudisk <path> explicitly.");
+    }
+
+    /// <summary>
+    /// HuDisk path を ResolvedTool に包む。.exe 拡張子を持ち non-Windows なら
+    /// MonoRun 扱い (= mono &lt;exe&gt; で起動)、それ以外は DirectExe。
+    /// </summary>
+    private ResolvedTool MakeHudiskResolved(string hudiskPath)
+    {
+        var ext = Path.GetExtension(hudiskPath);
+        bool isDotnetAssembly = string.Equals(ext, ".exe", StringComparison.OrdinalIgnoreCase);
+        if (isDotnetAssembly && !IsWindows)
+        {
+            // mono が無いと結局起動失敗するので、ここで早期発見させる
+            var mono = FindOnPath("mono");
+            if (mono == null)
+                throw new FileNotFoundException(
+                    $"HuDisk found at {hudiskPath} but `mono` not on PATH. "
+                    + "Install mono (Linux/macOS) or specify a native HuDisk via --hudisk.");
+            return new ResolvedTool(mono, ResolutionKind.MonoRun, hudiskPath);
+        }
+        return new ResolvedTool(hudiskPath, ResolutionKind.DirectExe);
+    }
+
+    /// <summary>
+    /// install dir (= make install で配置される) 配下の tools/ を返す。
+    /// SLANG_HOME → ~/.config/SLANG の順、存在するもののみ。
+    /// </summary>
+    private static IEnumerable<string> GetInstallToolDirs()
+    {
+        var slangHome = Environment.GetEnvironmentVariable("SLANG_HOME");
+        if (!string.IsNullOrEmpty(slangHome))
+        {
+            var p = Path.Combine(slangHome, "tools");
+            if (Directory.Exists(p)) yield return p;
+        }
+        var configTools = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".config", "SLANG", "tools");
+        if (Directory.Exists(configTools)) yield return configTools;
     }
 
     private string? ResolveExecutable(string? cliOverride, string fileName, bool includeBundledTools)
@@ -337,14 +408,18 @@ public class ToolResolver
 
 public enum ResolutionKind
 {
-    /// <summary>実行ファイルを直接 spawn (slangc / AILZ80ASM)</summary>
+    /// <summary>実行ファイルを直接 spawn (slangc / AILZ80ASM / Windows の HuDisk.exe)</summary>
     DirectExe,
-    /// <summary>dotnet run --project &lt;csproj&gt; 経由 (dev fallback)</summary>
+    /// <summary>dotnet run --project &lt;csproj&gt; 経由 (dev fallback、slangc 用)</summary>
     DotnetRun,
+    /// <summary>mono &lt;assembly.exe&gt; 経由 (Linux/macOS の HuDisk.exe 用)</summary>
+    MonoRun,
 }
 
 /// <summary>
-/// 解決結果。`Kind == DotnetRun` の場合 `Path` は dotnet の絶対パス、
-/// `ProjectPath` は --project に渡す csproj のパス。
+/// 解決結果。Kind ごとに Path の意味が異なる:
+/// - DirectExe: 実行ファイル絶対パス (= そのまま spawn)
+/// - DotnetRun: dotnet の絶対パス、ProjectPath は --project に渡す csproj
+/// - MonoRun: mono の絶対パス、ProjectPath は mono に渡す .NET assembly (.exe)
 /// </summary>
 public record ResolvedTool(string Path, ResolutionKind Kind, string? ProjectPath = null);

--- a/src/SLANGCompiler.Build/ToolResolver.cs
+++ b/src/SLANGCompiler.Build/ToolResolver.cs
@@ -194,13 +194,23 @@ public class ToolResolver
         if (File.Exists(bundledParent))
             return new ResolvedTool(Path.GetFullPath(bundledParent), ResolutionKind.DirectExe);
 
+        // install dir (~/.config/SLANG/tools/, $SLANG_HOME/tools/) — make install 後の経路
+        // (Phase 2 で追加: setup-tools → install で AILZ80ASM が install dir 配下に
+        //  入るが、それを slangbuild から見つけられないと「AILZ80ASM not found」エラー)
+        foreach (var installDir in GetInstallToolDirs())
+        {
+            var p = Path.Combine(installDir, name);
+            if (File.Exists(p)) return new ResolvedTool(p, ResolutionKind.DirectExe);
+        }
+
         var repoTools = LocateRepoFile($"tools/{name}");
         if (repoTools != null) return new ResolvedTool(repoTools, ResolutionKind.DirectExe);
 
         throw new FileNotFoundException(
             "AILZ80ASM not found. Tried: --asm, $AILZ80ASM_PATH, PATH, bundled "
-            + "{baseDir}/tools, {baseDir}/../tools, and repo root. "
-            + "Specify --asm <path> explicitly.");
+            + "{baseDir}/tools, {baseDir}/../tools, install dir tools/, and repo root. "
+            + "Run `make setup-tools` and `make install` to populate, "
+            + "or specify --asm <path> explicitly.");
     }
 
     /// <summary>

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
@@ -47,4 +47,15 @@ public class DiskConfig
     /// `{index}` placeholder を 0..N に展開して使う。
     /// </summary>
     public string OverlayName { get; set; } = "";
+
+    /// <summary>HuDisk の <c>-r &lt;load&gt;</c> 引数。null なら付けない (= ndc 等の
+    /// load address 概念無しツール)。</summary>
+    public int? MainLoad { get; set; }
+
+    /// <summary>HuDisk の <c>-g &lt;exec&gt;</c> 引数。null なら付けない。</summary>
+    public int? MainExec { get; set; }
+
+    /// <summary>overlay の load address。null なら -r を付けない。
+    /// (overlay には exec を付けない sos の慣習)</summary>
+    public int? OverlayLoad { get; set; }
 }

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
@@ -23,11 +23,12 @@ public class EnvironmentConfig
 
 /// <summary>
 /// `disk:` セクション (slangbuild --emit disk 用)。
-/// Phase 1 では format=d88 + tool=ndc のみサポート。
+/// 現状サポートは format=d88、tool=ndc / hudisk (sos.env への適用は素材揃い
+/// 後の Phase で予定)。
 /// </summary>
 public class DiskConfig
 {
-    /// <summary>"d88" 等。Phase 1 は "d88" のみ</summary>
+    /// <summary>"d88" のみ</summary>
     public string Format { get; set; } = "";
 
     /// <summary>
@@ -36,7 +37,7 @@ public class DiskConfig
     /// </summary>
     public string Template { get; set; } = "";
 
-    /// <summary>"ndc" 等。Phase 1 は "ndc" のみ</summary>
+    /// <summary>"ndc" / "hudisk"</summary>
     public string Tool { get; set; } = "";
 
     /// <summary>main bin の disk 内ファイル名 (例: "PROG.COM")</summary>

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentLoader.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentLoader.cs
@@ -67,6 +67,13 @@ public class EnvironmentLoader
                 MainName = raw.Disk.MainName ?? "",
                 OverlayName = raw.Disk.OverlayName ?? "",
             };
+            // HuDisk の -r / -g 用 (lsx/x1 では未指定 = null のまま)
+            if (!string.IsNullOrEmpty(raw.Disk.MainLoad))
+                config.Disk.MainLoad = ParseAddress(raw.Disk.MainLoad);
+            if (!string.IsNullOrEmpty(raw.Disk.MainExec))
+                config.Disk.MainExec = ParseAddress(raw.Disk.MainExec);
+            if (!string.IsNullOrEmpty(raw.Disk.OverlayLoad))
+                config.Disk.OverlayLoad = ParseAddress(raw.Disk.OverlayLoad);
         }
 
         return config;
@@ -126,5 +133,15 @@ public class EnvironmentLoader
 
         [YamlMember(Alias = "overlay_name")]
         public string? OverlayName { get; set; }
+
+        // HuDisk -r / -g 用 (string で受けて ParseAddress で int 化)
+        [YamlMember(Alias = "main_load")]
+        public string? MainLoad { get; set; }
+
+        [YamlMember(Alias = "main_exec")]
+        public string? MainExec { get; set; }
+
+        [YamlMember(Alias = "overlay_load")]
+        public string? OverlayLoad { get; set; }
     }
 }

--- a/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
@@ -94,6 +94,10 @@ public class BuildIntegrationTests : IDisposable
 
     private (int ExitCode, string Stdout, string Stderr) RunSlangbuild(
         string inputPath, params string[] extraArgs)
+        => RunSlangbuildWithSlangHome(_projectRoot, inputPath, extraArgs);
+
+    private (int ExitCode, string Stdout, string Stderr) RunSlangbuildWithSlangHome(
+        string slangHome, string inputPath, string[] extraArgs)
     {
         var buildProject = Path.Combine(_projectRoot, "src", "SLANGCompiler.Build", "SLANGCompiler.Build.csproj");
         var psi = new ProcessStartInfo
@@ -104,9 +108,10 @@ public class BuildIntegrationTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
-        // SLANG_HOME を _projectRoot に固定 (= installed `~/.config/SLANG` の古い env
-        // を参照しないようにし、新 disk: セクション込みの repo 内 lsx.env を読ませる)
-        psi.Environment["SLANG_HOME"] = _projectRoot;
+        // SLANG_HOME を override: 既定は _projectRoot (= installed `~/.config/SLANG` の
+        // 古い env を参照しないようにし、新 disk: セクション込みの repo 内 lsx.env を
+        // 読ませる)。InstalledEnv テスト等は mock install dir を渡す
+        psi.Environment["SLANG_HOME"] = slangHome;
         psi.ArgumentList.Add("run");
         psi.ArgumentList.Add("--project");
         psi.ArgumentList.Add(buildProject);
@@ -552,6 +557,122 @@ MYSUB() BEGIN END;
             "--emit", "disk");
         Assert.NotEqual(0, code);
         Assert.Contains("disk:", stderr);
+    }
+
+    [Fact]
+    public void EmitDisk_DiskTemplateOverride_UsesCustomPath()
+    {
+        // --disk-template で env の disk.template を override できる。
+        // override 用に pristine template を別 path にコピーして渡す。
+        var customTemplate = Path.Combine(_tempDir, "custom_template.D88");
+        File.Copy(Path.Combine(_projectRoot, "images", "templates", "LSXPROG.D88"),
+                  customTemplate);
+
+        var slPath = Path.Combine(_tempDir, "ovrtmpl.SL");
+        File.WriteAllText(slPath, @"
+MAIN() BEGIN MYSUB(); END;
+#MODULE $3000
+MYSUB() BEGIN END;
+#END
+");
+        var diskOut = Path.Combine(_tempDir, "ovrtmpl.d88");
+        var (code, _, stderr) = RunSlangbuild(slPath,
+            "-E", "lsx",
+            "--ndc", NdcPath(),
+            "--emit", "disk",
+            "--disk-template", customTemplate,
+            "--disk-image", diskOut);
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+        Assert.True(File.Exists(diskOut));
+        Assert.True(D88ContainsEntry(diskOut, "PROG.COM"));
+        Assert.True(D88ContainsEntry(diskOut, "M0.BIN"));
+    }
+
+    [Fact]
+    public void EmitDisk_DiskTemplateOverride_RequiresEmitDisk()
+    {
+        // --disk-template 単独 (= --emit disk なし) → error
+        var slPath = Path.Combine(_tempDir, "tplsolo.SL");
+        File.WriteAllText(slPath, "MAIN() BEGIN END;\n");
+        var (code, _, stderr) = RunSlangbuild(slPath,
+            "--disk-template", "/tmp/anything.D88");
+        Assert.NotEqual(0, code);
+        Assert.Contains("--disk-template requires --emit disk", stderr);
+    }
+
+    [Fact]
+    public void EmitDisk_DiskTemplateOverride_PreservesCustomTemplate()
+    {
+        // override 経由でも template の SHA-256 は build 前後で一致する
+        // (Codex Phase 1 重要指摘の継承: template direct mutate 禁止)
+        var customTemplate = Path.Combine(_tempDir, "preserve.D88");
+        File.Copy(Path.Combine(_projectRoot, "images", "templates", "LSXPROG.D88"),
+                  customTemplate);
+        var hashBefore = ComputeSha256(customTemplate);
+
+        var slPath = Path.Combine(_tempDir, "preserve.SL");
+        File.WriteAllText(slPath, @"
+MAIN() BEGIN MYSUB(); END;
+#MODULE $3000
+MYSUB() BEGIN END;
+#END
+");
+        var (code, _, stderr) = RunSlangbuild(slPath,
+            "-E", "lsx",
+            "--ndc", NdcPath(),
+            "--emit", "disk",
+            "--disk-template", customTemplate,
+            "--disk-image", Path.Combine(_tempDir, "preserve_out.d88"));
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+        Assert.Equal(hashBefore, ComputeSha256(customTemplate));
+    }
+
+    [Fact]
+    public void InstalledEnv_TemplateResolves()
+    {
+        // installed 環境 (= ~/.config/SLANG/runtime/env/lsx.env) でも env file の
+        // disk.template (= ../../images/templates/LSXPROG.D88) が install dir 配下の
+        // images/templates に解決できることを mock で保証する。
+        // → make install で images/ コピーが抜けると即 fail する CI gate。
+        var installDir = Path.Combine(_tempDir, "mock_install");
+        var runtimeDir = Path.Combine(installDir, "runtime");
+        var envDir = Path.Combine(runtimeDir, "env");
+        var imagesTemplatesDir = Path.Combine(installDir, "images", "templates");
+        Directory.CreateDirectory(envDir);
+        Directory.CreateDirectory(imagesTemplatesDir);
+
+        // env file (全 env) と runtime asm を mock install dir に staging
+        foreach (var f in Directory.GetFiles(Path.Combine(_projectRoot, "runtime", "env")))
+            File.Copy(f, Path.Combine(envDir, Path.GetFileName(f)));
+        foreach (var f in Directory.GetFiles(Path.Combine(_projectRoot, "runtime"), "*.asm"))
+            File.Copy(f, Path.Combine(runtimeDir, Path.GetFileName(f)));
+        // template も install dir 配下に配置 (= make install で images/ コピーされた状態を再現)
+        File.Copy(
+            Path.Combine(_projectRoot, "images", "templates", "LSXPROG.D88"),
+            Path.Combine(imagesTemplatesDir, "LSXPROG.D88"));
+
+        var slPath = Path.Combine(_tempDir, "instchk.SL");
+        File.WriteAllText(slPath, @"
+MAIN() BEGIN MYSUB(); END;
+#MODULE $3000
+MYSUB() BEGIN END;
+#END
+");
+        var diskOut = Path.Combine(_tempDir, "instchk.d88");
+        // SLANG_HOME = mock install dir、即ち PathResolver は env も template も
+        // install dir 配下を引く
+        var (code, _, stderr) = RunSlangbuildWithSlangHome(installDir, slPath, new[]
+        {
+            "-E", "lsx",
+            "--ndc", NdcPath(),
+            "--emit", "disk",
+            "--disk-image", diskOut,
+        });
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+        Assert.True(File.Exists(diskOut),
+            $"disk image not produced from installed env. stderr: {stderr}");
+        Assert.True(D88ContainsEntry(diskOut, "PROG.COM"));
+        Assert.True(D88ContainsEntry(diskOut, "M0.BIN"));
     }
 
     [Fact]

--- a/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Xunit;
+using SkippableFactAttribute = Xunit.SkippableFactAttribute;
 
 namespace SLANGCompiler.Tests;
 
@@ -137,6 +138,24 @@ public class BuildIntegrationTests : IDisposable
     {
         var name = OperatingSystem.IsWindows() ? "ndc.exe" : "ndc";
         return Path.Combine(_projectRoot, "tools", name);
+    }
+
+    /// <summary>repo root の tools/HuDisk.exe パスを返す。Sos テスト用。
+    /// 配布 fork が .NET assembly のみのため OS 問わず .exe 拡張子。</summary>
+    private string HudiskPath()
+        => Path.Combine(_projectRoot, "tools", "HuDisk.exe");
+
+    /// <summary>HuDisk.exe + (non-Windows なら mono) が揃っているか。
+    /// 揃っていなければ sos 系テストは Skip。</summary>
+    private bool HudiskAvailable()
+    {
+        if (!File.Exists(HudiskPath())) return false;
+        if (OperatingSystem.IsWindows()) return true;
+        // Linux/macOS では mono が PATH にあるか確認
+        var path = Environment.GetEnvironmentVariable("PATH");
+        if (string.IsNullOrEmpty(path)) return false;
+        return path.Split(Path.PathSeparator).Any(d =>
+            !string.IsNullOrEmpty(d) && File.Exists(Path.Combine(d, "mono")));
     }
 
     /// <summary>
@@ -673,6 +692,58 @@ MYSUB() BEGIN END;
             $"disk image not produced from installed env. stderr: {stderr}");
         Assert.True(D88ContainsEntry(diskOut, "PROG.COM"));
         Assert.True(D88ContainsEntry(diskOut, "M0.BIN"));
+    }
+
+    [SkippableFact]
+    public void EmitDisk_SosEnv_ProducesD88WithMain()
+    {
+        // sos env で HuDisk 経由の D88 生成 (Linux/macOS では mono 経由)。
+        // template (= images/templates/SOSPROG.D88) は setup-tools で生成済の
+        // 前提。HuDisk.exe + mono が揃っていなければ Skip (= setup-tools 未実行
+        // の dev 環境 / CI で適切にハンドル)。
+        Skip.IfNot(HudiskAvailable(),
+            "sos test requires HuDisk.exe (run `make setup-tools`) + mono on PATH");
+        Skip.IfNot(File.Exists(Path.Combine(_projectRoot, "images", "templates", "SOSPROG.D88")),
+            "sos test requires images/templates/SOSPROG.D88 (run `make setup-tools`)");
+
+        var slPath = Path.Combine(_tempDir, "sostest.SL");
+        File.WriteAllText(slPath, "MAIN() BEGIN END;\n");
+        var diskOut = Path.Combine(_tempDir, "sosout.d88");
+        var (code, _, stderr) = RunSlangbuild(slPath,
+            "-E", "sos",
+            "--hudisk", HudiskPath(),
+            "--emit", "disk",
+            "--disk-image", diskOut);
+        Assert.True(code == 0, $"slangbuild --emit disk (sos) failed (exit {code}). stderr: {stderr}");
+        Assert.True(File.Exists(diskOut), $"sos disk image not produced at {diskOut}");
+        // sos の disk listing は HuDisk で行う必要があるが、ndc では読めない場合
+        // も多い (HuDisk fs)。ここでは「ファイル生成」+「テンプレート不変」を
+        // 主検証とし、内容詳細は EmitDisk_SosTemplateNotMutated で別途確認
+    }
+
+    [SkippableFact]
+    public void EmitDisk_SosTemplateNotMutated()
+    {
+        // sos でも template (images/templates/SOSPROG.D88) は build 前後で
+        // SHA-256 一致 (Codex Phase 1 重要指摘の継承)。
+        Skip.IfNot(HudiskAvailable(),
+            "sos test requires HuDisk.exe + mono");
+        var template = Path.Combine(_projectRoot, "images", "templates", "SOSPROG.D88");
+        Skip.IfNot(File.Exists(template),
+            "sos test requires images/templates/SOSPROG.D88 (run `make setup-tools`)");
+
+        var hashBefore = ComputeSha256(template);
+
+        var slPath = Path.Combine(_tempDir, "sostpl.SL");
+        File.WriteAllText(slPath, "MAIN() BEGIN END;\n");
+        var (code, _, stderr) = RunSlangbuild(slPath,
+            "-E", "sos",
+            "--hudisk", HudiskPath(),
+            "--emit", "disk",
+            "--disk-image", Path.Combine(_tempDir, "sostpl_out.d88"));
+        Assert.True(code == 0, $"slangbuild failed (exit {code}). stderr: {stderr}");
+
+        Assert.Equal(hashBefore, ComputeSha256(template));
     }
 
     [Fact]

--- a/tests/SLANGCompiler.Tests/SLANGCompiler.Tests.csproj
+++ b/tests/SLANGCompiler.Tests/SLANGCompiler.Tests.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="Xunit.SkippableFact" Version="1.5.61" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\SLANGCompiler.Core\SLANGCompiler.Core.csproj" />


### PR DESCRIPTION
## Summary

Phase 2 (issue #157) の完成版。Phase 1 (PR #158) で導入した `slangbuild --emit disk` フレームを **sos / sosx1 (HuDisk 経路)** + **installed 環境対応** + **`--disk-template` 上書き** まで拡張、v0.23.0 リリースに含める。

**stacked PR**: base = `feature/slangbuild-emit-disk` (= Phase 1 PR #158)。Phase 1 マージ後に自動で base が `release/v0.23.0` に追従し、Phase 1 + Phase 2 が連続 commit で release branch に入る想定。

## 主要変更

### (1) sos / sosx1 (HuDisk) を `--emit disk` 経路に統合
- `runtime/env/sos.env` / `sosx1.env` に `disk:` セクション追加 (`tool: hudisk` + `main_load: "$3000"` / `main_exec: "$3000"` / `overlay_load: "$3000"`)
- `Makefile.dist` の sos / sosx1 disk_image を `slangbuild --emit disk --hudisk` 1 行に書換
- sosx1 用 `ENV` ブロック新設 (= 元々 disk_image 未定義だったため。sos と同 template `images/SOSPROG.D88` を共有)
- HuDisk の `-r` / `-g` は `Convert.ToInt32(s, 16)` で hex parse する (`$XXXX` prefix は FormatException)。`$` 無し hex 文字列で渡す形に修正 (= 旧 `Makefile.dist` sos 経路と同形式)

### (2) `--disk-template <path>` CLI 上書き
- `Driver.Options.DiskTemplatePath` / `Program.cs --disk-template` 追加
- `--emit disk` なしで `--disk-template` 指定 → error (validation)
- `DiskImageBuilder` constructor に `templateOverride` 引数。env の `disk.template` より優先
- テスト 3 件: `UsesCustomPath` / `RequiresEmitDisk` / `PreservesCustomTemplate` (= override 時も SHA-256 不変)

### (3) installed 環境対応 (Phase 1 残課題解消)
- `Makefile.dist` の `install-lib` に `images/` + `tools/` コピー追加 (Win + Unix 両方)
- `ToolResolver.ResolveNdc` / `ResolveHudisk` の解決順に `$SLANG_HOME/tools/` + `~/.config/SLANG/tools/` を追加 (= `make install` 後の install dir 配下を見つけられる)
- `setupenv.{sh,bat}` で S-OS template (`SOSPROG.D88`) を `images/templates/` に配置 (= LSX (Phase 1) と整合)
- `InstalledEnv_TemplateResolves` テストで CI gate 化 (mock install dir に env + runtime + images/templates を staging し SLANG_HOME 経由で検証)

### (4) HuDisk.exe を Linux/macOS で mono 経由起動
- `ResolutionKind.MonoRun` 新設 (DotnetRun と同パターン)
- `ResolveHudisk` が HuDisk.exe を見つけたら non-Windows なら MonoRun を返す (mono が PATH 不在なら早期 `FileNotFoundException`)
- `DiskImageBuilder.RunTool` が `ResolvedTool` を受けて mono prefix で起動
- 配布の HuDisk は ho-ogino/HuDisk fork の `feature/write-ascii-mode` ブランチ (= ASCII 書き込み可能版、setup-tools が curl で取得)

### ⚠ ndc / HuDisk binary は配布物に同梱しない
ライセンス確認の結果、両ツールの **binary 同梱は NG**。代わりに **`make setup-tools` 経由でユーザー側ダウンロード** + `make install` で `~/.config/SLANG/tools/` に配置する経路を整備。CHANGELOG / docs に明記。

## ファイル一覧

変更:
- `Makefile.dist` (install-lib に images + tools コピー、HUDISK 変数 .exe 固定、sos/sosx1 disk_image を slangbuild --emit disk 化)
- `setupenv.sh` / `setupenv.bat` (SOSPROG.D88 を images/templates/ に配置)
- `src/SLANGCompiler.Build/{DiskImageBuilder.cs, Driver.cs, Program.cs, ToolResolver.cs}` (--disk-template, --hudisk, tool 別 dispatch, MonoRun 対応)
- `src/SLANGCompiler.Core/Runtime/{EnvironmentConfig.cs, EnvironmentLoader.cs}` (DiskConfig 拡張: MainLoad/MainExec/OverlayLoad + ParseAddress)
- `runtime/env/sos.env` / `sosx1.env` (`disk:` セクション追加)
- `tests/SLANGCompiler.Tests/BuildIntegrationTests.cs` (6 テスト追加)
- `tests/SLANGCompiler.Tests/SLANGCompiler.Tests.csproj` (Xunit.SkippableFact 追加)
- `CHANGELOG.md` / `docs/SLANG-spec.md` (Phase 2 反映)

## Test plan

- [x] `dotnet test` 202/202 pass (Phase 1 196 + Phase 2 新規 6)
  - DiskTemplateOverride: UsesCustomPath / RequiresEmitDisk / PreservesCustomTemplate
  - InstalledEnv_TemplateResolves
  - SosEnv_ProducesD88WithMain (素材揃ってる時のみ実行)
  - SosTemplateNotMutated (素材揃ってる時のみ実行)
- [x] macOS smoke: `slangbuild ... -E sos --emit disk --disk-image /tmp/out.d88` → out.d88 内に `PROG.bin` (Load: 3000, Exec: 3000) + 元 boot disk 内容、template SHA-256 不変
- [x] Linux container (Docker) で配布 zip 解凍 → setup-tools → make install → `make ENV=lsx disk_image` (reviewer 側で確認)
- [x] Windows で `make ENV=x1 disk_image` / `make ENV=sos disk_image` smoke (reviewer 側で確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)