### PR TITLE
install.sh / install.bat / uninstall.{sh,bat} 新設、Makefile を wrapper に降格 (#160 短期案)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # 更新履歴
 
+## Unreleased (v0.24.0 候補)
+
+- 配布 zip に `install.sh` / `install.bat` / `uninstall.sh` / `uninstall.bat` を同梱、Makefile に依存せず install / uninstall できるよう導線を切り出し (#160 短期案)
+  - オプション: `--prefix <path>` / `--config-dir <path>` / `--dry-run` / `--verbose` / `--force` / `--uninstall` / `--help`
+  - **危険 path guard**: uninstall 時に空 / `/` / `$HOME` / `/tmp` 単体 / `C:\` / `%USERPROFILE%` 等を refuse (絶対パス正規化してから完全一致判定、`/tmp/sub` 等は許可)
+  - **ghost file 対策**: install 時、サブディレクトリ (include / runtime / images / tools) は staging copy → 既存削除 → rename でサブディレクトリ単位置換 (= 古い env file 等が残らない)
+  - `make install` / `make uninstall` は scripts への薄い wrapper として残置 (`--force` 既定 ON で後方互換、Make 経由は uninstall も非対話)
+  - 中期案 (`setupenv.{sh,bat}` の .NET 化 = `slangsetup` 新設) は別 PR で扱う
+
 ## Version 0.23.0
 
 - `#MODULE` (オーバーレイ) のモジュール専用ワーク対応 (#142)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - **危険 path guard**: uninstall 時に空 / `/` / `$HOME` / `/tmp` 単体 / `C:\` / `%USERPROFILE%` 等を refuse (絶対パス正規化してから完全一致判定、`/tmp/sub` 等は許可)
   - **ghost file 対策**: install 時、サブディレクトリ (include / runtime / images / tools) は staging copy → 既存削除 → rename でサブディレクトリ単位置換 (= 古い env file 等が残らない)
   - `make install` / `make uninstall` は scripts への薄い wrapper として残置 (`--force` 既定 ON で後方互換、Make 経由は uninstall も非対話)
+  - **Windows install default を `%LOCALAPPDATA%\Programs\SLANG` → `%USERPROFILE%\.local\bin` に変更** (= install.sh の `~/.local/bin` と対称、uv / pipx 等の CLI ツール慣習)
   - 中期案 (`setupenv.{sh,bat}` の .NET 化 = `slangsetup` 新設) は別 PR で扱う
 
 ## Version 0.23.0

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -13,7 +13,7 @@
 # に取られる問題があるため、`sudo make install PREFIX=/usr/local CONFIG_DIR=/usr/local/share/slang`
 # のように CONFIG_DIR も明示する運用を docs で案内 (system-wide は上級ユーザー向け)。
 ifeq ($(OS),Windows_NT)
-    PREFIX ?= $(LOCALAPPDATA)\Programs\SLANG
+    PREFIX ?= $(USERPROFILE)\.local\bin
     BINDIR = $(PREFIX)
     CONFIG_DIR = $(USERPROFILE)\.config\SLANG
 else
@@ -258,7 +258,7 @@ help:
 	@echo ""
 	@echo "Options:"
 	@echo "  PREFIX=path        - Installation prefix (default: ~/.local on Unix,"
-	@echo "                       %LOCALAPPDATA%\\Programs\\SLANG on Windows)"
+	@echo '                       %USERPROFILE%\.local\bin on Windows)'
 	@echo "  TARGET=path        - Sample source file (without extension)"
 	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/msx2/msxrom/cpm)"
 	@echo ""

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -120,66 +120,24 @@ IMGPROG = $(basename $(OUTPROG))$(BIN_EXT_ENV)
 
 all: help
 
-# インストール
-install: install-bin install-lib
-	@echo "Installation complete!"
-	@echo "  Binaries: $(BINDIR)"
-	@echo "  Libraries: $(CONFIG_DIR)"
+# インストール / アンインストール
+# Issue #160: 実体は install.sh / install.bat に切り出し済。本ターゲットは
+# 互換 wrapper として残置。Make 経由は --force 既定 ON のため、uninstall も
+# **確認 prompt なしで削除**される (= 既存 CI / muscle memory との互換維持)。
+# 確認 prompt を出したい場合は ./install.sh --uninstall を直接呼ぶ。
+install:
 ifeq ($(OS),Windows_NT)
-	@echo ""
-	@echo "Note: Please ensure '$(BINDIR)' is in your PATH."
+	install.bat --prefix "$(PREFIX)" --config-dir "$(CONFIG_DIR)" --force
 else
-	@echo ""
-	@echo "Note: If '$(BINDIR)' is not on your PATH, add this to your shell rc:"
-	@echo "  export PATH=\"$(BINDIR):\$$PATH\""
+	./install.sh --prefix "$(PREFIX)" --config-dir "$(CONFIG_DIR)" --force
 endif
 
-install-bin:
-ifeq ($(DETECTED_OS),Windows)
-	@echo "Windows: Please add bin directory to PATH manually"
-	-$(MKDIR) "$(BINDIR)"
-	$(CP) bin\slangc.exe "$(BINDIR)\"
-	$(CP) bin\slangbuild.exe "$(BINDIR)\"
-else
-	$(MKDIR) $(BINDIR)
-	$(CP) bin/slangc $(BINDIR)/
-	$(CP) bin/slangbuild $(BINDIR)/
-	chmod +x $(BINDIR)/slangc
-	chmod +x $(BINDIR)/slangbuild
-endif
-
-install-lib:
-ifeq ($(DETECTED_OS),Windows)
-	-$(MKDIR) "$(CONFIG_DIR)"
-	-$(MKDIR) "$(CONFIG_DIR)\include"
-	-$(MKDIR) "$(CONFIG_DIR)\runtime"
-	-$(MKDIR) "$(CONFIG_DIR)\images"
-	-$(MKDIR) "$(CONFIG_DIR)\images\templates"
-	-$(MKDIR) "$(CONFIG_DIR)\tools"
-	$(XCOPY) include "$(CONFIG_DIR)\include"
-	$(XCOPY) runtime "$(CONFIG_DIR)\runtime"
-	$(XCOPY) images "$(CONFIG_DIR)\images"
-	$(XCOPY) tools "$(CONFIG_DIR)\tools"
-else
-	$(MKDIR) $(CONFIG_DIR)
-	$(XCOPY) include $(CONFIG_DIR)/
-	$(XCOPY) runtime $(CONFIG_DIR)/
-	$(XCOPY) images $(CONFIG_DIR)/
-	$(XCOPY) tools $(CONFIG_DIR)/
-endif
-
-# アンインストール
 uninstall:
-ifeq ($(DETECTED_OS),Windows)
-	$(RM) "$(BINDIR)\slangc.exe"
-	$(RM) "$(BINDIR)\slangbuild.exe"
-	$(RMDIR) "$(CONFIG_DIR)"
+ifeq ($(OS),Windows_NT)
+	uninstall.bat --prefix "$(PREFIX)" --config-dir "$(CONFIG_DIR)" --force
 else
-	$(RM) $(BINDIR)/slangc
-	$(RM) $(BINDIR)/slangbuild
-	$(RMDIR) $(CONFIG_DIR)
+	./uninstall.sh --prefix "$(PREFIX)" --config-dir "$(CONFIG_DIR)" --force
 endif
-	@echo "Uninstallation complete!"
 
 # 開発ツールのセットアップ
 setup-tools:

--- a/README.md
+++ b/README.md
@@ -272,7 +272,28 @@ UILIB は SPRLIB と組み合わせる場合、UI 領域にスプライトを侵
 
 # 環境構築とSLANGプログラムのビルド方法
 
-SLANG Compilerは、Makefileを使ってWindows/macOS/Linuxでクロスプラットフォームにインストール・ビルドできます。
+SLANG Compilerは、Windows/macOS/Linuxでクロスプラットフォームにインストール・ビルドできます。
+
+## 配布 zip からのインストール
+
+[GitHub Releases](https://github.com/h-o-soft/SLANG-compiler/releases) から OS 別 zip をダウンロード→解凍した dir で:
+
+```
+./install.sh                              # Linux / macOS (ユーザーローカル、sudo 不要)
+install.bat                               # Windows
+sudo ./install.sh --prefix /usr/local --config-dir /usr/local/share/slang --force
+                                          # システムワイド (sudo 必須、CONFIG_DIR
+                                          # も必ず明示しないと sudo の HOME=/root 問題)
+./install.sh --uninstall                  # アンインストール
+./install.sh --dry-run                    # 何が起こるか事前確認
+./install.sh --help                       # 全オプション
+```
+
+default では Linux/macOS は `~/.local/bin` (binary) + `~/.config/SLANG/` (lib)、Windows は `%LOCALAPPDATA%\Programs\SLANG\` (binary) + `%USERPROFILE%\.config\SLANG\` (lib) に配置されます。
+
+外部ツール (ndc / HuDisk / AILZ80ASM) はライセンス都合で配布 zip に同梱しないため、`make setup-tools` で別途ダウンロードします (= `~/.config/SLANG/tools/` 配下に配置)。
+
+互換: `make install` / `make uninstall` も従来通り動作 (内部で install.sh / install.bat を呼ぶ wrapper)。**Make 経由は `--force` 既定 ON のため uninstall 時の確認 prompt は出ません**。
 
 ## ソースからビルドする場合
 

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ sudo ./install.sh --prefix /usr/local --config-dir /usr/local/share/slang --forc
 ./install.sh --help                       # 全オプション
 ```
 
-default では Linux/macOS は `~/.local/bin` (binary) + `~/.config/SLANG/` (lib)、Windows は `%LOCALAPPDATA%\Programs\SLANG\` (binary) + `%USERPROFILE%\.config\SLANG\` (lib) に配置されます。
+default では Linux/macOS は `~/.local/bin` (binary) + `~/.config/SLANG/` (lib)、Windows は `%USERPROFILE%\.local\bin\` (binary) + `%USERPROFILE%\.config\SLANG\` (lib) に配置されます (= 両 OS で `~/.local/bin` 系に揃え、uv / pipx 等の CLI ツール慣習に整合)。
 
 外部ツール (ndc / HuDisk / AILZ80ASM) はライセンス都合で配布 zip に同梱しないため、`make setup-tools` で別途ダウンロードします (= `~/.config/SLANG/tools/` 配下に配置)。
 

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -920,8 +920,8 @@ overlay に渡すと compiler 内部ラベルとの衝突リスクがあるた�
 配布スクリプト (`Makefile.dist` / `publish.sh`) では `--slangc` / `--asm` /
 `--ndc` / `--hudisk` を明示指定する運用 (PATH 優先は再現性が低いため)。
 `make setup-tools` がライセンス都合で同梱できない `ndc` / `HuDisk.exe` を
-ダウンロードして `tools/` に配置し、`make install` で `~/.config/SLANG/tools/`
-にコピーする。
+ダウンロードして `tools/` に配置し、`./install.sh` (または `make install`) で
+`~/.config/SLANG/tools/` にコピーする。
 
 ---
 

--- a/install.bat
+++ b/install.bat
@@ -2,7 +2,7 @@
 REM SLANG Compiler installer (Windows, cmd.exe).
 REM
 REM Usage: install.bat [options]
-REM   --prefix <path>      Install bin to <path>      (default: %LOCALAPPDATA%\Programs\SLANG)
+REM   --prefix <path>      Install bin to <path>      (default: %USERPROFILE%\.local\bin)
 REM   --config-dir <path>  Install lib to <path>      (default: %USERPROFILE%\.config\SLANG)
 REM   --dry-run            Show actions without executing
 REM   --verbose            Print each step to stderr
@@ -49,7 +49,7 @@ call :usage 1>&2
 exit /b 2
 :parsed
 
-if "%PREFIX%"==""     set "PREFIX=%LOCALAPPDATA%\Programs\SLANG"
+if "%PREFIX%"==""     set "PREFIX=%USERPROFILE%\.local\bin"
 if "%CONFIG_DIR%"=="" set "CONFIG_DIR=%USERPROFILE%\.config\SLANG"
 set "BINDIR=%PREFIX%"
 
@@ -58,8 +58,8 @@ if /I "%ACTION%"=="uninstall" goto do_uninstall
 REM ============================================================
 REM   do_install
 REM ============================================================
-REM sanity check は install 経路でだけ走らせる (= uninstall は配布 zip
-REM 解凍 dir から実行する必要がない)。Codex 指摘の Medium fix。
+REM Run sanity check only on the install path. (uninstall does not need
+REM to be run from an extracted distribution dir.)
 for %%F in (bin\slangc.exe bin\slangbuild.exe include runtime images tools) do (
   if not exist "%%F" (
     echo Error: '%%F' not found in %SCRIPT_DIR%. 1>&2
@@ -103,7 +103,7 @@ if "%VERBOSE%"=="1" echo   copy bin\slangbuild.exe -^> %BINDIR%\ 1>&2
 copy /Y bin\slangbuild.exe "%BINDIR%\" >nul
 if errorlevel 1 ( echo Error: failed to copy slangbuild.exe 1>&2 & exit /b 1 )
 
-REM ghost file 対策: 既存サブディレクトリを RD /S /Q で削除してから xcopy /E /Y /I
+REM Ghost-file safety: remove the existing subdir with rd /s /q before xcopy /E /Y /I.
 for %%D in (include runtime images tools) do (
   if "%VERBOSE%"=="1" echo   replace %CONFIG_DIR%\%%D 1>&2
   if exist "%CONFIG_DIR%\%%D" rd /s /q "%CONFIG_DIR%\%%D"
@@ -124,19 +124,19 @@ echo Uninstalling SLANG from:
 echo   Binaries:  %BINDIR%\slangc.exe, slangbuild.exe
 echo   Libraries: %CONFIG_DIR% (entire directory)
 
-REM 危険 path guard:
-REM (1) full path 化して D:\. や D:\foo\.. のような正規化前表現を解決。
-REM     for %%I in (...) do set "P=%%~fI" は cmd.exe の絶対パス展開
-REM     (= Unix 側の cd "$p" && pwd と同じ思想)。
-REM (2) trailing \ を除去 (= D:\ と D: を同一視)。
-REM (3) drive root pattern (?:) を一律 refuse、その後既存 guard。
+REM Dangerous-path guard:
+REM (1) Resolve to a full path so D:\. or D:\foo\.. normalize first.
+REM     for %%I in (...) do set "P=%%~fI" expands to an absolute path
+REM     (analogous to cd "$p" && pwd on Unix).
+REM (2) Strip trailing backslash (treat D:\ and D: as the same).
+REM (3) Refuse any drive-root pattern (?:), then apply the existing guard.
 for %%I in ("%CONFIG_DIR%") do set "P=%%~fI"
 if "%P:~-1%"=="\" set "P=%P:~0,-1%"
 if "%P%"==""                    goto :err_path
-REM 任意 drive root (X:) を refuse — C:\ / D:\ / D:\. / D:\foo\.. を全て拒否
-REM (上記 full path 化により D:\. は D:\ → D: に解決済)。
+REM Refuse any drive root (X:) -- C:\ / D:\ / D:\. / D:\foo\.. all rejected
+REM (the full-path step above already resolves D:\. to D:\ -> D:).
 if "%P:~1,1%"==":" if "%P:~2%"=="" goto :err_path
-REM 親 dir / システム dir 一致拒否
+REM Refuse parent / system dirs.
 if /I "%P%"=="%SYSTEMDRIVE%"    goto :err_path
 if /I "%P%"=="%USERPROFILE%"    goto :err_path
 if /I "%P%"=="%LOCALAPPDATA%"   goto :err_path
@@ -172,7 +172,7 @@ exit /b 1
 echo SLANG Compiler installer (Windows, cmd.exe).
 echo.
 echo Usage: install.bat [options]
-echo   --prefix ^<path^>      Install bin to ^<path^>      (default: %%LOCALAPPDATA%%\Programs\SLANG)
+echo   --prefix ^<path^>      Install bin to ^<path^>      (default: %%USERPROFILE%%\.local\bin)
 echo   --config-dir ^<path^>  Install lib to ^<path^>      (default: %%USERPROFILE%%\.config\SLANG)
 echo   --dry-run            Show actions without executing
 echo   --verbose            Print each step to stderr

--- a/install.bat
+++ b/install.bat
@@ -53,7 +53,13 @@ if "%PREFIX%"==""     set "PREFIX=%LOCALAPPDATA%\Programs\SLANG"
 if "%CONFIG_DIR%"=="" set "CONFIG_DIR=%USERPROFILE%\.config\SLANG"
 set "BINDIR=%PREFIX%"
 
-REM ---- sanity check (= extracted distribution directory check) ----
+if /I "%ACTION%"=="uninstall" goto do_uninstall
+
+REM ============================================================
+REM   do_install
+REM ============================================================
+REM sanity check は install 経路でだけ走らせる (= uninstall は配布 zip
+REM 解凍 dir から実行する必要がない)。Codex 指摘の Medium fix。
 for %%F in (bin\slangc.exe bin\slangbuild.exe include runtime images tools) do (
   if not exist "%%F" (
     echo Error: '%%F' not found in %SCRIPT_DIR%. 1>&2
@@ -64,11 +70,6 @@ for %%F in (bin\slangc.exe bin\slangbuild.exe include runtime images tools) do (
   )
 )
 
-if /I "%ACTION%"=="uninstall" goto do_uninstall
-
-REM ============================================================
-REM   do_install
-REM ============================================================
 echo Installing SLANG to:
 echo   Binaries:  %BINDIR%
 echo   Libraries: %CONFIG_DIR%
@@ -123,11 +124,15 @@ echo Uninstalling SLANG from:
 echo   Binaries:  %BINDIR%\slangc.exe, slangbuild.exe
 echo   Libraries: %CONFIG_DIR% (entire directory)
 
-REM 危険 path guard: trailing \ を正規化してから完全一致で refuse
+REM 危険 path guard: trailing \ を正規化してから判定
 set "P=%CONFIG_DIR%"
 if "%P:~-1%"=="\" set "P=%P:~0,-1%"
 if "%P%"==""                    goto :err_path
-if /I "%P%"=="C:"               goto :err_path
+REM 任意 drive root (X:) を refuse — C:\ / D:\ / E:\ ... を一律拒否。
+REM 正規化済 %P% は drive letter のみなら長さ 2 (= 例: "D:")。
+REM 2 文字目が ':' かつ それ以降が空なら drive root と判定。
+if "%P:~1,1%"==":" if "%P:~2%"=="" goto :err_path
+REM 親 dir / システム dir 一致拒否
 if /I "%P%"=="%SYSTEMDRIVE%"    goto :err_path
 if /I "%P%"=="%USERPROFILE%"    goto :err_path
 if /I "%P%"=="%LOCALAPPDATA%"   goto :err_path

--- a/install.bat
+++ b/install.bat
@@ -145,6 +145,11 @@ if /I "%P%"=="%PROGRAMFILES%"   goto :err_path
 if /I "%P%"=="%PROGRAMFILES(X86)%" goto :err_path
 if /I "%P%"=="%SYSTEMROOT%"     goto :err_path
 if /I "%P%"=="%WINDIR%"         goto :err_path
+REM Refuse default-parent dirs (typo without trailing \SLANG would wipe other
+REM apps' settings). Example: --config-dir "%USERPROFILE%\.config" without
+REM \SLANG would remove all of ~/.config (git, vim, etc.).
+if /I "%P%"=="%USERPROFILE%\.config" goto :err_path
+if /I "%P%"=="%USERPROFILE%\.local"  goto :err_path
 
 if "%FORCE%"=="0" (
   set /p ANS="Continue? [y/N]: "

--- a/install.bat
+++ b/install.bat
@@ -1,0 +1,173 @@
+@echo off
+REM SLANG Compiler installer (Windows, cmd.exe).
+REM
+REM Usage: install.bat [options]
+REM   --prefix <path>      Install bin to <path>      (default: %LOCALAPPDATA%\Programs\SLANG)
+REM   --config-dir <path>  Install lib to <path>      (default: %USERPROFILE%\.config\SLANG)
+REM   --dry-run            Show actions without executing
+REM   --verbose            Print each step to stderr
+REM   --force              Skip overwrite confirmation (= for non-interactive use)
+REM   --uninstall          Switch to uninstall mode
+REM   --help               Show this usage
+REM
+REM `make install` calls this script with --force as a thin wrapper.
+REM Make-based invocation also skips the uninstall confirmation prompt.
+
+setlocal EnableDelayedExpansion
+
+set "SCRIPT_DIR=%~dp0"
+cd /d "%SCRIPT_DIR%"
+
+REM ---- arg parse ----
+set "ACTION=install"
+set "PREFIX="
+set "CONFIG_DIR="
+set "DRY_RUN=0"
+set "VERBOSE=0"
+set "FORCE=0"
+
+:parse
+if "%~1"=="" goto parsed
+if /I "%~1"=="--prefix" (
+  if "%~2"=="" ( echo Error: --prefix requires a non-empty value 1>&2 & exit /b 2 )
+  set "PREFIX=%~2" & shift & shift & goto parse
+)
+if /I "%~1"=="--config-dir" (
+  if "%~2"=="" ( echo Error: --config-dir requires a non-empty value 1>&2 & exit /b 2 )
+  set "CONFIG_DIR=%~2" & shift & shift & goto parse
+)
+if /I "%~1"=="--dry-run"    ( set "DRY_RUN=1" & shift & goto parse )
+if /I "%~1"=="--verbose"    ( set "VERBOSE=1" & shift & goto parse )
+if /I "%~1"=="-v"           ( set "VERBOSE=1" & shift & goto parse )
+if /I "%~1"=="--force"      ( set "FORCE=1" & shift & goto parse )
+if /I "%~1"=="-f"           ( set "FORCE=1" & shift & goto parse )
+if /I "%~1"=="--uninstall"  ( set "ACTION=uninstall" & shift & goto parse )
+if /I "%~1"=="--help"       ( call :usage & exit /b 0 )
+if /I "%~1"=="-h"           ( call :usage & exit /b 0 )
+echo Unknown option: %~1 1>&2
+call :usage 1>&2
+exit /b 2
+:parsed
+
+if "%PREFIX%"==""     set "PREFIX=%LOCALAPPDATA%\Programs\SLANG"
+if "%CONFIG_DIR%"=="" set "CONFIG_DIR=%USERPROFILE%\.config\SLANG"
+set "BINDIR=%PREFIX%"
+
+REM ---- sanity check (= extracted distribution directory check) ----
+for %%F in (bin\slangc.exe bin\slangbuild.exe include runtime images tools) do (
+  if not exist "%%F" (
+    echo Error: '%%F' not found in %SCRIPT_DIR%. 1>&2
+    echo. 1>&2
+    echo This installer must be run from an extracted distribution directory. 1>&2
+    echo For repo development, run 'make publish-local' first to populate bin\. 1>&2
+    exit /b 1
+  )
+)
+
+if /I "%ACTION%"=="uninstall" goto do_uninstall
+
+REM ============================================================
+REM   do_install
+REM ============================================================
+echo Installing SLANG to:
+echo   Binaries:  %BINDIR%
+echo   Libraries: %CONFIG_DIR%
+
+if "%FORCE%"=="0" (
+  if exist "%BINDIR%\slangc.exe" (
+    set /p ANS="Existing installation found. Overwrite? [y/N]: "
+    if /I not "!ANS!"=="y" if /I not "!ANS!"=="yes" ( echo Aborted. & exit /b 1 )
+  )
+)
+
+if "%DRY_RUN%"=="1" (
+  echo DRY: mkdir %BINDIR%
+  echo DRY: mkdir %CONFIG_DIR%
+  echo DRY: copy bin\slangc.exe -^> %BINDIR%\
+  echo DRY: copy bin\slangbuild.exe -^> %BINDIR%\
+  for %%D in (include runtime images tools) do (
+    echo DRY: rd /s /q %CONFIG_DIR%\%%D
+    echo DRY: xcopy /E /Y /I %%D -^> %CONFIG_DIR%\%%D
+  )
+  exit /b 0
+)
+
+if not exist "%BINDIR%"     mkdir "%BINDIR%"
+if not exist "%CONFIG_DIR%" mkdir "%CONFIG_DIR%"
+
+if "%VERBOSE%"=="1" echo   copy bin\slangc.exe -^> %BINDIR%\ 1>&2
+copy /Y bin\slangc.exe     "%BINDIR%\" >nul
+if errorlevel 1 ( echo Error: failed to copy slangc.exe 1>&2 & exit /b 1 )
+if "%VERBOSE%"=="1" echo   copy bin\slangbuild.exe -^> %BINDIR%\ 1>&2
+copy /Y bin\slangbuild.exe "%BINDIR%\" >nul
+if errorlevel 1 ( echo Error: failed to copy slangbuild.exe 1>&2 & exit /b 1 )
+
+REM ghost file 対策: 既存サブディレクトリを RD /S /Q で削除してから xcopy /E /Y /I
+for %%D in (include runtime images tools) do (
+  if "%VERBOSE%"=="1" echo   replace %CONFIG_DIR%\%%D 1>&2
+  if exist "%CONFIG_DIR%\%%D" rd /s /q "%CONFIG_DIR%\%%D"
+  xcopy /E /Y /I "%%D" "%CONFIG_DIR%\%%D" >nul
+  if errorlevel 1 ( echo Error: failed to copy %%D 1>&2 & exit /b 1 )
+)
+
+echo Installation complete!
+echo.
+echo Note: please ensure '%BINDIR%' is in your PATH.
+exit /b 0
+
+REM ============================================================
+REM   do_uninstall
+REM ============================================================
+:do_uninstall
+echo Uninstalling SLANG from:
+echo   Binaries:  %BINDIR%\slangc.exe, slangbuild.exe
+echo   Libraries: %CONFIG_DIR% (entire directory)
+
+REM 危険 path guard: trailing \ を正規化してから完全一致で refuse
+set "P=%CONFIG_DIR%"
+if "%P:~-1%"=="\" set "P=%P:~0,-1%"
+if "%P%"==""                    goto :err_path
+if /I "%P%"=="C:"               goto :err_path
+if /I "%P%"=="%SYSTEMDRIVE%"    goto :err_path
+if /I "%P%"=="%USERPROFILE%"    goto :err_path
+if /I "%P%"=="%LOCALAPPDATA%"   goto :err_path
+if /I "%P%"=="%APPDATA%"        goto :err_path
+if /I "%P%"=="%PROGRAMFILES%"   goto :err_path
+if /I "%P%"=="%PROGRAMFILES(X86)%" goto :err_path
+if /I "%P%"=="%SYSTEMROOT%"     goto :err_path
+if /I "%P%"=="%WINDIR%"         goto :err_path
+
+if "%FORCE%"=="0" (
+  set /p ANS="Continue? [y/N]: "
+  if /I not "!ANS!"=="y" if /I not "!ANS!"=="yes" ( echo Aborted. & exit /b 1 )
+)
+
+if "%DRY_RUN%"=="1" (
+  echo DRY: del %BINDIR%\slangc.exe %BINDIR%\slangbuild.exe
+  echo DRY: rd /s /q %P%
+  exit /b 0
+)
+
+if exist "%BINDIR%\slangc.exe"     del /f /q "%BINDIR%\slangc.exe"     >nul 2>nul
+if exist "%BINDIR%\slangbuild.exe" del /f /q "%BINDIR%\slangbuild.exe" >nul 2>nul
+if exist "%P%"                     rd  /s /q "%P%"
+
+echo Uninstallation complete!
+exit /b 0
+
+:err_path
+echo Refusing to remove dangerous path: '%P%' (from '%CONFIG_DIR%') 1>&2
+exit /b 1
+
+:usage
+echo SLANG Compiler installer (Windows, cmd.exe).
+echo.
+echo Usage: install.bat [options]
+echo   --prefix ^<path^>      Install bin to ^<path^>      (default: %%LOCALAPPDATA%%\Programs\SLANG)
+echo   --config-dir ^<path^>  Install lib to ^<path^>      (default: %%USERPROFILE%%\.config\SLANG)
+echo   --dry-run            Show actions without executing
+echo   --verbose            Print each step to stderr
+echo   --force              Skip overwrite confirmation
+echo   --uninstall          Switch to uninstall mode
+echo   --help               Show this usage
+goto :eof

--- a/install.bat
+++ b/install.bat
@@ -124,13 +124,17 @@ echo Uninstalling SLANG from:
 echo   Binaries:  %BINDIR%\slangc.exe, slangbuild.exe
 echo   Libraries: %CONFIG_DIR% (entire directory)
 
-REM 危険 path guard: trailing \ を正規化してから判定
-set "P=%CONFIG_DIR%"
+REM 危険 path guard:
+REM (1) full path 化して D:\. や D:\foo\.. のような正規化前表現を解決。
+REM     for %%I in (...) do set "P=%%~fI" は cmd.exe の絶対パス展開
+REM     (= Unix 側の cd "$p" && pwd と同じ思想)。
+REM (2) trailing \ を除去 (= D:\ と D: を同一視)。
+REM (3) drive root pattern (?:) を一律 refuse、その後既存 guard。
+for %%I in ("%CONFIG_DIR%") do set "P=%%~fI"
 if "%P:~-1%"=="\" set "P=%P:~0,-1%"
 if "%P%"==""                    goto :err_path
-REM 任意 drive root (X:) を refuse — C:\ / D:\ / E:\ ... を一律拒否。
-REM 正規化済 %P% は drive letter のみなら長さ 2 (= 例: "D:")。
-REM 2 文字目が ':' かつ それ以降が空なら drive root と判定。
+REM 任意 drive root (X:) を refuse — C:\ / D:\ / D:\. / D:\foo\.. を全て拒否
+REM (上記 full path 化により D:\. は D:\ → D: に解決済)。
 if "%P:~1,1%"==":" if "%P:~2%"=="" goto :err_path
 REM 親 dir / システム dir 一致拒否
 if /I "%P%"=="%SYSTEMDRIVE%"    goto :err_path

--- a/install.sh
+++ b/install.sh
@@ -102,30 +102,36 @@ guard_path() {
   # 末尾 / を除去 (= /home/foo/ と /home/foo を同一視)。
   # ただし `/` 単体は除去すると "" になり message 表示が壊れるので保持。
   [ "$abs" = "/" ] || abs="${abs%/}"
+  # $HOME の親 dir も拒否 (= macOS の /Users, Linux の /home を動的に取得)。
+  # 静的 path も併記してベルトとサスペンダーで防御。
+  HOME_PARENT=$(dirname "$HOME")
   case "$abs" in
-    "" | "/" | "$HOME" | "/root" | "/root/.config" | "/home" | "/usr" | \
-    "/etc" | "/var" | "/tmp" | "/opt")
+    "" | "/" | "$HOME" | "$HOME_PARENT" \
+    | "/root" | "/root/.config" \
+    | "/home" | "/Users" \
+    | "/usr" | "/etc" | "/var" | "/tmp" | "/opt")
       echo "Refusing to remove dangerous path: '$abs' (from '$p')" >&2
       exit 1 ;;
   esac
   case "$p" in "." | "..") echo "Refusing relative path: '$p'" >&2; exit 1 ;; esac
 }
 
-# ---- sanity check (= 配布 zip 解凍 dir で実行されているか) ----
-for required in bin/slangc bin/slangbuild include runtime images tools; do
-  if [ ! -e "$required" ]; then
-    cat >&2 <<EOF
+# ---- install ----
+do_install() {
+  # sanity check は install 経路でだけ走らせる (= uninstall は配布 zip
+  # 解凍 dir から実行する必要がない)。Codex 指摘の Medium fix。
+  for required in bin/slangc bin/slangbuild include runtime images tools; do
+    if [ ! -e "$required" ]; then
+      cat >&2 <<EOF
 Error: '$required' not found in $SCRIPT_DIR.
 
 This installer must be run from an extracted distribution directory.
 For repo development, run 'make publish-local' first to populate bin/.
 EOF
-    exit 1
-  fi
-done
+      exit 1
+    fi
+  done
 
-# ---- install ----
-do_install() {
   echo "Installing SLANG to:"
   echo "  Binaries:  $BINDIR"
   echo "  Libraries: $CONFIG_DIR"

--- a/install.sh
+++ b/install.sh
@@ -104,9 +104,13 @@ guard_path() {
   [ "$abs" = "/" ] || abs="${abs%/}"
   # $HOME の親 dir も拒否 (= macOS の /Users, Linux の /home を動的に取得)。
   # 静的 path も併記してベルトとサスペンダーで防御。
+  # 加えて default の親 dir (= $HOME/.config, $HOME/.local) を refuse する。
+  # 例: --config-dir "$HOME/.config" を `/SLANG` 抜きで typo 指定すると
+  # ~/.config 配下の他アプリ設定 (git, vim, etc.) を全部消す事故になる。
   HOME_PARENT=$(dirname "$HOME")
   case "$abs" in
     "" | "/" | "$HOME" | "$HOME_PARENT" \
+    | "$HOME/.config" | "$HOME/.local" \
     | "/root" | "/root/.config" \
     | "/home" | "/Users" \
     | "/usr" | "/etc" | "/var" | "/tmp" | "/opt")

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,199 @@
+#!/bin/sh
+# SLANG Compiler installer (Unix: Linux / macOS).
+#
+# 配布 zip 解凍 dir 直下で実行する想定 (= bin/, include/, runtime/, images/,
+# tools/ が cwd にあること)。repo 直下から使う場合は `make publish-local` 後に
+# 実行する。
+#
+# Usage: ./install.sh [options]
+#   --prefix <path>      Install bin to <path>/bin (default: $HOME/.local)
+#   --config-dir <path>  Install lib to <path>     (default: $HOME/.config/SLANG)
+#   --dry-run            実行せず "DRY: ..." を表示するだけ
+#   --verbose, -v        各ステップを stderr に出力
+#   --force, -f          確認 prompt を skip (= CI 等の非対話用)
+#   --uninstall          アンインストールモードに切替
+#   --help, -h           この usage を表示
+#
+# `make install` は本 script を `--force` 付きで呼ぶ薄い wrapper。
+# Make 経由は **uninstall 時の確認 prompt も出ない** ので注意。
+
+set -eu
+
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+cd "$SCRIPT_DIR"
+
+# ---- arg parse ----
+ACTION=install
+PREFIX=""
+CONFIG_DIR=""
+DRY_RUN=0
+VERBOSE=0
+FORCE=0
+
+usage() {
+  sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --prefix)
+      [ $# -ge 2 ] || { echo "Error: --prefix requires a value" >&2; exit 2; }
+      [ -n "$2" ]  || { echo "Error: --prefix value cannot be empty" >&2; exit 2; }
+      PREFIX="$2"; shift 2 ;;
+    --config-dir)
+      [ $# -ge 2 ] || { echo "Error: --config-dir requires a value" >&2; exit 2; }
+      [ -n "$2" ]  || { echo "Error: --config-dir value cannot be empty" >&2; exit 2; }
+      CONFIG_DIR="$2"; shift 2 ;;
+    --dry-run)     DRY_RUN=1; shift ;;
+    --verbose|-v)  VERBOSE=1; shift ;;
+    --force|-f)    FORCE=1; shift ;;
+    --uninstall)   ACTION=uninstall; shift ;;
+    --help|-h)     usage; exit 0 ;;
+    *)             echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# ---- OS detect & default paths ----
+case "$(uname -s)" in
+  Darwin)               OS=macos ;;
+  Linux)                OS=linux ;;
+  MINGW*|MSYS*|CYGWIN*)
+    echo "Warning: detected Unix-like Windows shell ($(uname -s))." >&2
+    echo "         Native Windows users should use install.bat instead." >&2
+    OS=winbash
+    ;;
+  *) echo "Unsupported OS: $(uname -s)" >&2; exit 1 ;;
+esac
+
+: "${PREFIX:=$HOME/.local}"
+: "${CONFIG_DIR:=$HOME/.config/SLANG}"
+BINDIR="$PREFIX/bin"
+
+# ---- helper functions ----
+log()  { [ "$VERBOSE" -eq 1 ] && echo "  $*" >&2; :; }
+run()  {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY: $*"
+  else
+    "$@"
+  fi
+}
+
+confirm() {
+  # $1: prompt message
+  if [ "$FORCE" -eq 1 ]; then return 0; fi
+  if [ ! -t 0 ]; then
+    echo "Error: non-interactive shell detected. Use --force to skip prompts." >&2
+    exit 1
+  fi
+  printf '%s [y/N]: ' "$1"
+  read ans
+  case "$ans" in [yY]*) return 0 ;; *) echo "Aborted." >&2; exit 1 ;; esac
+}
+
+# 危険 path guard: 絶対パス正規化してから完全一致で拒否
+guard_path() {
+  p="$1"
+  if [ -d "$p" ]; then
+    abs=$(cd "$p" && pwd)
+  else
+    case "$p" in /*) abs="$p" ;; *) abs="$(pwd)/$p" ;; esac
+  fi
+  # 末尾 / を除去 (= /home/foo/ と /home/foo を同一視)。
+  # ただし `/` 単体は除去すると "" になり message 表示が壊れるので保持。
+  [ "$abs" = "/" ] || abs="${abs%/}"
+  case "$abs" in
+    "" | "/" | "$HOME" | "/root" | "/root/.config" | "/home" | "/usr" | \
+    "/etc" | "/var" | "/tmp" | "/opt")
+      echo "Refusing to remove dangerous path: '$abs' (from '$p')" >&2
+      exit 1 ;;
+  esac
+  case "$p" in "." | "..") echo "Refusing relative path: '$p'" >&2; exit 1 ;; esac
+}
+
+# ---- sanity check (= 配布 zip 解凍 dir で実行されているか) ----
+for required in bin/slangc bin/slangbuild include runtime images tools; do
+  if [ ! -e "$required" ]; then
+    cat >&2 <<EOF
+Error: '$required' not found in $SCRIPT_DIR.
+
+This installer must be run from an extracted distribution directory.
+For repo development, run 'make publish-local' first to populate bin/.
+EOF
+    exit 1
+  fi
+done
+
+# ---- install ----
+do_install() {
+  echo "Installing SLANG to:"
+  echo "  Binaries:  $BINDIR"
+  echo "  Libraries: $CONFIG_DIR"
+
+  if [ -e "$BINDIR/slangc" ] || [ -e "$BINDIR/slangbuild" ] || [ -d "$CONFIG_DIR" ]; then
+    confirm "Existing installation found. Overwrite?"
+  fi
+
+  run mkdir -p "$BINDIR" "$CONFIG_DIR"
+
+  log "copy bin/slangc -> $BINDIR/"
+  run cp bin/slangc     "$BINDIR/"
+  run chmod +x          "$BINDIR/slangc"
+  log "copy bin/slangbuild -> $BINDIR/"
+  run cp bin/slangbuild "$BINDIR/"
+  run chmod +x          "$BINDIR/slangbuild"
+
+  # ghost file 対策: サブディレクトリは staging copy → 既存削除 → rename
+  # で原子的置換 (= 古い env file 等が残らない)
+  STAGING=""
+  if [ "$DRY_RUN" -eq 0 ]; then
+    STAGING=$(mktemp -d "$CONFIG_DIR/.install.XXXXXX")
+    trap '[ -n "${STAGING:-}" ] && rm -rf "$STAGING"' EXIT INT TERM
+  fi
+  for d in include runtime images tools; do
+    log "stage $d -> $CONFIG_DIR/$d (atomic replace)"
+    if [ "$DRY_RUN" -eq 1 ]; then
+      echo "DRY: cp -R $d <staging>/"
+      echo "DRY: rm -rf $CONFIG_DIR/$d"
+      echo "DRY: mv <staging>/$d $CONFIG_DIR/$d"
+    else
+      cp -R "$d" "$STAGING/"
+      rm -rf "$CONFIG_DIR/$d"
+      mv "$STAGING/$d" "$CONFIG_DIR/$d"
+    fi
+  done
+
+  echo "Installation complete!"
+  case ":$PATH:" in
+    *":$BINDIR:"*) ;;
+    *)
+      echo
+      echo "Note: '$BINDIR' is not in your PATH. Add this to your shell rc:"
+      echo "  export PATH=\"$BINDIR:\$PATH\""
+      ;;
+  esac
+}
+
+# ---- uninstall ----
+do_uninstall() {
+  echo "Uninstalling SLANG from:"
+  echo "  Binaries:  $BINDIR/{slangc,slangbuild}"
+  echo "  Libraries: $CONFIG_DIR (entire directory)"
+
+  guard_path "$CONFIG_DIR"
+  confirm "Continue?"
+
+  log "rm -f $BINDIR/slangc $BINDIR/slangbuild"
+  run rm -f  "$BINDIR/slangc" "$BINDIR/slangbuild"
+  log "rm -rf $CONFIG_DIR"
+  run rm -rf "$CONFIG_DIR"
+
+  echo "Uninstallation complete!"
+}
+
+# ---- dispatch ----
+if [ "$ACTION" = uninstall ]; then
+  do_uninstall
+else
+  do_install
+fi

--- a/publish.sh
+++ b/publish.sh
@@ -58,6 +58,12 @@ createRelease() {
   cp ../../LICENSE .
   cp ../../setupenv.bat .
   cp ../../setupenv.sh .
+  # Issue #160 短期案: install scripts (Makefile に依存しない install 経路)
+  cp ../../install.sh    .
+  cp ../../install.bat   .
+  cp ../../uninstall.sh  .
+  cp ../../uninstall.bat .
+  chmod +x install.sh uninstall.sh
 
   # RunCPM bundle (per-platform binary + CP/M utilities + wrapper)
   mkdir -p tools/runcpm/cpm

--- a/uninstall.bat
+++ b/uninstall.bat
@@ -1,0 +1,5 @@
+@echo off
+REM SLANG Compiler uninstaller (Windows). install.bat --uninstall to a thin shim.
+REM call (instead of plain invocation) preserves quoted argument forwarding for
+REM whitespace-containing paths (e.g. --prefix "C:\Temp\slang test").
+call "%~dp0install.bat" --uninstall %*

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+# SLANG Compiler uninstaller (Unix). install.sh --uninstall への薄い shim。
+exec "$(dirname "$0")/install.sh" --uninstall "$@"


### PR DESCRIPTION
## Summary

Issue #160 短期案として、`make install` / `make uninstall` の実体を **`install.sh` / `install.bat`** + **`uninstall.{sh,bat}`** に切り出し、Makefile を薄い wrapper に降格しました。Windows の make 不在環境、CI / IDE 統合、ユーザー独自 wrapper script から `./install.sh` を直接呼べるようになります。

中期案 (`setupenv.{sh,bat}` の .NET 化 = `slangsetup` 新設) は別 PR で扱います。

## 主要変更

### 新規 scripts (4 ファイル)

| ファイル | 役割 |
|---|---|
| `install.sh` | POSIX sh、Linux/macOS。引数 `--prefix` / `--config-dir` / `--dry-run` / `--verbose` / `--force` / `--uninstall` / `--help` |
| `install.bat` | cmd.exe、Windows。同オプション、cp932 / BOM なし |
| `uninstall.sh` | `install.sh --uninstall` への薄い shim |
| `uninstall.bat` | `install.bat --uninstall` への薄い shim (`call` 経由で空白入り path 対応) |

### Codex review で詰めた安全策

- **危険 path guard** (uninstall): 絶対パス正規化してから完全一致で空 / `/` / `$HOME` / `/root` / `/tmp` 単体 等を refuse。`/tmp/sub` は許可 (= ワイルドカードで雑に拒否しない)。Windows は `C:\` / `%SYSTEMDRIVE%` / `%USERPROFILE%` / `%LOCALAPPDATA%` / `%PROGRAMFILES%` / `%SYSTEMROOT%` 等 (trailing `\` 正規化込み)
- **ghost file 対策** (install): include / runtime / images / tools の各サブディレクトリは `mktemp` staging → `cp -R` → 既存削除 → `mv` でサブディレクトリ単位置換。古い env file 等が残らない (Windows は `RD /S /Q` + `xcopy /E /Y /I`)
- **空文字列 `--prefix` / `--config-dir` 即 error**: `:=` で default 補填されて意図しない `$HOME` 配下削除を防ぐ (実機 smoke で罠を踏んだので fix 済)
- **非対話 hang 防止**: `[ -t 0 ]` で tty 判定し、非対話なら確認 prompt なし abort + `--force` 推奨
- **sanity check**: `bin/slangc` 等が cwd に揃っているか確認、無ければ「extracted distribution directory で実行してください、repo の場合は `make publish-local` 後に再試行」案内

### Makefile.dist wrapper 化

- `install` / `uninstall` ターゲットの実体を scripts 呼び出しに置換、`install-bin` / `install-lib` 細分ターゲットは削除
- `--force` 既定 ON で後方互換 (= 既存 CI / muscle memory が壊れない)。**`make uninstall` も非対話** となるため README / Makefile.dist コメントで明示
- `setup-tools` は現状維持 (= 中期 `slangsetup` で扱う)

### 配布 / docs

- `publish.sh` で 4 scripts を配布 zip に同梱、Unix scripts は `chmod +x`
- `README.md` に「配布 zip からのインストール」section 追加 (`./install.sh` 主軸 + sudo system-wide 例 + Make 互換併記)
- `docs/SLANG-spec.md` の ToolResolver 解決順記述を「`make install`」→「`./install.sh` (または `make install`)」併記
- `CHANGELOG.md` に v0.24.0 unreleased entry 新設

## ファイル一覧

新規:
- `install.sh` / `install.bat` / `uninstall.sh` / `uninstall.bat`

変更:
- `Makefile.dist` (install / uninstall を scripts wrapper 化、install-bin / install-lib 削除)
- `publish.sh` (4 scripts 同梱)
- `README.md` (配布 zip 用 install section 追加)
- `docs/SLANG-spec.md` (1 行併記)
- `CHANGELOG.md` (v0.24.0 unreleased entry 新設)

## Test plan

- [x] `dotnet test` 202/202 pass (= scripts は src/ を触らず regression なし)
- [x] `sh -n install.sh uninstall.sh` + `dash -n install.sh uninstall.sh` 構文 OK
- [x] 配布 zip 解凍 → `./install.sh --dry-run` 出力確認 (= mkdir → bin copy → 各サブディレクトリ staging+rm+mv パターン)
- [x] 配布 zip 解凍 → `./install.sh --prefix /tmp/X --config-dir /tmp/Y --force` で実 install → `slangc --version` = `slangc 0.23.0`、`examples/STARS.SL` の実コンパイル OK
- [x] ghost file smoke (= 偽 ghost を `runtime/env/` に置いて再 install で消える、staging dir も cleanup される)
- [x] 危険 path guard smoke: `--config-dir ""` / `"/"` / `"$HOME"` / `"/tmp"` 単体は refuse、`/tmp/sub` は許可
- [x] 空文字列 `--config-dir` 即 error (= default 補填の罠を防ぐ)
- [x] `make install` / `make uninstall` wrapper 経由動作確認 (= `--force` 既定 ON で非対話)
- [x] Windows `install.bat` 実機 smoke (reviewer 側、特に空白入り path: `--prefix "C:\Temp\slang test"`)
- [x] Windows `uninstall.bat` shim の `%*` quote 確認 (= 崩れたら `call %~dp0install.bat` 経由は既に採用済)

## 関連

- v0.23.0 で導入済の前段:
  - `make install` default を `~/.local/bin` に変更 (sudo 不要)
  - `~/.config/SLANG/tools/` への install dir 配置 + `ToolResolver` 解決順拡張
  - `setupenv.sh` の POSIX sh 互換化 (Linux dash 対応)
- 中期: Issue #160 中期案 (`slangsetup` 新設) は本 PR 完了後に別 issue / PR で着手予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)