### PR TITLE
pc80mk2 環境を slangbuild に統合 — CMT 出力対応

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@
   - **AILZ80ASM エラー表示**: `--verbose` 無しでも `main assembly failed` の詳細 (= 未定義 label 等) が stderr に出るよう修正 (= AILZ80ASM がエラーを stdout に流す癖を吸収)
   - 他 PC-8801 系 (pc80mk2 / pc80mk2x) は別 PR で順次
 
+- pc80mk2 環境 (PC-8001mkII ROM 環境) を `slangbuild` に統合 — CMT (cassette tape) 出力対応 (Phase 3 続編)
+  - env file (`runtime/env/pc80mk2.env`) に新フィールド `output: cmt` を追加。`slangbuild` が AILZ80ASM 起動時に `-bin` shortcut を `-cmt` に置換 + `-gap 0` を自動付与し、出力拡張子を `.bin` → `.cmt` に切替 (= 旧 dev `Makefile` の `BIN_EXT/ASM_OPT` 設定を `slangbuild` に移植、`Makefile.dist` 化で抜けていた CMT 対応を復元)
+  - 新 `EnvironmentConfig.OutputFormat` (string?)。null/未指定 = `.bin` default、`"cmt"` で AILZ80ASM CMT format。`output:` 値は `bin` / `cmt` のみ許可、それ以外は `InvalidDataException` で reject (= typo 早期検出)
+  - `AssemblerRunner.AssembleMain` / `AssembleOverlay` に `outputFlag` (`-bin` / `-cmt`) + `extraArgs: string[]?` 引数追加。`-bin` と `-cmt` を同時に渡すと両 format の file が出てしまうので、format ごとに 1 つに切替える設計。prelink Pass 1 / Pass 3 / 単段 / overlay 全段で同じ outputFlag/extraArgs を pass (= AILZ80ASM option 不一致でアドレス解決崩壊するのを防止)
+  - `Driver.Run()` 冒頭で `EnvironmentResolver` を 1 度だけ呼ぶ前倒しに変更、`BuildDiskImage()` 内の env 二重解決を排除。`--emit disk` + `disk:` 不在 env の組合せは compile 前に early reject
+  - `Makefile.dist`: `OUTPROG` を `$(BIN_EXT)` 経由で拡張子化 (`PROG.bin` 固定 → `PROG$(BIN_EXT)`)、pc80mk2 ENV ブロック追加 (`BIN_EXT/BIN_EXT_ENV = .cmt`、`DISK_IMAGE = $(OUTPROG)`)、`disk_image` 分岐に `pc80mk2: $(OUTPROG)` 明示追加 (= 旧 ELSE 分岐 ndc 経路に落ちないよう、cpm / msxrom と同じ pattern)、`clean` recipe / `help` ENV 一覧にも反映
+  - `make ENV=pc80mk2 build / run / disk_image` のいずれでも `examples/PROG.cmt` が生成される。M88 等のエミュレータで `.cmt` をそのまま CLOAD で読み込める想定 (`EMU` 変数はユーザー側設定)
+  - **scope 外**: pc80mk2x (XBIOS 直接環境、XBIOS.CMT 結合が別途必要) / overlay 結合 (= `M0.cmt` を main に結合) / `--emit disk` 統合 (= cassette は disk じゃないので非対象) は本 PR 外。overlay も `_m0.cmt` 別ファイルで出るのみ、loader 組み立てはユーザー側
+
 ## Version 0.23.0
 
 - `#MODULE` (オーバーレイ) のモジュール専用ワーク対応 (#142)

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -78,7 +78,10 @@ HUDISK = tools/HuDisk.exe
 # その分岐は slangbuild の ToolResolver に閉じている。
 UDOSTOOL = tools/udostool.exe
 
-OUTPROG = $(dir $(TARGET))PROG.bin
+# OUTPROG は ENV ブロック内で BIN_EXT を上書きすると `.cmt` 等にも切替わる
+# (= pc80mk2 で `PROG.cmt` 出力)。slangbuild は env file `output:` から
+# 出力 format を判定して同じ拡張子を生成するので、Make 側の OUTPROG と必ず一致する。
+OUTPROG = $(dir $(TARGET))PROG$(BIN_EXT)
 ASM_OPT =
 
 # エミュレータ設定（環境に応じて変更）
@@ -102,6 +105,16 @@ else ifeq ($(ENV), pc88mk2sr)
   EMU = @echo "Set EMU variable for your emulator" \#
   DISK_IMAGE = images/PC88MK2SR.d88
   BIN_EXT_ENV = $(BIN_EXT)
+else ifeq ($(ENV), pc80mk2)
+  # PC-8001mkII ROM 環境: cassette tape (CMT) 出力。
+  # slangbuild が env file (`output: cmt`) を見て AILZ80ASM に `-cmt -gap 0` を pass、
+  # 出力拡張子を `.cmt` にする。disk image は無く、`disk_image` target は OUTPROG
+  # (= PROG.cmt) そのものを指す (= cpm / msxrom と同じパターン)。
+  # M88 等のエミュレータで `.cmt` をそのまま CLOAD で読み込める想定。
+  EMU = @echo "PC-8001 emulator not configured. Set EMU variable" \#
+  BIN_EXT = .cmt
+  BIN_EXT_ENV = .cmt
+  DISK_IMAGE = $(OUTPROG)
 else ifeq ($(ENV), msxrom)
   EMU = @echo "Set EMU variable for your emulator" \#
   BIN_EXT_ENV = $(BIN_EXT)
@@ -172,6 +185,11 @@ ifeq ($(ENV), cpm)
 disk_image: $(OUTPROG)
 else ifeq ($(ENV), msxrom)
 disk_image: $(OUTPROG)
+else ifeq ($(ENV), pc80mk2)
+# pc80mk2 は CMT 出力 (= disk image なし)。slangbuild が env file の
+# `output: cmt` に従って `.cmt` を出すので、disk_image target は main bin
+# (= PROG.cmt) を produce すれば十分 (= cpm / msxrom と同じパターン)。
+disk_image: $(OUTPROG)
 else ifeq ($(ENV), sos)
 # sos / sosx1 は slangbuild --emit disk + HuDisk 経路。template
 # (images/templates/SOSPROG.D88) を $(DISK_IMAGE) にコピーしてから main +
@@ -210,10 +228,10 @@ disk_image: $(TARGET)$(SRC_EXT)
 		--slangc $(SLANGC) --asm $(ASM) --ndc $(NDC) \
 		-o $(dir $(TARGET))PROG --emit disk --disk-image $(DISK_IMAGE)
 else
-# その他 d88 系 (msx2 / msxlsx / pc80mk2 / pc80mk2x 等): 未統合 env は
+# その他 d88 系 (msx2 / msxlsx / pc80mk2x 等): 未統合 env は
 # 従来の ndc P + Python helper 経路を維持。今後 env ごとに `disk:` セクション
 # を追加して順次新 `slangbuild --emit disk` 経路へ移行する
-# (= pc88mk2sr は udostool 経路で移行済)。
+# (= pc88mk2sr は udostool / pc80mk2 は CMT 出力経路で移行済)。
 ADD_OVERLAYS = $(PYTHON) tools/disk-add-overlays.py
 
 disk_image: $(IMGPROG)
@@ -253,11 +271,11 @@ build: $(OUTPROG)
 # クリーンアップ
 clean:
 ifeq ($(OS),Windows_NT)
-	-del /Q /F $(subst /,\,$(TARGET)$(ASM_EXT)) $(subst /,\,$(TARGET)$(BIN_EXT)) $(subst /,\,$(dir $(TARGET))PROG.bin) $(subst /,\,$(dir $(TARGET))PROG.com) 2>nul
+	-del /Q /F $(subst /,\,$(TARGET)$(ASM_EXT)) $(subst /,\,$(TARGET)$(BIN_EXT)) $(subst /,\,$(dir $(TARGET))PROG.bin) $(subst /,\,$(dir $(TARGET))PROG.com) $(subst /,\,$(dir $(TARGET))PROG.cmt) 2>nul
 	@REM disk-add-overlays.py の staging dir は通常 finally で消えるが念押し
 	-rmdir /S /Q $(subst /,\,$(dir $(TARGET)).staging) 2>nul
 else
-	rm -f $(TARGET)$(ASM_EXT) $(TARGET)$(BIN_EXT) $(TARGET)$(BIN_EXT_ENV) $(dir $(TARGET))PROG.bin $(dir $(TARGET))PROG.com
+	rm -f $(TARGET)$(ASM_EXT) $(TARGET)$(BIN_EXT) $(TARGET)$(BIN_EXT_ENV) $(dir $(TARGET))PROG.bin $(dir $(TARGET))PROG.com $(dir $(TARGET))PROG.cmt
 	@# disk-add-overlays.py の staging dir は通常 finally で消えるが念押し
 	-rm -rf $(dir $(TARGET)).staging
 endif
@@ -280,6 +298,6 @@ help:
 	@echo "  PREFIX=path        - Installation prefix (default: ~/.local on Unix,"
 	@echo '                       %USERPROFILE%\.local\bin on Windows)'
 	@echo "  TARGET=path        - Sample source file (without extension)"
-	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/msx2/msxrom/cpm)"
+	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/pc88mk2sr/pc80mk2/msx2/msxrom/cpm)"
 	@echo ""
 	@echo "Detected OS: $(DETECTED_OS)"

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -1042,9 +1042,46 @@ make ENV=cpm TARGET=examples/MODTEST_RESIDENT run
 の代替策 + 実験用)。
 
 旧 `tools/disk-add-overlays.py` は legacy helper として残置 (新規利用は非推奨)。
-msx2 / msxlsx / pc80mk2 / pc80mk2x 等の d88 系 env は従来の `tools/disk-add-overlays.py`
+msx2 / msxlsx / pc80mk2x 等の d88 系 env は従来の `tools/disk-add-overlays.py`
 経路を維持しており、今後 env ごとに `--emit disk` 経路へ移行予定 (= pc88mk2sr は
-udostool 経路で移行済)。
+udostool 経路、pc80mk2 は CMT 出力経路で移行済)。
+
+#### CMT (cassette tape) 出力 env (= pc80mk2)
+
+`pc80mk2` (PC-8001mkII ROM 環境) は disk image ではなく **cassette tape 形式
+(CMT)** で出力する。env file (`runtime/env/pc80mk2.env`) の新フィールド
+`output: cmt` を見て、`slangbuild` が AILZ80ASM 起動時に `-bin` shortcut を
+`-cmt` に置換 + `-gap 0` を自動付与し、出力拡張子を `.bin` → `.cmt` に
+切替える (`-bin` と `-cmt` を同時に渡すと両 format が出るので、format ごとに
+1 つに切替える設計):
+
+```yaml
+# runtime/env/pc80mk2.env (抜粋)
+env_type: 5
+os_type: 3
+default_org: "$C000"
+output: cmt          # ← この一行で AILZ80ASM `-cmt -gap 0` + `.cmt` 拡張子
+libraries:
+  - runtime.yml
+  ...
+```
+
+`output:` フィールドの仕様:
+
+| 値 | 意味 |
+|---|---|
+| 未指定 / `bin` | `.bin` 拡張子、AILZ80ASM `-bin <path>` (= default) |
+| `cmt` | `.cmt` 拡張子、AILZ80ASM `-cmt <path> -gap 0` (= `-bin` の代わりに `-cmt`、加えて `-gap 0`) |
+| その他 (`rom` / `sna` 等) | env load 時 `InvalidDataException` で reject (= typo 早期検出) |
+
+`make ENV=pc80mk2 build / run / disk_image` のいずれでも `examples/PROG.cmt`
+が生成され、M88 等のエミュレータで CLOAD 経由で読み込める想定 (`Makefile.dist`
+の `EMU` 変数はユーザー側設定)。`disk:` セクションは持たないので
+`--emit disk` は env load 後に early reject される。
+
+**現在の制約**: overlay (`#MODULE` 使用時) も `_m0.cmt` 別ファイルで出るのみ
+で、main への結合 / loader 組み立てはユーザー側責務。pc80mk2x (XBIOS 直接
+環境) は別 env で対応予定。
 
 サンプル限定の最小実装で、overlay 命名は `M<N>.BIN` 固定、各 overlay は
 128 byte 以内であることを前提としている (より大きい overlay は loader 拡張

--- a/runtime/env/pc80mk2.env
+++ b/runtime/env/pc80mk2.env
@@ -1,6 +1,7 @@
 env_type: 5
 os_type: 3
 default_org:	"$C000"
+output: cmt
 libraries:
   - runtime.yml
   - libfloat.yml

--- a/src/SLANGCompiler.Build/AssemblerRunner.cs
+++ b/src/SLANGCompiler.Build/AssemblerRunner.cs
@@ -31,10 +31,22 @@ public class AssemblerRunner
     /// <param name="lstPath">non-null なら `-lst &lt;path&gt;` を付与してリスト
     /// ファイルを出力。本番アセンブル (単段モード or prelink Pass 3) では指定し、
     /// prelink Pass 1 (中間用) では null にして無駄な出力を避ける。</param>
+    /// <param name="outputFlag">AILZ80ASM の出力 format flag (= shortcut option 名)。
+    /// default <c>"-bin"</c> (raw バイナリ)。env file `output: cmt` の場合は
+    /// <c>"-cmt"</c> を渡して CMT (cassette tape) format で出力する。
+    /// `-bin` と `-cmt` は AILZ80ASM の異なる shortcut であり、両者を同時に
+    /// 渡すと両 format のファイルが出力されるので、format 切替時はこの引数で
+    /// 1 つに切り替える。`outBinPath` の path / 拡張子はこの flag の値とは独立。</param>
+    /// <param name="extraArgs">format 切替で必要な追加引数 (例: cmt なら
+    /// <c>["-gap", "0"]</c>)。Pass 1 / Pass 3 でアドレス整合を保つため、prelink
+    /// 全段で同じ extraArgs を渡す必要がある。</param>
     public AssemblerResult AssembleMain(string asmPath, string outBinPath, string outSymPath,
-                                        bool superAssemble = true, string? lstPath = null)
+                                        bool superAssemble = true, string? lstPath = null,
+                                        string outputFlag = "-bin",
+                                        string[]? extraArgs = null)
     {
-        var args = BuildArgs(new[] { asmPath }, outBinPath, outSymPath, superAssemble, lstPath);
+        var args = BuildArgs(new[] { asmPath }, outBinPath, outSymPath, superAssemble, lstPath,
+                             outputFlag, extraArgs);
         return Run(args);
     }
 
@@ -46,25 +58,37 @@ public class AssemblerRunner
     /// <param name="superAssemble">true (default) = 既存挙動 (PR-B 単段フロー用)、
     /// false = `-nsa` 付与 (PR-B2 prelink Pass 1/3 用)</param>
     /// <param name="lstPath">non-null なら `-lst &lt;path&gt;` を付与</param>
+    /// <param name="outputFlag"><see cref="AssembleMain"/> と同じ。default <c>"-bin"</c>、
+    /// CMT 出力時は <c>"-cmt"</c>。</param>
+    /// <param name="extraArgs"><see cref="AssembleMain"/> と同じ。Pass 1/3 で main と
+    /// 同じ extraArgs を渡す必要。</param>
     public AssemblerResult AssembleOverlay(string importsAsmPath, string overlayAsmPath,
                                            string outBinPath, string outSymPath,
-                                           bool superAssemble = true, string? lstPath = null)
+                                           bool superAssemble = true, string? lstPath = null,
+                                           string outputFlag = "-bin",
+                                           string[]? extraArgs = null)
     {
         var args = BuildArgs(new[] { importsAsmPath, overlayAsmPath },
-                             outBinPath, outSymPath, superAssemble, lstPath);
+                             outBinPath, outSymPath, superAssemble, lstPath,
+                             outputFlag, extraArgs);
         return Run(args);
     }
 
     private static string[] BuildArgs(string[] inputs, string outBinPath, string outSymPath,
-                                      bool superAssemble, string? lstPath)
+                                      bool superAssemble, string? lstPath,
+                                      string outputFlag, string[]? extraArgs)
     {
         var list = new List<string>(inputs);
-        list.Add("-bin"); list.Add(outBinPath);
+        // outputFlag は AILZ80ASM の shortcut option (-bin / -cmt 等) 名。
+        // path との 2 引数で 1 つの出力 format を指定する (= -bin と -cmt を同時に
+        // 渡すと両 format の file が出るので、env 別に switch する)。
+        list.Add(outputFlag); list.Add(outBinPath);
         list.Add("-sym"); list.Add(outSymPath);
         if (lstPath != null) { list.Add("-lst"); list.Add(lstPath); }
         list.Add("-sm");  list.Add("minimal-equ");
         list.Add("-f");
         if (!superAssemble) list.Add("-nsa");
+        if (extraArgs != null && extraArgs.Length > 0) list.AddRange(extraArgs);
         return list.ToArray();
     }
 

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -65,6 +65,44 @@ public class Driver
             return 1;
         }
 
+        // === env 解決 (前倒し) ===
+        // env file を 1 度だけ解決し、出力 format / disk image 組み立てに共有する。
+        // env 未解決は即 error (= slangc 側でも fail するので早期失敗で十分)。
+        // BuildDiskImage 側で再解決する旧フローは廃止 (= 二重解決排除)。
+        var pathResolver = new PathResolver(_opts.IncludePaths, _opts.LibraryPaths);
+        var searchPaths = pathResolver.GetRuntimePaths()
+                                       .Concat(pathResolver.GetLibPaths())
+                                       .ToList();
+        var resolved = EnvironmentResolver.Resolve(_opts.Environment, searchPaths);
+        if (resolved == null)
+        {
+            Console.Error.WriteLine($"slangbuild: env not found: {_opts.Environment}");
+            return 1;
+        }
+        var (envConfig, envPath) = resolved.Value;
+
+        // --emit disk + disk: セクション無しは早期 reject (= 無駄な compile/asm 回避)
+        if (_opts.EmitMode == "disk" && envConfig.Disk == null)
+        {
+            Console.Error.WriteLine(
+                $"slangbuild: --emit disk requires `disk:` section in env: {envPath}");
+            return 1;
+        }
+
+        // === 出力 format / 拡張子 / AILZ80ASM 出力 flag / extra args 決定 ===
+        // env file `output: cmt` 指定で `.bin` → `.cmt` 切替 + AILZ80ASM の
+        // shortcut option を `-bin` → `-cmt` に置換 + `-gap 0` を追加 pass。
+        // `-bin` と `-cmt` を同時に渡すと両 format の file が出るので、format
+        // ごとに 1 つに切替える設計 (= AssemblerRunner 側 outputFlag 引数)。
+        // null/未指定 (= bin default) なら従来通り `-bin` のみ。
+        // outputFlag / extraArgs は prelink Pass 1/3 でアドレス整合上 main /
+        // overlay 全段で同じものを渡す必要 (= 各 helper method で参照)。
+        var binExt = (envConfig.OutputFormat == "cmt") ? ".cmt" : ".bin";
+        var asmOutputFlag = (envConfig.OutputFormat == "cmt") ? "-cmt" : "-bin";
+        var asmExtraArgs = (envConfig.OutputFormat == "cmt")
+            ? new[] { "-gap", "0" }
+            : null;
+
         // 出力ベースパス決定:
         //   -o 指定あり → 絶対パスならそのまま、相対パスなら cwd 基準で resolve
         //                  (Path.GetFullPath は相対なら cwd を補う)。これにより
@@ -81,7 +119,7 @@ public class Driver
         var outputDir = Path.GetDirectoryName(outputBase)!;
         var prefix = Path.GetFileName(outputBase);
         var mainAsm = outputBase + ".ASM";
-        var mainBin = outputBase + ".bin";
+        var mainBin = outputBase + binExt;
         var mainSym = outputBase + ".sym";
 
         var intermediates = new List<string>();
@@ -140,14 +178,16 @@ public class Driver
             {
                 // === 単段モード (PR-B 既存パス) ===
                 int rc = AssembleSingleStage(runner, plan, mainAsm, mainBin, mainSym,
-                                             overlayAsms, outputDir, intermediates);
+                                             overlayAsms, outputDir, intermediates,
+                                             binExt, asmOutputFlag, asmExtraArgs);
                 if (rc != 0) return rc;
             }
             else
             {
                 // === prelink モード (PR-B2): Pass 1 → Pass 2 → Pass 3 ===
                 int rc = AssemblePrelink(runner, plan, mainBin, mainSym,
-                                         outputDir, intermediates);
+                                         outputDir, intermediates,
+                                         binExt, asmOutputFlag, asmExtraArgs);
                 if (rc != 0) return rc;
             }
 
@@ -156,15 +196,15 @@ public class Driver
             {
                 var overlayBins = overlayAsms
                     .Select(a => Path.Combine(outputDir,
-                        Path.GetFileNameWithoutExtension(a) + ".bin"))
+                        Path.GetFileNameWithoutExtension(a) + binExt))
                     .ToList();
-                int diskRc = BuildDiskImage(mainBin, overlayBins, outputBase);
+                int diskRc = BuildDiskImage(envConfig, envPath, mainBin, overlayBins, outputBase);
                 if (diskRc != 0) return diskRc;
             }
 
             if (_opts.Verbose)
             {
-                Console.Error.WriteLine($"slangbuild: success — {prefix}.bin"
+                Console.Error.WriteLine($"slangbuild: success — {prefix}{binExt}"
                     + (overlayAsms.Count > 0 ? $" + {overlayAsms.Count} overlay(s)" : ""));
             }
             succeeded = true;
@@ -204,10 +244,14 @@ public class Driver
     /// </summary>
     private int AssembleSingleStage(AssemblerRunner runner, PrelinkPlan plan,
         string mainAsm, string mainBin, string mainSym,
-        List<string> overlayAsms, string outputDir, List<string> intermediates)
+        List<string> overlayAsms, string outputDir, List<string> intermediates,
+        string binExt, string asmOutputFlag, string[]? asmExtraArgs)
     {
         var mainLst = Path.ChangeExtension(mainBin, ".LST");
-        var mainResult = runner.AssembleMain(mainAsm, mainBin, mainSym, lstPath: mainLst);
+        var mainResult = runner.AssembleMain(mainAsm, mainBin, mainSym,
+                                             lstPath: mainLst,
+                                             outputFlag: asmOutputFlag,
+                                             extraArgs: asmExtraArgs);
         if (!mainResult.Success)
         {
             Console.Error.Write(mainResult.Stderr);
@@ -220,7 +264,7 @@ public class Driver
         {
             var overlayBase = Path.GetFileNameWithoutExtension(overlayAsm);
             var importsAsm = Path.Combine(outputDir, overlayBase + ".imports.asm");
-            var overlayBin = Path.Combine(outputDir, overlayBase + ".bin");
+            var overlayBin = Path.Combine(outputDir, overlayBase + binExt);
             var overlaySym = Path.Combine(outputDir, overlayBase + ".sym");
             var overlayLst = Path.Combine(outputDir, overlayBase + ".LST");
 
@@ -235,7 +279,9 @@ public class Driver
             }
 
             var ovResult = runner.AssembleOverlay(importsAsm, overlayAsm, overlayBin, overlaySym,
-                                                  lstPath: overlayLst);
+                                                  lstPath: overlayLst,
+                                                  outputFlag: asmOutputFlag,
+                                                  extraArgs: asmExtraArgs);
             if (!ovResult.Success)
             {
                 Console.Error.Write(ovResult.Stderr);
@@ -256,7 +302,8 @@ public class Driver
     /// アドレスが一致することを保証する。
     /// </summary>
     private int AssemblePrelink(AssemblerRunner runner, PrelinkPlan plan,
-        string mainBin, string mainSym, string outputDir, List<string> intermediates)
+        string mainBin, string mainSym, string outputDir, List<string> intermediates,
+        string binExt, string asmOutputFlag, string[]? asmExtraArgs)
     {
         if (_opts.Verbose) Console.Error.WriteLine($"slangbuild: prelink mode (cross-references found)");
 
@@ -266,7 +313,10 @@ public class Driver
         {
             var baseName = Path.GetFileNameWithoutExtension(t.AsmPath);
             var dummyImportsPath = Path.Combine(outputDir, baseName + ".dummy.imports.asm");
-            var pass1BinPath = Path.Combine(outputDir, baseName + ".pass1.bin");
+            // Pass 1 の bin は即削除 intermediate なので拡張子は固定で良いが、
+            // AILZ80ASM 出力 format (= -cmt) を main / Pass 3 と揃える都合上、
+            // ファイル extension も binExt にしておく (= 一貫性、debug 時の混乱防止)。
+            var pass1BinPath = Path.Combine(outputDir, baseName + ".pass1" + binExt);
             var pass1SymPath = Path.Combine(outputDir, baseName + ".pass1.sym");
 
             PrelinkPlan.WriteDummyImports(t, dummyImportsPath);
@@ -274,7 +324,9 @@ public class Driver
 
             var result = runner.AssembleOverlay(dummyImportsPath, t.AsmPath,
                                                 pass1BinPath, pass1SymPath,
-                                                superAssemble: false);
+                                                superAssemble: false,
+                                                outputFlag: asmOutputFlag,
+                                                extraArgs: asmExtraArgs);
             if (!result.Success)
             {
                 Console.Error.Write(result.Stderr);
@@ -310,7 +362,7 @@ public class Driver
                     + "(none found in any target sym: " + string.Join(", ", unresolved) + ")");
             }
 
-            // 本番出力ファイル名: main は <prefix>.bin、overlay は <prefix>._mN.bin
+            // 本番出力ファイル名: main は <prefix>{binExt}、overlay は <prefix>._mN{binExt}
             string outBin, outSym, outLst;
             if (t.Label == "main")
             {
@@ -320,13 +372,15 @@ public class Driver
             }
             else
             {
-                outBin = Path.Combine(outputDir, baseName + ".bin");
+                outBin = Path.Combine(outputDir, baseName + binExt);
                 outSym = Path.Combine(outputDir, baseName + ".sym");
                 outLst = Path.Combine(outputDir, baseName + ".LST");
             }
 
             var result = runner.AssembleOverlay(importsAsm, t.AsmPath, outBin, outSym,
-                                                superAssemble: false, lstPath: outLst);
+                                                superAssemble: false, lstPath: outLst,
+                                                outputFlag: asmOutputFlag,
+                                                extraArgs: asmExtraArgs);
             if (!result.Success)
             {
                 Console.Error.Write(result.Stderr);
@@ -342,26 +396,17 @@ public class Driver
 
     /// <summary>
     /// `--emit disk` 用の disk image 組み立て phase。
-    /// env file を Core の <see cref="EnvironmentResolver"/> 経由で解決し
-    /// (= slangc と検索順を一致させる)、disk セクションが無ければ error。
+    /// envConfig は Run() 冒頭で <see cref="EnvironmentResolver"/> 経由で解決済み
+    /// (= 二重解決排除、Disk null チェックも Run() 側で early reject 済)。
     /// Phase 1 は format=d88 / tool=ndc のみサポート。
     /// </summary>
-    private int BuildDiskImage(string mainBin, IList<string> overlayBins, string outputBase)
+    private int BuildDiskImage(EnvironmentConfig envConfig, string envPath,
+                               string mainBin, IList<string> overlayBins, string outputBase)
     {
-        // env file 解決 (= slangc と同じ resolver / search paths を使用)
-        var pathResolver = new PathResolver(_opts.IncludePaths, _opts.LibraryPaths);
-        var searchPaths = pathResolver.GetRuntimePaths().Concat(pathResolver.GetLibPaths());
-        var resolved = EnvironmentResolver.Resolve(_opts.Environment, searchPaths);
-        if (resolved == null)
-        {
-            Console.Error.WriteLine(
-                $"slangbuild: --emit disk: env not found: {_opts.Environment}");
-            return 1;
-        }
-        var (envConfig, envPath) = resolved.Value;
         if (_opts.Verbose)
             Console.Error.WriteLine($"slangbuild: disk: env loaded from {envPath}");
 
+        // Run() 冒頭で early reject 済みだが、防御的に再 check (= 内部不整合検出)
         if (envConfig.Disk == null)
         {
             Console.Error.WriteLine(

--- a/src/SLANGCompiler.Build/Program.cs
+++ b/src/SLANGCompiler.Build/Program.cs
@@ -123,6 +123,13 @@ internal class Program
             Console.Error.WriteLine($"slangbuild: {ex.Message}");
             return 1;
         }
+        catch (InvalidDataException ex)
+        {
+            // EnvironmentLoader から throw される env file 構文エラー
+            // (= `output:` 値の typo 等)。stack trace は不要 = 一行 message 化。
+            Console.Error.WriteLine($"slangbuild: {ex.Message}");
+            return 1;
+        }
     }
 
     private static void PrintUsage()

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
@@ -15,6 +15,15 @@ public class EnvironmentConfig
     public bool CodeReadonly { get; set; }
 
     /// <summary>
+    /// AILZ80ASM の出力 format。null/未指定 = bin (= `.bin` 拡張子、追加
+    /// オプションなし)。"cmt" = cassette tape image (= `.cmt` 拡張子 +
+    /// AILZ80ASM に `-cmt -gap 0` を pass)。
+    /// 将来 "rom" / "sna" 等の format 追加可能 (= EnvironmentLoader 側で
+    /// allowlist を拡張)。
+    /// </summary>
+    public string? OutputFormat { get; set; }
+
+    /// <summary>
     /// disk image 出力設定 (slangbuild --emit disk 用)。env file に
     /// `disk:` セクションが無ければ null。
     /// </summary>

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentLoader.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentLoader.cs
@@ -38,6 +38,26 @@ public class EnvironmentLoader
         // コード領域の読取専用フラグ（ROM環境）
         config.CodeReadonly = raw.CodeReadonly;
 
+        // output: AILZ80ASM 出力 format (default = bin、"cmt" で CMT 出力)。
+        // 空白/null は null、"bin" も null に正規化 (= 内部表現統一)、
+        // それ以外は明示エラーで typo を早期検出。
+        var rawOutput = raw.Output?.Trim();
+        if (string.IsNullOrEmpty(rawOutput))
+        {
+            config.OutputFormat = null;
+        }
+        else
+        {
+            var normalized = rawOutput.ToLowerInvariant();
+            if (normalized != "bin" && normalized != "cmt")
+            {
+                throw new InvalidDataException(
+                    $"Invalid `output:` value '{rawOutput}' in {envFilePath}. "
+                    + "Allowed: bin (default) / cmt.");
+            }
+            config.OutputFormat = (normalized == "bin") ? null : normalized;
+        }
+
         // ライブラリリスト（.yml → .asm に変換）
         if (raw.Libraries != null)
         {
@@ -128,6 +148,9 @@ public class EnvironmentLoader
 
         [YamlMember(Alias = "optimize")]
         public string? Optimize { get; set; }
+
+        [YamlMember(Alias = "output")]
+        public string? Output { get; set; }
 
         [YamlMember(Alias = "disk")]
         public EnvFileDiskData? Disk { get; set; }

--- a/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
@@ -747,6 +747,27 @@ MYSUB() BEGIN END;
     }
 
     [Fact]
+    public void Pc80mk2_OutputCmt_ProducesCmtNotBin()
+    {
+        // pc80mk2 env (= `output: cmt`) で slangbuild → `<prefix>.cmt` が出ること、
+        // および `.bin` が出ないこと (= Driver の `.bin` hardcode 漏れを CI で検出)。
+        // AILZ80ASM の `-cmt -gap 0` 引数は env 経由で自動的に付与される。
+        var slPath = Path.Combine(_tempDir, "pc80mk2_smoke.SL");
+        File.WriteAllText(slPath, "MAIN() BEGIN END;\n");
+
+        var (code, _, stderr) = RunSlangbuild(slPath, "-E", "pc80mk2");
+        Assert.True(code == 0,
+            $"slangbuild (pc80mk2) failed (exit {code}). stderr: {stderr}");
+
+        var cmtPath = Path.Combine(_tempDir, "pc80mk2_smoke.cmt");
+        var binPath = Path.Combine(_tempDir, "pc80mk2_smoke.bin");
+        Assert.True(File.Exists(cmtPath),
+            $"main cmt not produced at {cmtPath}. stderr: {stderr}");
+        Assert.False(File.Exists(binPath),
+            $"unexpected `.bin` produced at {binPath} — `.bin` hardcode regression");
+    }
+
+    [Fact]
     public void EmitDisk_DefaultDiskImagePath_DerivesFromOutputPrefix()
     {
         // --disk-image 省略時は <output_prefix>.d88 に出る。

--- a/tests/SLANGCompiler.Tests/EnvironmentLoaderTests.cs
+++ b/tests/SLANGCompiler.Tests/EnvironmentLoaderTests.cs
@@ -163,6 +163,75 @@ disk:
     }
 
     [Fact]
+    public void OutputFormat_DeserializesAndNormalizes()
+    {
+        // `output: CMT` (大文字) も `cmt` に lowercase 正規化される。
+        var envPath = WriteEnv("cmt_upper.env", """
+env_type: 5
+os_type: 3
+default_org: "$C000"
+output: CMT
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Equal("cmt", config.OutputFormat);
+    }
+
+    [Fact]
+    public void OutputFormat_NullByDefault()
+    {
+        // `output:` 未指定 env では OutputFormat == null (= bin default)。
+        var envPath = WriteEnv("no_output.env", """
+env_type: 0
+os_type: 0
+default_org: "$100"
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Null(config.OutputFormat);
+    }
+
+    [Fact]
+    public void OutputFormat_BinNormalizedToNull()
+    {
+        // `output: bin` は default と同じなので null に正規化 (= 内部表現統一)。
+        var envPath = WriteEnv("bin_explicit.env", """
+env_type: 0
+os_type: 0
+default_org: "$100"
+output: bin
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Null(config.OutputFormat);
+    }
+
+    [Fact]
+    public void OutputFormat_InvalidValueThrows()
+    {
+        // `output: rom` 等の未知値は InvalidDataException で reject (= typo 早期検出)。
+        var envPath = WriteEnv("bad_output.env", """
+env_type: 0
+os_type: 0
+default_org: "$100"
+output: rom
+libraries:
+  - runtime.yml
+""");
+
+        var ex = Assert.Throws<InvalidDataException>(() => EnvironmentLoader.Load(envPath));
+        Assert.Contains("rom", ex.Message);
+        Assert.Contains("bin", ex.Message);
+        Assert.Contains("cmt", ex.Message);
+    }
+
+    [Fact]
     public void DiskSystemFiles_PathNormalization_RemovesDotSegments()
     {
         // env file dir 基準で `./xxx/../foo/ipl.bin` のような dotted path が


### PR DESCRIPTION
## Summary

PC-8001mkII ROM 環境 (`pc80mk2`) を slangbuild build 経路に乗せ、旧 dev `Makefile` で入っていたが `Makefile.dist` 化で抜けていた **CMT (cassette tape) 出力** を復元します。M88 等のエミュレータで `.cmt` をそのまま CLOAD で読み込める想定です。

env 統合 Phase 3 シリーズの 2 本目 (#162 pc88mk2sr に続く)。

## 主要変更

- **env file 拡張**: 新フィールド `output:` (`bin` / `cmt` / 未指定)。`EnvironmentLoader` で正規化 + Unknown 値は `InvalidDataException` で reject (= typo 早期検出)
- **AssemblerRunner**: `outputFlag` (`-bin` / `-cmt`) と `extraArgs` 引数を追加。AILZ80ASM の `-bin` と `-cmt` は独立した output shortcut で両者同時に渡すと両 format ファイルが出るので、format ごとに 1 つに切替える設計
- **Driver.Run() 冒頭で env 解決を前倒し**: `EnvironmentResolver` を 1 度だけ呼んで envConfig を保持、`BuildDiskImage` 内の二重解決を排除。`--emit disk` + `disk:` 不在 env は compile 前に early reject
- **`.bin` hardcode 6 箇所 + verbose success message** を `binExt` (= env の OutputFormat 由来) 経由に置換
- **`Program.cs`**: `catch (InvalidDataException ex)` 追加 (= stack trace なしで一行 message 化)
- **`runtime/env/pc80mk2.env`**: `output: cmt` 1 行追加
- **`Makefile.dist`**: \`OUTPROG\` を \`\$(BIN_EXT)\` 経由で拡張子化、pc80mk2 ENV ブロック追加 (\`BIN_EXT/BIN_EXT_ENV = .cmt\`、\`DISK_IMAGE = \$(OUTPROG)\`)、\`disk_image\` 分岐に \`pc80mk2: \$(OUTPROG)\` 明示追加 (= cpm / msxrom と同じ pattern、旧 ELSE ndc 経路に落ちないため)、\`clean\` recipe / \`help\` ENV 一覧にも反映

`make ENV=pc80mk2 build / run / disk_image` のいずれでも `examples/PROG.cmt` が生成されます。

## テスト

- **新規 4 件 (`EnvironmentLoaderTests.cs`)**: `OutputFormat_DeserializesAndNormalizes` (`output: CMT` 大文字も小文字化) / `OutputFormat_NullByDefault` / `OutputFormat_BinNormalizedToNull` / `OutputFormat_InvalidValueThrows`
- **新規 1 件 (`BuildIntegrationTests.cs`)**: `Pc80mk2_OutputCmt_ProducesCmtNotBin` — `.cmt` 生成 + `.bin` 非生成 (= `.bin` hardcode 漏れを CI で検出)
- **既存 207 + 新規 5 = 212/212 全 pass** ✅

## 設計上の発見

実装中の smoke で AILZ80ASM の挙動を確認: `-bin <path>` と `-cmt` を**両方**渡すと AILZ80ASM は両 format のファイルを出力します (`-bin` と `-cmt` は等価な shortcut で `-om bin` / `-om cmt` への糖衣)。このため当初の「`-bin <path>` 維持 + `-cmt -gap 0` extra args」設計を、**`-bin` を `-cmt` に置換 + `-gap 0` だけ extra args** に変更しました。`outputFlag` 引数を `AssemblerRunner` に追加し、prelink Pass 1 / Pass 3 / 単段 / overlay 全段で同じ outputFlag/extraArgs を pass (アドレス整合のため)。

## scope 外 (本 PR で扱わない)

- **pc80mk2x** (XBIOS 直接環境、XBIOS.CMT 結合が別途必要) は別 PR
- **overlay 結合** (= \`M0.cmt\` を main 結合) はユーザー側責務、本 PR では \`_m0.cmt\` 別ファイルで出すのみ
- **\`--emit disk\` 統合** (= cassette は disk じゃないので非対象)
- **emulator 起動 EMU 設定** (= \`Makefile.dist\` の \`EMU\` 変数は default の「emulator not configured」メッセージ、ユーザー側設定)

## Test plan

- [x] `dotnet test` 212/212 全 pass (既存 207 件 regression なし)
- [x] 手動 smoke: pc80mk2 で `/tmp/pc80_smoke.cmt` (56 byte) 生成 + `.bin` 非生成
- [x] 手動 smoke: lsx で `.bin` regression なし
- [x] 手動 smoke: Unknown `output: rom` で `slangbuild: Invalid output: value 'rom' ...` + exit 1
- [x] 実機 / M88 エミュレータでの CLOAD 動作確認 (= ユーザー側)
- [x] Makefile.dist 経由 `make ENV=pc80mk2 build / run` の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)