### PR TITLE
vgs0 環境を slangbuild に統合 — bin padding (8KB bank switching 対応)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   - **VRTC 割り込みハンドラの GAMEVSYNC を条件化**: `libp88_base.asm` の `INTVRTC` で `CALL GAMEVSYNC` を `#if exists USE_GAMEVSYNC` で囲み、SL 側で `CONST ASM USE_GAMEVSYNC = 1;` を立てた場合のみ呼ぶ形に。`USE_GAMEVSYNC` 未定義の SL は GAMEVSYNC 関数を書かなくても build できる
   - **AILZ80ASM エラー表示**: `--verbose` 無しでも `main assembly failed` の詳細 (= 未定義 label 等) が stderr に出るよう修正 (= AILZ80ASM がエラーを stdout に流す癖を吸収)
 
+- vgs0 環境 (VGS-Zero、Z80 ターゲット) を `slangbuild` に対応 — 8KB bank switching に合わせた bin padding
+  - 新 env file フィールド `bin_pad_size:` (= main 用、固定 byte サイズの末尾 0 padding) と `overlay_pad_align:` (= overlay 用、指定値の倍数に切り上げ末尾 0 padding) を追加
+  - `runtime/env/vgs0.env` に `bin_pad_size: 16384` + `overlay_pad_align: 8192` を設定 (= main を 16KB 固定 ROM、各 overlay を 8KB bank 単位に揃える)
+  - bin が `bin_pad_size` を超えた場合は silent truncation を防ぐため明示エラー (`slangbuild: bin_pad_size: bin size N byte exceeds target ...`)
+  - 両フィールドは `output: cmt` env で指定すると env load 時 `InvalidDataException` で reject (= cmt header 込み bin に padding は意味不明)
+  - `Makefile.dist` に vgs0 ENV ブロック (`BIN_EXT/BIN_EXT_ENV = .bin`、`DISK_IMAGE = $(OUTPROG)`) + `disk_image` 分岐 + help ENV 一覧追加
+
 - pc80mk2xsd 環境 (PC-8001mkII XBIOS 直接環境、SD カード経路) を `slangbuild` に対応
   - 新 env file フィールド `cmt_assets:` (= output dir に copy する static asset の相対 path リスト)、`overlay_name:` (= overlay 出力 file 名 template、`{index}` 展開)、`overlay_output_format:` (= overlay 専用の出力 format、bin / cmt 切替)
   - pc80mk2xsd では main を CMT 形式 + overlay を raw binary で出し、`M{index}.BIN` 命名で output dir に rename。`cmt_assets` で `XBIOS.CMT` を output dir にコピーするので、user は output dir 全体を SD カードに移すだけで揃う

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -139,6 +139,16 @@ else ifeq ($(ENV), pc80mk2xsd)
   BIN_EXT = .cmt
   BIN_EXT_ENV = .cmt
   DISK_IMAGE = $(OUTPROG)
+else ifeq ($(ENV), vgs0)
+  # VGS-Zero ROM 出力 (= raw bin、env file `bin_pad_size: 16384` +
+  # `overlay_pad_align: 8192` で slangbuild が main を 16KB 固定 / 各
+  # overlay を 8KB 倍数に切り上げ padding する)。VGS-Zero は 8KB 単位の
+  # bank switching ハードで、各 overlay を bank 単位に揃える必要があるため。
+  # disk image なし、`disk_image` target は OUTPROG (= PROG.bin) そのもの。
+  EMU = @echo "VGS-Zero emulator not configured. Set EMU variable" \#
+  BIN_EXT = .bin
+  BIN_EXT_ENV = .bin
+  DISK_IMAGE = $(OUTPROG)
 else ifeq ($(ENV), msxrom)
   EMU = @echo "Set EMU variable for your emulator" \#
   BIN_EXT_ENV = $(BIN_EXT)
@@ -223,6 +233,11 @@ else ifeq ($(ENV), pc80mk2xsd)
 # pc80mk2xsd は CMT 個別配置 (= slangbuild が main.cmt + 各 M{N}.BIN +
 # XBIOS.CMT を output dir に揃える)。disk image なし、disk_image target は
 # OUTPROG (= PROG.cmt) を produce すれば十分。
+disk_image: $(OUTPROG)
+else ifeq ($(ENV), vgs0)
+# vgs0 は ROM bin 出力 (= disk image なし)。slangbuild が padding 済 bin
+# (16KB 固定 main + 8KB 倍数 overlay) を出すので、disk_image target は
+# OUTPROG (= PROG.bin) を produce すれば十分。
 disk_image: $(OUTPROG)
 else ifeq ($(ENV), sos)
 # sos / sosx1 は slangbuild --emit disk + HuDisk 経路。template
@@ -333,6 +348,6 @@ help:
 	@echo "  PREFIX=path        - Installation prefix (default: ~/.local on Unix,"
 	@echo '                       %USERPROFILE%\.local\bin on Windows)'
 	@echo "  TARGET=path        - Sample source file (without extension)"
-	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/pc88mk2sr/pc80mk2/pc80mk2x/pc80mk2xsd/msx2/msxrom/cpm)"
+	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/pc88mk2sr/pc80mk2/pc80mk2x/pc80mk2xsd/vgs0/msx2/msxrom/cpm)"
 	@echo ""
 	@echo "Detected OS: $(DETECTED_OS)"

--- a/README.md
+++ b/README.md
@@ -146,6 +146,8 @@ PRINT文はテキストVRAMへの直接書き込みで実現しています。�
 
 VGS-Zero用の環境です。
 
+`slangbuild` (および `Makefile.dist build / run / disk_image ENV=vgs0`) は env file (`bin_pad_size: 16384` + `overlay_pad_align: 8192`) に従って、main を 16KB 固定 ROM、各 overlay (`#MODULE`) を 8KB の倍数に切り上げて末尾を 0 で埋めます。VGS-Zero は 8KB 単位の bank switching を持つため、overlay も 8KB 単位に揃える必要があります。bank 切替は `runtime/libvgs0_base.asm` 既存の helper から呼べます。
+
 ## zxn (ZX Spectrum Next)
 
 ZX Spectrum Next用の環境です。

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -1194,7 +1194,7 @@ overlay_pad_align: 8192     # 各 overlay を 8KB 倍数に切り上げ
 - null / 0 / 負 = padding なし (= 既存挙動、Loader 上で null 相当に正規化)
 - `output: cmt` env で指定すると env load 時 `InvalidDataException` で
   reject (= cmt header 込み bin に padding は意味不明)
-- 拡張領域は OS 保証で 0 fill (= `dd if=/dev/zero conv=notrunc` と等価)
+- 拡張領域は slangbuild が明示的に 0 を書き出して padding する (= `dd if=/dev/zero conv=notrunc` と等価、Windows / Linux / macOS で同じ挙動)
 
 VGS-Zero (https://github.com/suzukiplan/vgszero) は 8KB 単位の bank
 switching を持つハードで、各 overlay を 8KB 単位に揃えることで bank

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -1171,6 +1171,36 @@ defines:
 - `ENV_TYPE` / `OS_TYPE` は env file `env_type:` / `os_type:` から
   自動的に登録される (= 既存挙動、`defines:` を書かなくても利用可能)
 
+#### bin padding env (= vgs0)
+
+固定サイズ ROM 出力や bank switching ハードに対応するため、env file に
+`bin_pad_size:` (= main 用、固定 byte) と `overlay_pad_align:` (= overlay
+用、指定値の倍数に切り上げ) を指定すると、slangbuild が AILZ80ASM 出力後
+に末尾を 0 で埋めて指定サイズに揃える:
+
+```yaml
+# runtime/env/vgs0.env (抜粋)
+bin_pad_size: 16384         # main を 16KB 固定 (VGS-Zero ROM 領域 = 8KB×2)
+overlay_pad_align: 8192     # 各 overlay を 8KB 倍数に切り上げ
+                            # (= 8KB bank switching に揃える)
+```
+
+| フィールド | 内容 |
+|---|---|
+| `bin_pad_size:` (int) | main bin の **固定 byte サイズ**。padding 後に必ずこの size になる。既存サイズが超えていたら `slangbuild: bin_pad_size: bin size N byte exceeds target ...` の明示エラーで exit 1 (= silent truncation 防止) |
+| `overlay_pad_align:` (int) | 各 overlay bin を指定値の **倍数に切り上げ** padding。上限なし。empty overlay は no-op |
+
+両者の semantics:
+- null / 0 / 負 = padding なし (= 既存挙動、Loader 上で null 相当に正規化)
+- `output: cmt` env で指定すると env load 時 `InvalidDataException` で
+  reject (= cmt header 込み bin に padding は意味不明)
+- 拡張領域は OS 保証で 0 fill (= `dd if=/dev/zero conv=notrunc` と等価)
+
+VGS-Zero (https://github.com/suzukiplan/vgszero) は 8KB 単位の bank
+switching を持つハードで、各 overlay を 8KB 単位に揃えることで bank
+switch loader が読み込み可能になる。SL から bank 切替を呼ぶ helper は
+`runtime/libvgs0_base.asm` に既存。
+
 ---
 
 サンプル限定の最小実装で、overlay 命名は `M<N>.BIN` 固定、各 overlay は

--- a/runtime/env/vgs0.env
+++ b/runtime/env/vgs0.env
@@ -2,6 +2,8 @@ env_type: 6
 os_type: 5
 default_org:	"$0000"
 default_work: "$C000"
+bin_pad_size: 16384
+overlay_pad_align: 8192
 libraries:
   - runtime.yml
   - libfloat.yml

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -650,12 +650,7 @@ public class Driver
             return 1;
         }
         if (currentSize == targetSize) return 0;
-        // 不足分を 0 で末尾 padding (= FileStream.SetLength で拡張、追加領域
-        // は OS 保証で 0 fill。dd if=/dev/zero conv=notrunc と等価)。
-        using (var fs = new FileStream(binPath, FileMode.Open, FileAccess.Write))
-        {
-            fs.SetLength(targetSize);
-        }
+        WriteZeroPadding(binPath, currentSize, targetSize);
         if (_opts.Verbose)
             Console.Error.WriteLine(
                 $"slangbuild: bin pad: {Path.GetFileName(binPath)} "
@@ -675,15 +670,36 @@ public class Driver
         if (currentSize == 0) return 0; // empty overlay は no-op
         long rounded = ((currentSize + align - 1) / align) * align;
         if (currentSize == rounded) return 0;
-        using (var fs = new FileStream(binPath, FileMode.Open, FileAccess.Write))
-        {
-            fs.SetLength(rounded);
-        }
+        WriteZeroPadding(binPath, currentSize, rounded);
         if (_opts.Verbose)
             Console.Error.WriteLine(
                 $"slangbuild: overlay pad: {Path.GetFileName(binPath)} "
                 + $"{currentSize} → {rounded} byte (align {align}, zero-filled)");
         return 0;
+    }
+
+    /// <summary>
+    /// bin の末尾 (= currentSize の位置) から targetSize まで 0 を明示的に
+    /// 書き込む。<c>FileStream.SetLength</c> の拡張領域は Windows で 0 fill
+    /// が仕様上未定義 (Microsoft Learn 記載) なので、portable に保証するため
+    /// `dd if=/dev/zero conv=notrunc` と等価な明示書き込みで実装する。
+    /// 8KB chunk で write することで巨大 padding でもメモリ消費を抑える。
+    /// </summary>
+    private static void WriteZeroPadding(string binPath, long currentSize, long targetSize)
+    {
+        long padBytes = targetSize - currentSize;
+        if (padBytes <= 0) return;
+        const int ChunkSize = 8192;
+        var zeros = new byte[(int)Math.Min(padBytes, ChunkSize)];
+        using var fs = new FileStream(binPath, FileMode.Open, FileAccess.Write);
+        fs.Seek(0, SeekOrigin.End);
+        long written = 0;
+        while (written < padBytes)
+        {
+            int chunk = (int)Math.Min(zeros.Length, padBytes - written);
+            fs.Write(zeros, 0, chunk);
+            written += chunk;
+        }
     }
 
     /// <summary>

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -246,6 +246,36 @@ public class Driver
                     .ToList();
             }
 
+            // === Step 3.5a-pad: bin padding (env.BinPadSize / OverlayPadAlign 指定時) ===
+            // VGS-Zero 等で固定サイズ ROM 出力 (= main を 16384 byte 固定 +
+            // 各 overlay を 8192 倍数に切り上げ padding)。renamedOverlayBins
+            // 経由で rename 後 path に対して padding するので、pc80mk2xsd の
+            // `_m{N}` 命名でも VGS-Zero の `M{index}.BIN` 命名でも対応可能。
+            // CMT 出力 (= output: cmt) との排他は Loader で保証済。
+            if (envConfig.BinPadSize.HasValue && envConfig.BinPadSize.Value > 0)
+            {
+                int padRc = PadBinToFixedSize(mainBin, envConfig.BinPadSize.Value);
+                if (padRc != 0) return padRc;
+            }
+            if (envConfig.OverlayPadAlign.HasValue && envConfig.OverlayPadAlign.Value > 0)
+            {
+                foreach (var ov in renamedOverlayBins)
+                {
+                    // renamedOverlayBins に登録済の overlay は生成されている
+                    // べき成果物。欠落は internal error として silent wrong
+                    // 防止のため明示エラー (cmt_concat の missing file 対応と
+                    // 揃える方針)。
+                    if (!File.Exists(ov))
+                    {
+                        Console.Error.WriteLine(
+                            $"slangbuild: overlay_pad_align: overlay file not found: {ov}");
+                        return 1;
+                    }
+                    int rc = PadBinToAlignment(ov, envConfig.OverlayPadAlign.Value);
+                    if (rc != 0) return rc;
+                }
+            }
+
             // === Step 3.5b: cmt_assets コピー (env.CmtAssets 指定時) ===
             // pc80mk2xsd で XBIOS.CMT 等を output dir にコピー。ユーザーは
             // output dir 全体を SD カードに移すだけで揃う運用。
@@ -601,6 +631,59 @@ public class Driver
     {
         using var src = File.OpenRead(srcPath);
         src.CopyTo(dst);
+    }
+
+    /// <summary>
+    /// bin を指定 byte size まで末尾 0 で padding。既存サイズが指定サイズを
+    /// 超えていた場合は silent truncation を避けるため error 終了。
+    /// VGS-Zero 等の固定サイズ ROM 出力用 (= 16384 byte 固定 ROM 等)。
+    /// </summary>
+    private int PadBinToFixedSize(string binPath, int targetSize)
+    {
+        var currentSize = new FileInfo(binPath).Length;
+        if (currentSize > targetSize)
+        {
+            Console.Error.WriteLine(
+                $"slangbuild: bin_pad_size: bin size {currentSize} byte exceeds "
+                + $"target {targetSize} byte ({binPath}). reduce code size or "
+                + $"increase bin_pad_size in env file.");
+            return 1;
+        }
+        if (currentSize == targetSize) return 0;
+        // 不足分を 0 で末尾 padding (= FileStream.SetLength で拡張、追加領域
+        // は OS 保証で 0 fill。dd if=/dev/zero conv=notrunc と等価)。
+        using (var fs = new FileStream(binPath, FileMode.Open, FileAccess.Write))
+        {
+            fs.SetLength(targetSize);
+        }
+        if (_opts.Verbose)
+            Console.Error.WriteLine(
+                $"slangbuild: bin pad: {Path.GetFileName(binPath)} "
+                + $"{currentSize} → {targetSize} byte (zero-filled)");
+        return 0;
+    }
+
+    /// <summary>
+    /// bin を alignment の倍数 (= ((size + align - 1) / align) * align) に
+    /// 末尾 0 で padding。すでに倍数なら no-op。empty (= 0 byte) でも no-op。
+    /// 上限なし。VGS-Zero の 8KB bank switching 等で各 overlay を bank 単位
+    /// に揃えるため。
+    /// </summary>
+    private int PadBinToAlignment(string binPath, int align)
+    {
+        var currentSize = new FileInfo(binPath).Length;
+        if (currentSize == 0) return 0; // empty overlay は no-op
+        long rounded = ((currentSize + align - 1) / align) * align;
+        if (currentSize == rounded) return 0;
+        using (var fs = new FileStream(binPath, FileMode.Open, FileAccess.Write))
+        {
+            fs.SetLength(rounded);
+        }
+        if (_opts.Verbose)
+            Console.Error.WriteLine(
+                $"slangbuild: overlay pad: {Path.GetFileName(binPath)} "
+                + $"{currentSize} → {rounded} byte (align {align}, zero-filled)");
+        return 0;
     }
 
     /// <summary>

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentConfig.cs
@@ -81,6 +81,26 @@ public class EnvironmentConfig
     /// 名前は <c>^[A-Za-z_][A-Za-z0-9_]*$</c> regex で validate。
     /// </summary>
     public Dictionary<string, int>? Defines { get; set; }
+
+    /// <summary>
+    /// main bin の **固定サイズ** (byte 単位)。AILZ80ASM 出力後に末尾を 0
+    /// で埋めて指定サイズに揃える。null / 0 / 負 = padding なし (既存挙動)。
+    /// VGS-Zero (vgs0) で 16384 byte 固定 ROM 出力に使う。
+    /// <see cref="OutputFormat"/> == "cmt" 環境では指定不可 (Loader で reject)。
+    /// 既存 bin が指定サイズを超えていた場合 Driver が error で終了
+    /// (= silent truncation 防止)。
+    /// </summary>
+    public int? BinPadSize { get; set; }
+
+    /// <summary>
+    /// overlay (`#MODULE`) bin の **alignment** (byte 単位)。各 overlay の
+    /// サイズを指定値の倍数に切り上げて末尾を 0 で埋める。null / 0 / 負 =
+    /// padding なし (既存挙動)。VGS-Zero の 8KB bank switching に対応する
+    /// ため <c>8192</c> 指定で各 overlay を 8KB 単位に揃える。
+    /// <see cref="OutputFormat"/> == "cmt" 環境では指定不可 (Loader で reject)。
+    /// 上限なし (= overlay サイズに応じて切り上げ、empty overlay は no-op)。
+    /// </summary>
+    public int? OverlayPadAlign { get; set; }
 }
 
 /// <summary>

--- a/src/SLANGCompiler.Core/Runtime/EnvironmentLoader.cs
+++ b/src/SLANGCompiler.Core/Runtime/EnvironmentLoader.cs
@@ -148,6 +148,23 @@ public class EnvironmentLoader
             config.Defines = validated;
         }
 
+        // bin_pad_size / overlay_pad_align: bin 出力 (= output: cmt 以外)
+        // 専用。cmt 環境で指定すると header 込み bin に padding する形に
+        // なり意味不明なので reject。null / 0 / 負 = padding なし
+        // (= 設定漏れ寛容、明示的 reject はしない、Loader 上で null 相当に
+        // 正規化)。
+        bool hasBinPadSize = raw.BinPadSize.HasValue && raw.BinPadSize.Value > 0;
+        bool hasOverlayPadAlign =
+            raw.OverlayPadAlign.HasValue && raw.OverlayPadAlign.Value > 0;
+        if ((hasBinPadSize || hasOverlayPadAlign) && config.OutputFormat == "cmt")
+        {
+            throw new InvalidDataException(
+                $"`bin_pad_size` / `overlay_pad_align` are not allowed with "
+                + $"`output: cmt` in {envFilePath}.");
+        }
+        if (hasBinPadSize) config.BinPadSize = raw.BinPadSize!.Value;
+        if (hasOverlayPadAlign) config.OverlayPadAlign = raw.OverlayPadAlign!.Value;
+
         // overlay_name validate (path 安全性 + {index} 必須):
         // - {index} placeholder 必須 (= 無いと overlay 複数個で全部同じ path
         //   に上書き silent wrong)
@@ -266,6 +283,12 @@ public class EnvironmentLoader
 
         [YamlMember(Alias = "defines")]
         public Dictionary<string, int>? Defines { get; set; }
+
+        [YamlMember(Alias = "bin_pad_size")]
+        public int? BinPadSize { get; set; }
+
+        [YamlMember(Alias = "overlay_pad_align")]
+        public int? OverlayPadAlign { get; set; }
 
         [YamlMember(Alias = "disk")]
         public EnvFileDiskData? Disk { get; set; }

--- a/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
@@ -976,6 +976,128 @@ PROC_CMT_MARKER() BEGIN END;
     }
 
     [Fact]
+    public void Vgs0_PadsMainTo16384_OverlayTo8192Multiple()
+    {
+        // vgs0 env (= `bin_pad_size: 16384` + `overlay_pad_align: 8192`) で
+        // slangbuild build → main = exactly 16384 byte、各 overlay は 8192
+        // の倍数に切り上げ + 末尾 0 fill。
+        //
+        // 検証戦略: 同じ SL を 2 つの env で build して bytes 比較
+        // (a) 標準 vgs0 env で padded build (= padding 後の bin)
+        // (b) padding なし fixture env で raw build (= padding 前の bin)
+        // → (a) の先頭 raw.Length byte == raw bin の bytes 完全一致 +
+        //   (a) の末尾 padding 部分は全 0
+        var slPath = Path.Combine(_tempDir, "vgs0_test.SL");
+        File.WriteAllText(slPath, """
+MAIN() BEGIN MYSUB(); END;
+#MODULE $1000
+MYSUB() BEGIN END;
+#END
+""");
+
+        // (a) padded build (= 標準 vgs0)
+        var (codeA, _, stderrA) = RunSlangbuild(slPath, "-E", "vgs0", "--keep-asm");
+        Assert.True(codeA == 0,
+            $"slangbuild (vgs0 padded) failed (exit {codeA}). stderr: {stderrA}");
+
+        var paddedMainBin = Path.Combine(_tempDir, "vgs0_test.bin");
+        var paddedOverlayBin = Path.Combine(_tempDir, "vgs0_test._m0.bin");
+        Assert.True(File.Exists(paddedMainBin), $"padded main bin not at {paddedMainBin}");
+        Assert.True(File.Exists(paddedOverlayBin), $"padded overlay bin not at {paddedOverlayBin}");
+
+        // (b) raw build (= vgs0.env から padding fields だけ抜いた fixture)
+        var origEnv = File.ReadAllText(
+            Path.Combine(_projectRoot, "runtime", "env", "vgs0.env"));
+        var lines = origEnv.Split('\n');
+        var filtered = lines.Where(l =>
+            !l.TrimStart().StartsWith("bin_pad_size:")
+            && !l.TrimStart().StartsWith("overlay_pad_align:"));
+
+        var fixtureEnvDir = Path.Combine(_tempDir, "fxnopad", "env");
+        Directory.CreateDirectory(fixtureEnvDir);
+        var fixtureEnvPath = Path.Combine(fixtureEnvDir, "vgs0_nopad.env");
+        File.WriteAllText(fixtureEnvPath, string.Join("\n", filtered));
+
+        var slPath2 = Path.Combine(_tempDir, "vgs0_nopad.SL");
+        File.WriteAllText(slPath2, """
+MAIN() BEGIN MYSUB(); END;
+#MODULE $1000
+MYSUB() BEGIN END;
+#END
+""");
+
+        var (codeB, _, stderrB) = RunSlangbuild(slPath2,
+            "-E", "vgs0_nopad",
+            "-L", Path.Combine(_tempDir, "fxnopad"));
+        Assert.True(codeB == 0,
+            $"slangbuild (vgs0_nopad raw) failed (exit {codeB}). stderr: {stderrB}");
+
+        var rawMainBin = Path.Combine(_tempDir, "vgs0_nopad.bin");
+        var rawOverlayBin = Path.Combine(_tempDir, "vgs0_nopad._m0.bin");
+        Assert.True(File.Exists(rawMainBin));
+        Assert.True(File.Exists(rawOverlayBin));
+
+        // === assertions ===
+        var paddedMain = File.ReadAllBytes(paddedMainBin);
+        var paddedOverlay = File.ReadAllBytes(paddedOverlayBin);
+        var rawMain = File.ReadAllBytes(rawMainBin);
+        var rawOverlay = File.ReadAllBytes(rawOverlayBin);
+
+        // (1) main = 16384 byte 固定
+        Assert.Equal(16384, paddedMain.Length);
+
+        // (2) overlay = 8192 倍数 (= 切り上げ)
+        Assert.True(paddedOverlay.Length > 0,
+            $"padded overlay length is 0");
+        Assert.True(paddedOverlay.Length % 8192 == 0,
+            $"padded overlay length {paddedOverlay.Length} not multiple of 8192");
+        // raw が 8192 byte 以下なら padded は 8192 byte
+        Assert.Equal(((rawOverlay.Length + 8191) / 8192) * 8192, paddedOverlay.Length);
+
+        // (3) main / overlay の先頭 raw.Length byte は raw と完全一致
+        // (= 先頭が壊れる実装ミスを catch)
+        Assert.Equal(rawMain, paddedMain.Take(rawMain.Length).ToArray());
+        Assert.Equal(rawOverlay, paddedOverlay.Take(rawOverlay.Length).ToArray());
+
+        // (4) main / overlay の padding 部分 (= 先頭以降の末尾) は全て 0
+        for (int i = rawMain.Length; i < paddedMain.Length; i++)
+            Assert.Equal((byte)0, paddedMain[i]);
+        for (int i = rawOverlay.Length; i < paddedOverlay.Length; i++)
+            Assert.Equal((byte)0, paddedOverlay[i]);
+    }
+
+    [Fact]
+    public void BinPadSize_Overflow_ReturnsFriendlyError()
+    {
+        // bin が pad_size を超えている場合は silent truncation を防ぐため
+        // 明示エラーで exit 1。`bin_pad_size: 8` の fixture env で大きい
+        // SL を build して overflow を意図的に発生させる。
+        var fixtureEnvDir = Path.Combine(_tempDir, "ovrf_env", "env");
+        Directory.CreateDirectory(fixtureEnvDir);
+        var fixtureEnvPath = Path.Combine(fixtureEnvDir, "ovrf.env");
+        File.WriteAllText(fixtureEnvPath, """
+env_type: 6
+os_type: 5
+default_org: "$0000"
+bin_pad_size: 8
+libraries:
+  - runtime.yml
+  - libfloat.yml
+  - libvgs0_base.yml
+""");
+
+        var slPath = Path.Combine(_tempDir, "ovrf_test.SL");
+        File.WriteAllText(slPath, "MAIN() BEGIN END;\n");
+
+        var (code, _, stderr) = RunSlangbuild(slPath,
+            "-E", "ovrf",
+            "-L", Path.Combine(_tempDir, "ovrf_env"));
+        Assert.NotEqual(0, code);
+        Assert.Contains("bin_pad_size", stderr);
+        Assert.Contains("exceeds", stderr);
+    }
+
+    [Fact]
     public void CmtConcat_MissingFile_ReturnsFriendlyError()
     {
         // `cmt_concat:` の path が存在しない fixture env で build → exit 1 +

--- a/tests/SLANGCompiler.Tests/EnvironmentLoaderTests.cs
+++ b/tests/SLANGCompiler.Tests/EnvironmentLoaderTests.cs
@@ -522,6 +522,139 @@ libraries:
     }
 
     [Fact]
+    public void BinPadSize_DeserializesIntegerValue()
+    {
+        var envPath = WriteEnv("padsize.env", """
+env_type: 6
+os_type: 5
+default_org: "$0000"
+bin_pad_size: 16384
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Equal(16384, config.BinPadSize);
+    }
+
+    [Fact]
+    public void BinPadSize_NullByDefault()
+    {
+        var envPath = WriteEnv("nopadsize.env", """
+env_type: 0
+os_type: 0
+default_org: "$100"
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Null(config.BinPadSize);
+    }
+
+    [Fact]
+    public void BinPadSize_AndOverlayPadAlign_ZeroOrNegativeNormalizesToNull()
+    {
+        // 0 / 負数で指定すると null 相当 (= padding なし扱い、明示 reject
+        // ではなく寛容に 0/負を null と同じ意味として扱う)。
+        var envPathZero = WriteEnv("padzero.env", """
+env_type: 6
+os_type: 5
+default_org: "$0000"
+bin_pad_size: 0
+overlay_pad_align: 0
+libraries:
+  - runtime.yml
+""");
+        var configZero = EnvironmentLoader.Load(envPathZero);
+        Assert.Null(configZero.BinPadSize);
+        Assert.Null(configZero.OverlayPadAlign);
+
+        var envPathNeg = WriteEnv("padneg.env", """
+env_type: 6
+os_type: 5
+default_org: "$0000"
+bin_pad_size: -1
+overlay_pad_align: -8192
+libraries:
+  - runtime.yml
+""");
+        var configNeg = EnvironmentLoader.Load(envPathNeg);
+        Assert.Null(configNeg.BinPadSize);
+        Assert.Null(configNeg.OverlayPadAlign);
+    }
+
+    [Fact]
+    public void OverlayPadAlign_DeserializesIntegerValue()
+    {
+        var envPath = WriteEnv("ovalign.env", """
+env_type: 6
+os_type: 5
+default_org: "$0000"
+overlay_pad_align: 8192
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Equal(8192, config.OverlayPadAlign);
+    }
+
+    [Fact]
+    public void OverlayPadAlign_NullByDefault()
+    {
+        var envPath = WriteEnv("noovalign.env", """
+env_type: 0
+os_type: 0
+default_org: "$100"
+libraries:
+  - runtime.yml
+""");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Null(config.OverlayPadAlign);
+    }
+
+    [Fact]
+    public void BinPadSize_RequiresOutputBin_OtherwiseThrows()
+    {
+        // output: cmt env で bin_pad_size 指定すると header 込み bin に
+        // padding する形になり意味不明なので reject。
+        var envPath = WriteEnv("padcmt.env", """
+env_type: 5
+os_type: 3
+default_org: "$C000"
+output: cmt
+bin_pad_size: 16384
+libraries:
+  - runtime.yml
+""");
+
+        var ex = Assert.Throws<InvalidDataException>(() => EnvironmentLoader.Load(envPath));
+        Assert.Contains("bin_pad_size", ex.Message);
+        Assert.Contains("output: cmt", ex.Message);
+    }
+
+    [Fact]
+    public void OverlayPadAlign_RequiresOutputBin_OtherwiseThrows()
+    {
+        // output: cmt env で overlay_pad_align 指定も同じ理由で reject。
+        var envPath = WriteEnv("ovaligncmt.env", """
+env_type: 5
+os_type: 3
+default_org: "$C000"
+output: cmt
+overlay_pad_align: 8192
+libraries:
+  - runtime.yml
+""");
+
+        var ex = Assert.Throws<InvalidDataException>(() => EnvironmentLoader.Load(envPath));
+        Assert.Contains("overlay_pad_align", ex.Message);
+        Assert.Contains("output: cmt", ex.Message);
+    }
+
+    [Fact]
     public void DiskSystemFiles_PathNormalization_RemovesDotSegments()
     {
         // env file dir 基準で `./xxx/../foo/ipl.bin` のような dotted path が


### PR DESCRIPTION
## Summary

VGS-Zero (https://github.com/suzukiplan/vgszero) の env (`vgs0`) を slangbuild に統合します。VGS-Zero は **8KB 単位の bank switching** を持つ Z80 ターゲットハードで、ROM image / overlay 共に 8KB の倍数で出力する必要があります。

dev build flow では `dd if=/dev/zero` で main を 16384 byte に padding していましたが (= overlay は user 側手動)、これを slangbuild に内製化 + **overlay の 8KB align padding も新規対応**。

## 主要変更

### 新 EnvironmentConfig フィールド 2 件
- `BinPadSize` (int?): main 用、**固定 byte サイズ** (= padding 後の total size)
- `OverlayPadAlign` (int?): overlay 用、指定値の **倍数に切り上げ** padding

両者とも `output: cmt` env で指定すると env load 時 `InvalidDataException` で reject (= cmt header 込み bin に padding は意味不明)、null / 0 / 負 = padding なし扱い (= Loader 上で null 相当に正規化)。

### Driver.cs 新 step 2 種
- `PadBinToFixedSize()`: main を BinPadSize に固定 padding (`FileStream.SetLength` で拡張、超過なら **silent truncation 防止のため exit 1 + 明示エラー**)
- `PadBinToAlignment()`: overlay を OverlayPadAlign の倍数に切り上げ padding (= empty は no-op、overlay file 欠落は internal error として exit 1)
- 実行位置: overlay rename 後、`cmt_assets` / `cmt_concat` / `--emit disk` の前

### env file
```yaml
# runtime/env/vgs0.env (抜粋)
bin_pad_size: 16384       # main を 16KB 固定 ROM
overlay_pad_align: 8192   # 各 overlay を 8KB bank 単位に揃える
```

### `Makefile.dist`
- vgs0 ENV ブロック (`BIN_EXT/BIN_EXT_ENV = .bin`、`DISK_IMAGE = $(OUTPROG)`)
- `disk_image` 分岐 + help ENV 一覧追加

## テスト

- **新規 unit test 7 件 (`EnvironmentLoaderTests.cs`)**: BinPadSize / OverlayPadAlign の deserialize / null / 0/負正規化 / cmt 排他 reject 各種
- **新規 integration test 2 件 (`BuildIntegrationTests.cs`)**:
  - `Vgs0_PadsMainTo16384_OverlayTo8192Multiple`: 同じ SL を **2 env で build して bytes 比較** (= 標準 `vgs0` = padded、fixture `vgs0_nopad` = raw)。main = 16384 byte / overlay = 8192 倍数 / 先頭 raw 一致 / padding 部分は全 0 を全部 assert (Codex Low 指摘 #2 反映)
  - `BinPadSize_Overflow_ReturnsFriendlyError`: 小さい `bin_pad_size: 8` の fixture env で大きい SL build → exit 1 + 明示エラー
- **既存 231 + 新規 9 = 240/240 全 pass** ✅

## 手動 smoke 結果

- ✅ vgs0 で `#MODULE` 入り SL → `v.bin` 16384 byte (53 → padded 16384) + `v._m0.bin` 8192 byte (1 → padded 8192)
- ✅ lsx regression なし (43 byte の `.bin` 出力)
- ✅ overflow error (`bin_pad_size: 8` で 53 byte SL → 明示エラー + exit 1)
- ✅ cmt 排他 reject (`output: cmt` + `bin_pad_size` で env load 時エラー)
- ✅ Makefile.dist 経由 ENV=vgs0 で slangbuild 起動成功 (= STARS は lsx 用 SL なので vgs0 では assemble 通らないのは正常)

## scope 外

VGS-Zero の bank switch 制御コード自体は `runtime/libvgs0_base.asm:56` 以降の既存 helper を使う想定 (= 本 PR は ROM padding spec のみ追加)。

## Test plan

- [x] `dotnet test` 240/240 全 pass
- [x] 手動 smoke 5 項目 (上記)
- [x] 実機 / VGS-Zero エミュレータでの 16KB ROM + 8KB overlay 動作確認 (= ユーザー側)

🤖 Generated with [Claude Code](https://claude.com/claude-code)