### PR TITLE
zxn 環境を slangbuild に統合 — Makefile 整理のみ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@
   - **VRTC 割り込みハンドラの GAMEVSYNC を条件化**: `libp88_base.asm` の `INTVRTC` で `CALL GAMEVSYNC` を `#if exists USE_GAMEVSYNC` で囲み、SL 側で `CONST ASM USE_GAMEVSYNC = 1;` を立てた場合のみ呼ぶ形に。`USE_GAMEVSYNC` 未定義の SL は GAMEVSYNC 関数を書かなくても build できる
   - **AILZ80ASM エラー表示**: `--verbose` 無しでも `main assembly failed` の詳細 (= 未定義 label 等) が stderr に出るよう修正 (= AILZ80ASM がエラーを stdout に流す癖を吸収)
 
+- zxn 環境 (ZX Spectrum Next、Z80 ターゲット) を `slangbuild` に対応 — Makefile 整理のみ
+  - `Makefile.dist` に zxn ENV ブロック追加 (`BIN_EXT/BIN_EXT_ENV = .bin`、`SRC_EXT = .sl` で `examples/zxn/*.sl` 小文字対応、`DISK_IMAGE = $(OUTPROG)`) + `disk_image` 分岐 + `help` ENV 一覧
+  - `examples/zxn/Makefile` を slangbuild 経由に書き換え (= 旧 `SLANGCompiler -E zxn --output-debug-symbol` + `AILZ80ASM` の 2 段を `slangbuild -E zxn` 1 段に統一)。`%.bin: %.sl` / `%.nex: %.bin %.cfg` の pattern rule 化 + `clean` target 整理
+  - 既存 `runtime/env/zxn.env` / runtime libs / Driver / EnvironmentConfig / EnvironmentLoader は変更なし (= lsx と同じ raw bin 経路で動く)
+  - `.nex` 形式変換は外部ツール `nexcreator` を引き続き使用 (= ユーザー側でインストール、CSpect 等で実行可能形式に変換)
+
 - vgs0 環境 (VGS-Zero、Z80 ターゲット) を `slangbuild` に対応 — 8KB bank switching に合わせた bin padding
   - 新 env file フィールド `bin_pad_size:` (= main 用、固定 byte サイズの末尾 0 padding) と `overlay_pad_align:` (= overlay 用、指定値の倍数に切り上げ末尾 0 padding) を追加
   - `runtime/env/vgs0.env` に `bin_pad_size: 16384` + `overlay_pad_align: 8192` を設定 (= main を 16KB 固定 ROM、各 overlay を 8KB bank 単位に揃える)

--- a/Makefile.dist
+++ b/Makefile.dist
@@ -149,6 +149,16 @@ else ifeq ($(ENV), vgs0)
   BIN_EXT = .bin
   BIN_EXT_ENV = .bin
   DISK_IMAGE = $(OUTPROG)
+else ifeq ($(ENV), zxn)
+  # ZX Spectrum Next 用 (raw bin 出力)。.nex 形式変換は外部ツール
+  # (nexcreator) でユーザー側で行う。examples/zxn/ サンプルは小文字
+  # `.sl` 拡張子のため SRC_EXT を override する (Linux の case-sensitive
+  # FS 対策)。disk image なし、`disk_image` target は OUTPROG そのもの。
+  EMU = @echo "ZX Spectrum Next emulator not configured. Set EMU variable" \#
+  BIN_EXT = .bin
+  BIN_EXT_ENV = .bin
+  SRC_EXT = .sl
+  DISK_IMAGE = $(OUTPROG)
 else ifeq ($(ENV), msxrom)
   EMU = @echo "Set EMU variable for your emulator" \#
   BIN_EXT_ENV = $(BIN_EXT)
@@ -238,6 +248,10 @@ else ifeq ($(ENV), vgs0)
 # vgs0 は ROM bin 出力 (= disk image なし)。slangbuild が padding 済 bin
 # (16KB 固定 main + 8KB 倍数 overlay) を出すので、disk_image target は
 # OUTPROG (= PROG.bin) を produce すれば十分。
+disk_image: $(OUTPROG)
+else ifeq ($(ENV), zxn)
+# zxn は raw bin 出力 (= disk image なし)。.nex 化は外部 nexcreator で
+# ユーザー側。disk_image target は OUTPROG (= PROG.bin) そのもの。
 disk_image: $(OUTPROG)
 else ifeq ($(ENV), sos)
 # sos / sosx1 は slangbuild --emit disk + HuDisk 経路。template
@@ -348,6 +362,6 @@ help:
 	@echo "  PREFIX=path        - Installation prefix (default: ~/.local on Unix,"
 	@echo '                       %USERPROFILE%\.local\bin on Windows)'
 	@echo "  TARGET=path        - Sample source file (without extension)"
-	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/pc88mk2sr/pc80mk2/pc80mk2x/pc80mk2xsd/vgs0/msx2/msxrom/cpm)"
+	@echo "  ENV=env            - Target environment (lsx/x1/sos/sosx1/pc88mk2sr/pc80mk2/pc80mk2x/pc80mk2xsd/vgs0/zxn/msx2/msxrom/cpm)"
 	@echo ""
 	@echo "Detected OS: $(DETECTED_OS)"

--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Layer 2グラフィックス、タイルマップ、スプライト、パレッ�
 
 サンプルは examples/zxn フォルダにあります。
 
+`slangbuild` (および `Makefile.dist build TARGET=examples/zxn/game ENV=zxn`) で `.bin` を出力できます (= 旧 `SLANGCompiler -E zxn` + `AILZ80ASM` の 2 段経路を内製化)。`.nex` 形式 (= CSpect 等の実行可能形式) への変換は外部ツール `nexcreator` を使い、`examples/zxn/Makefile` で flow が完結します。
+
 # ランタイムについて
 
 SLANG Compilerはランタイムライブラリとして、`runtime/` フォルダ内の `.asm` ファイルを読み込みます。

--- a/docs/SLANG-spec.md
+++ b/docs/SLANG-spec.md
@@ -1201,6 +1201,20 @@ switching を持つハードで、各 overlay を 8KB 単位に揃えること�
 switch loader が読み込み可能になる。SL から bank 切替を呼ぶ helper は
 `runtime/libvgs0_base.asm` に既存。
 
+#### raw bin 出力 env (= zxn)
+
+`zxn` (ZX Spectrum Next) は env file (`runtime/env/zxn.env`) に
+`output:` / `bin_pad_size:` / `cmt_concat:` / `disk:` 等の特殊
+フィールドを **一切持たない** 最小 env で、lsx と同じ raw bin 出力
+経路で動作する。`Makefile.dist` には `ENV=zxn` 用の ENV ブロックが
+あり (`BIN_EXT = .bin`、`SRC_EXT = .sl` で小文字 `.sl` ファイル名に
+対応、`DISK_IMAGE = $(OUTPROG)`)、`make ENV=zxn build TARGET=...` で
+slangbuild 経由 build が可能。
+
+`.nex` 形式 (= CSpect 等で実行可能形式) への変換は外部ツール
+`nexcreator` を使う運用 (= `examples/zxn/Makefile` 参照)。slangbuild は
+raw `.bin` の生成までを責務とし、`.nex` 化は scope 外。
+
 ---
 
 サンプル限定の最小実装で、overlay 命名は `M<N>.BIN` 固定、各 overlay は

--- a/examples/zxn/Makefile
+++ b/examples/zxn/Makefile
@@ -1,34 +1,27 @@
 PROJECT = game
 NEXCREATOR = nexcreator
+SLANGBUILD = slangbuild
+EMU = mono Emu/CSpect/CSpect.exe -w6 -tv -nextrom -zxnext
 
 all: build
-	mono Emu/CSpect/CSpect.exe -w6 -tv -nextrom  -zxnext game.nex
+	$(EMU) game.nex
 
 build: game.nex
 
 nomusic: game_nomusic.nex
-	mono Emu/CSpect/CSpect.exe -w6 -tv -nextrom  -zxnext game_nomusic.nex
+	$(EMU) game_nomusic.nex
 
 build_nomusic: game_nomusic.nex
 
+# slangbuild が SLANG → ASM → bin を 1 段で実行 (旧 SLANGCompiler +
+# AILZ80ASM 2 段経路を内製化)。デバッグ用 .sym / .ASM を残したい場合は
+# --keep-asm を追加。
+%.bin: %.sl
+	$(SLANGBUILD) -E zxn $< -o $*
+
+# nexcreator で .bin → .nex (CSpect 等で実行可能形式)。.cfg 変更時にも再生成。
+%.nex: %.bin %.cfg
+	$(NEXCREATOR) $*.cfg $@
+
 clean:
-	rm -f ${PROJECT}.bin
-	rm -f $(PROJECT).asm
-	rm -f game.nex
-	rm -f game_nomusic.bin
-	rm -f game_nomusic.asm
-	rm -f game_nomusic.nex
-
-game.nex: ${PROJECT}.bin
-	${NEXCREATOR} game.cfg game.nex
-
-game.bin: $(PROJECT).sl
-	SLANGCompiler -E zxn --output-debug-symbol $(PROJECT).sl
-	AILZ80ASM $(PROJECT).asm -bin -f
-
-game_nomusic.nex: game_nomusic.bin
-	${NEXCREATOR} game_nomusic.cfg game_nomusic.nex
-
-game_nomusic.bin: game_nomusic.sl
-	SLANGCompiler -E zxn --output-debug-symbol game_nomusic.sl
-	AILZ80ASM game_nomusic.asm -bin -f
+	rm -f *.bin *.nex *.ASM *.LST *.sym


### PR DESCRIPTION
## Summary

ZX Spectrum Next (`zxn`) 環境を slangbuild 統合します。`runtime/env/zxn.env` に `output:` / `bin_pad_size:` / `cmt_concat:` / `disk:` 等の特殊フィールドは **一切なし** (= 既存の lsx と同じ raw bin 経路で動く) なので、**新規コード変更ゼロ**で `Makefile.dist` と `examples/zxn/Makefile` の整備だけで完結します。

## 主要変更

### `Makefile.dist`
- zxn ENV ブロック追加 (`BIN_EXT/BIN_EXT_ENV = .bin`、**`SRC_EXT = .sl`** で `examples/zxn/*.sl` 小文字対応 = Linux case-sensitive FS 対策、`DISK_IMAGE = $(OUTPROG)`)
- `disk_image` 分岐に zxn 明示追加 (cpm / msxrom / pc80mk2 系と同 pattern)
- `help` ENV 一覧に `zxn` 追加

### `examples/zxn/Makefile`
- 旧 `SLANGCompiler -E zxn --output-debug-symbol` + `AILZ80ASM` の **2 段経路** → `slangbuild -E zxn input.sl -o output_prefix` の **1 段** に統一
- `--output-debug-symbol` 削除 (= 現代 slangc に同 option なし、debug 用 sym は `-sym -sm minimal-equ` 経由で生成、残したい場合は `--keep-asm` の運用に移行)
- `%.bin: %.sl` + `%.nex: %.bin %.cfg` の **pattern rule 化** (= cfg 変更時にも `.nex` 再生成、Codex Low 指摘 #3)
- `clean` target を一行に整理
- `EMU` 変数化 (= CSpect 起動行を共通化)

### CHANGELOG / docs / README
確定事項のみで更新。`.nex` 変換は外部ツール `nexcreator` を引き続き使用 (= 責務外)。

## Codex review 反映

- **Medium #1 (smoke 出力先)**: AILZ80ASM の `include` 解決が ASM 出力先 dir 基準のため、smoke 例を `-o examples/zxn/PROG_SMOKE` (= sample asset dir 配下) に揃えた
- **Medium #2 (拡張子 case)**: `examples/zxn/*.sl` は小文字、`Makefile.dist` zxn ENV ブロックで `SRC_EXT = .sl` override (user 判断 A、ファイル rename しない)
- **Low #3 (clean / cfg 依存)**: clean target 復活 + `%.nex: %.bin %.cfg` 依存追加
- **`--output-debug-symbol` 削除**: OK 確認済 (= 現代 slangc に同 option なし、debug 用は `--keep-asm` 運用)

## テスト

- `dotnet test` 既存 **240/240 pass を維持** (= コード変更ゼロなので regression なし)
- 新規 unit / integration test なし (= zxn 特有挙動なし、既存 lsx 系 test で raw bin 経路カバー済)

## 手動 smoke 結果

- ✅ slangbuild 直呼び: `examples/zxn/PROG_SMOKE.bin` 6994 byte 出力
- ✅ Makefile.dist 経由 (`ENV=zxn TARGET=examples/zxn/game`): `examples/zxn/PROG.bin` 7378 byte 出力
- ✅ lsx regression なし (`examples/PROG.bin` 1288 byte = STARS 用、不変)

## scope 外

- `runtime/env/zxn.env` / runtime libs / `EnvironmentConfig` / `EnvironmentLoader` / `Driver` 変更なし
- `nexcreator` を slangbuild 内製化 (= 外部ツール責務、本 PR 外)
- `examples/zxn/*.sl` のファイル名 rename (= user 判断 A、現状維持)
- AILZ80ASM の `include` 解決を SL ソース dir 基準にする option (= 現状 ASM 出力先 dir 基準、smoke 例で対処)

## Test plan

- [x] `dotnet test` 240/240 全 pass 維持
- [x] 手動 smoke 3 項目 (上記)
- [x] 実機 / CSpect エミュレータでの `.nex` 動作確認 (= ユーザー側、`nexcreator` 経路)
- [x] Linux 環境での `make ENV=zxn` 動作確認 (= `SRC_EXT = .sl` override が効くこと、user 環境)

🤖 Generated with [Claude Code](https://claude.com/claude-code)