### PR TITLE
fix(semantic+ir): BYTE 配列引数の型情報伝播 + 関数スコープ重複名検出

### DIFF
--- a/src/SLANGCompiler.Core/IR/IrGenerator.cs
+++ b/src/SLANGCompiler.Core/IR/IrGenerator.cs
@@ -770,15 +770,15 @@ public class IrGenerator : IAstVisitor<IrOperand>
         _localOffset = 0;
 
         // 仮引数を仮登録（オフセットはLocalDeclarations走査後に確定）
-        // 各引数のバイトサイズを ParamDecl.Size から取得 (FLOAT=3, BYTE/WORD=2)
+        // 各引数のバイトサイズを ParamDecl.Size から取得 (FLOAT=3, BYTE/WORD=2、配列引数は常に 2 byte ポインタ)
         var paramNames = new List<string>();
         var paramSizes = new List<int>();
         foreach (var p in node.Parameters)
         {
-            int sz = p.Size == DataSize.Float ? 3 : 2;
-            _localVars[p.Name] = new LocalVarInfo(0, sz); // 仮オフセット、正しいサイズ
+            var info = MakeParamLocalVarInfo(p, 0); // 仮オフセット
+            _localVars[p.Name] = info;
             paramNames.Add(p.Name);
-            paramSizes.Add(sz);
+            paramSizes.Add(info.ByteSize);
         }
 
         Emit(IrOp.FuncBegin, IrOperand.Sym(LabelUtils.SanitizeLabel(node.Name)));
@@ -798,9 +798,9 @@ public class IrGenerator : IAstVisitor<IrOperand>
             int paramTotalBytes = paramSizes.Sum();
             int totalFrameSize = _localOffset + paramTotalBytes;
             int argOff = 0x70 - totalFrameSize;
-            for (int i = 0; i < paramNames.Count; i++)
+            for (int i = 0; i < node.Parameters.Count; i++)
             {
-                _localVars[paramNames[i]] = new LocalVarInfo(argOff, paramSizes[i]);
+                _localVars[paramNames[i]] = MakeParamLocalVarInfo(node.Parameters[i], argOff);
                 argOff += paramSizes[i];
             }
             // localOffsetに引数分も加算（ADD IY,BCのフレームサイズ）
@@ -833,6 +833,29 @@ public class IrGenerator : IAstVisitor<IrOperand>
     }
 
     /// <summary>ローカル変数のオフセットを割り当て</summary>
+    /// <summary>
+    /// 仮引数 (ParamDecl) を関数スコープの LocalVarInfo に変換する。
+    /// 配列引数 (BYTE T[] など) は常に 2 byte ポインタとしてスタックに積まれるが、
+    /// 添字アクセス時に必要な要素サイズ (BYTE=1 / WORD=2 / FLOAT=3) と byte 配列フラグも反映する。
+    /// </summary>
+    private static LocalVarInfo MakeParamLocalVarInfo(ParamDecl p, int offset)
+    {
+        if (p.IsArray)
+        {
+            int elemSize = p.Size switch
+            {
+                DataSize.Byte => 1,
+                DataSize.Float => 3,
+                _ => 2,
+            };
+            bool isByte = p.Size == DataSize.Byte;
+            return new LocalVarInfo(offset, 2, Kind: VarKind.Pointer, IsByte: isByte, ElemSize: elemSize);
+        }
+        // 非配列: BYTE/WORD はスタックに 2 byte で積む (BYTE は upper byte 不定)、FLOAT は 3 byte
+        int sz = p.Size == DataSize.Float ? 3 : 2;
+        return new LocalVarInfo(offset, sz);
+    }
+
     private int AllocLocalVar(string name, int byteSize)
     {
         // BYTE/WORDとも2バイト確保（仕様準拠）

--- a/src/SLANGCompiler.Core/Semantics/SemanticAnalyzer.cs
+++ b/src/SLANGCompiler.Core/Semantics/SemanticAnalyzer.cs
@@ -25,9 +25,12 @@ public class SemanticAnalyzer : IAstVisitor<object?>
 
     public SymbolTable Symbols => _symbols;
 
+    private readonly bool _caseSensitive;
+
     public SemanticAnalyzer(DiagnosticBag diagnostics, bool caseSensitive = false)
     {
         _diagnostics = diagnostics;
+        _caseSensitive = caseSensitive;
         _symbols = new SymbolTable(caseSensitive);
         _constEval = new ConstEvaluator(_symbols);
         RegisterBuiltins();
@@ -308,7 +311,7 @@ public class SemanticAnalyzer : IAstVisitor<object?>
     public object? VisitFuncDef(FuncDef node)
     {
         // 関数自体をグローバルに登録 (overlay 配下でも main と共有する global scope へ)
-        var paramTypes = node.Parameters.Select(p => DataSizeToType(p.Size)).ToList();
+        var paramTypes = node.Parameters.Select(MakeParamType).ToList();
         var returnType = DataSizeToType(node.ReturnSize);
         var funcType = new FunctionType(returnType, paramTypes);
         var funcSym = _currentOverlayIndex.HasValue
@@ -322,12 +325,26 @@ public class SemanticAnalyzer : IAstVisitor<object?>
         var prevFunc = _currentFunc;
         _currentFunc = new FuncInfo(node.Name);
 
+        // 関数スコープ内で定義された名前を追跡し、重複をエラー化する。
+        // SymbolTable.Scope.Define は後勝ち上書きで silent overwrite するため、
+        // ここで明示的に重複を検出しないと param と static/local 宣言が同名になっても
+        // 警告すら出ず IR と semantic で解決順が逆転する危険な状態になる。
+        var nameComparer = _caseSensitive ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+        var defined = new HashSet<string>(nameComparer);
+
         // 仮引数を動的変数として登録
         // 仕様: 引数は(IY+$70)から順に配置
         int argOffset = 0x70;
         foreach (var param in node.Parameters)
         {
-            var pType = DataSizeToType(param.Size);
+            if (!defined.Add(param.Name))
+            {
+                _diagnostics.Error(
+                    $"duplicate parameter name '{param.Name}' in function '{node.Name}'",
+                    param.Span);
+                continue;
+            }
+            var pType = MakeParamType(param);
             var pSym = _symbols.Define(param.Name, SymbolKind.Parameter, pType);
             pSym.IsGlobal = false;
             pSym.Offset = argOffset;
@@ -338,12 +355,18 @@ public class SemanticAnalyzer : IAstVisitor<object?>
         _currentFuncName = node.Name;
         _inStaticDecl = true;
         foreach (var decl in node.StaticDeclarations)
+        {
+            CheckDuplicateDeclName(decl, defined, node.Name, "static declaration");
             decl.Accept(this);
+        }
         _inStaticDecl = false;
 
         // 局所宣言（IYフレームに配置）
         foreach (var decl in node.LocalDeclarations)
+        {
+            CheckDuplicateDeclName(decl, defined, node.Name, "local declaration");
             decl.Accept(this);
+        }
 
         // 本体
         node.Body.Accept(this);
@@ -517,6 +540,40 @@ public class SemanticAnalyzer : IAstVisitor<object?>
         DataSize.Float => SlangType.Float,
         _ => SlangType.Word,
     };
+
+    /// <summary>
+    /// 仮引数 (ParamDecl) を semantic 型に変換する。
+    /// 配列引数 (BYTE T[] など) は PointerType wrap、それ以外は基本型そのまま。
+    /// IR 側 MakeParamLocalVarInfo と対応する形で IsArray を扱う。
+    /// </summary>
+    private static SlangType MakeParamType(ParamDecl p)
+    {
+        var baseType = DataSizeToType(p.Size);
+        return p.IsArray ? new PointerType(baseType) : baseType;
+    }
+
+    /// <summary>
+    /// 関数スコープ内の宣言ノード (VarDecl / ArrayDecl / ConstDecl) の名前が
+    /// 既存定義と衝突したらエラーを出す。AST ノードによって名前フィールドが
+    /// 異なるので局所的に解決する。defined set にも未定義の名前を追加する。
+    /// </summary>
+    private void CheckDuplicateDeclName(AstNode decl, HashSet<string> defined, string funcName, string kind)
+    {
+        string? name = decl switch
+        {
+            VarDecl v => v.Name,
+            ArrayDecl a => a.Name,
+            ConstDecl c => c.Name,
+            _ => null,
+        };
+        if (name == null) return;
+        if (!defined.Add(name))
+        {
+            _diagnostics.Error(
+                $"duplicate name '{name}' in function '{funcName}' ({kind} conflicts with parameter or earlier declaration)",
+                decl.Span);
+        }
+    }
 }
 
 /// <summary>

--- a/tests/SLANGCompiler.Tests/CodeGenTests.cs
+++ b/tests/SLANGCompiler.Tests/CodeGenTests.cs
@@ -560,4 +560,73 @@ public class CodeGenTests
         // BYTE store回数（LD (HL),E without INC HL; LD (HL),D）
         Assert.DoesNotContain("INC\tHL\n\tLD\t(HL),D", body);
     }
+
+    [Fact]
+    public void ByteArrayParam_ByteStep_ByteLoad()
+    {
+        // 引数 `BYTE T[]` (BYTE 配列ポインタ) へのインデックスアクセスが
+        // BYTE step / BYTE load コードを生成することを確認 (= 旧バグ:
+        // ParamDecl.IsArray + Size が IR の LocalVarInfo に伝わらず WORD 扱い
+        // → 2 byte step / 2 byte load の wrong code 生成、を防止)。
+        var asm = Compile("F(BYTE T[]) VAR BYTE B[2]; { B[0] = T[0]; B[1] = T[1]; } MAIN() BEGIN F($1000); END;");
+        var body = asm.Split("F:")[1].Split("_F_EXIT")[0];
+        // BYTE load: LD L,(HL); LD H,$00 (1 byte 読込 + 上位 0 fill)
+        Assert.Contains("LD\tL,(HL)", body);
+        Assert.Contains("LD\tH,$00", body);
+        // BYTE step: T[1] には INC HL (= +1 byte)。
+        Assert.Contains("INC\tHL", body);
+        // WORD load (= 2 byte 読込) が出ていないこと
+        Assert.DoesNotContain("LD\tE,(HL)\n\tINC\tHL\n\tLD\tD,(HL)", body);
+    }
+
+    private (string asm, DiagnosticBag diag) TryCompile(string source)
+    {
+        var diag = new DiagnosticBag();
+        var lexer = new Lexer.Lexer(source);
+        var tokens = lexer.Tokenize();
+        var preprocessor = new Preprocessor(diag);
+        tokens = preprocessor.Process(tokens, ".");
+        var parser = new Parser.Parser(tokens, diag);
+        var ast = parser.ParseCompilationUnit();
+        var analyzer = new SemanticAnalyzer(diag);
+        analyzer.Analyze(ast);
+        return ("", diag);
+    }
+
+    [Fact]
+    public void DuplicateName_ParamVsStaticDecl_Errors()
+    {
+        // F(T) VAR BYTE T[]; ... — param T と static decl T が衝突
+        // 旧挙動: silent overwrite で IR と semantic で解決順が逆転する危険
+        var (_, diag) = TryCompile("F(T) VAR BYTE T[]; { T[0] = 0; } MAIN() BEGIN F($1000); END;");
+        Assert.True(diag.HasErrors);
+        Assert.Contains(diag.Diagnostics, d => d.Message.Contains("duplicate name 'T'"));
+    }
+
+    [Fact]
+    public void DuplicateName_ParamVsParam_Errors()
+    {
+        // F(T, T) — 同名パラメータの重複
+        var (_, diag) = TryCompile("F(T, T) { } MAIN() BEGIN F(1, 2); END;");
+        Assert.True(diag.HasErrors);
+        Assert.Contains(diag.Diagnostics, d => d.Message.Contains("duplicate parameter name 'T'"));
+    }
+
+    [Fact]
+    public void DuplicateName_CaseInsensitive_Errors()
+    {
+        // F(T, t) — case-insensitive モード default で同名扱い
+        var (_, diag) = TryCompile("F(T, t) { } MAIN() BEGIN F(1, 2); END;");
+        Assert.True(diag.HasErrors);
+        Assert.Contains(diag.Diagnostics, d => d.Message.Contains("duplicate parameter name"));
+    }
+
+    [Fact]
+    public void DuplicateName_StaticVsLocal_Errors()
+    {
+        // F() VAR X; { VAR X; ... } — static と local の衝突
+        var (_, diag) = TryCompile("F() VAR X; BEGIN VAR X; X=1; END; MAIN() BEGIN F(); END;");
+        Assert.True(diag.HasErrors);
+        Assert.Contains(diag.Diagnostics, d => d.Message.Contains("duplicate name 'X'"));
+    }
 }


### PR DESCRIPTION
## Summary

`F(BYTE T[]) ... T[i]` のような BYTE 配列引数が WORD として扱われて誤コードを生成していた件と、関数引数とローカル/静的宣言が同名でも警告無しに silent overwrite され、IR と semantic で同一識別子の解決先が逆転していた件をまとめて修正。

## Bug 1: BYTE 配列引数の型情報が IR / semantic に伝わらない

`ParamDecl` には `IsArray` (true/false) と `Size` (BYTE/WORD/FLOAT) が parser で正しく取れているが、それを使う側で無視されていた:

- `IrGenerator.VisitFuncDef` の param 仮登録 (L779) と offset 確定 (L803) で `LocalVarInfo(0, sz)` のように `Kind` / `IsByte` / `ElemSize` が default のまま登録 → 添字アクセス時に `Kind=Scalar / ElemSize=2 (= WORD)` 判定で WORD 路線のコード生成
- `SemanticAnalyzer.VisitFuncDef` の `paramTypes` (L311) と param symbol 登録 (L330) も `DataSizeToType(p.Size)` のみで `IsArray` を無視 → 関数 signature と仮引数 symbol の型情報も WORD/BYTE/FLOAT スカラ扱い

### 症状

```c
F(BYTE T[]) VAR BYTE B[4]; { B[0] = T[0]; B[1] = T[1]; ... }
```

旧コード生成 (= バグ):
```asm
LD HL,$0000; ADD HL,DE; LD E,(HL); INC HL; LD D,(HL)  ; ← 2 byte 読み (WORD)
LD HL,$0002; ...                                       ; ← +2 byte step (WORD)
```

修正後 (= TEST1 = ローカル宣言版と同一):
```asm
LD L,(HL); LD H,$00       ; ← 1 byte 読み + 上位 0 fill (BYTE)
INC HL; LD L,(HL); ...    ; ← +1 byte step (BYTE)
```

### Fix

- IR 側に `MakeParamLocalVarInfo(ParamDecl, offset)` helper を追加し、`IsArray` 時は `Kind=Pointer + IsByte + ElemSize` を反映 (BYTE→1 / WORD→2 / FLOAT→3)。**仮登録と offset 確定の両方で同じ helper を経由** するようにし、片側だけ直すような事故を防止
- semantic 側に `MakeParamType(ParamDecl)` helper を追加し、`IsArray` 時は `PointerType(DataSizeToType(p.Size))` を返す。L311 / L330 の両方で使用

## Bug 2: 関数スコープ重複名が silent drop / IR と semantic で解決順が逆転

```c
TEST3(T)
VAR BYTE T[];   ← param T と static decl T が衝突。警告無し。
{ B[0] = T[0]; ... }
```

- IR 側 (`_localVars[name] = ...`) は last-write-wins で param 仮登録 → static decl の登録 (= correct Pointer/IsByte 情報) → param offset 確定の上書きで static decl 情報が消され、結果的に param 路線で解決
- semantic 側 (`Scope.Define()`) も last-write-wins だが順序が逆 (param → static 上書きで static T が param T を潰す)
- → **IR と semantic で同一識別子の解決先が逆転する dangerous な状態** だった

### Fix

- `SemanticAnalyzer.VisitFuncDef` で関数スコープに入った直後から `defined` HashSet (case-insensitive default、`_caseSensitive` 尊重) で名前を tracking
- 4 ケースを `_diagnostics.Error` でエラー化:
  - param 同士の重複 (`F(T, T)`)
  - param vs static decl (TEST3 相当)
  - param vs local decl
  - static vs local decl
- `CheckDuplicateDeclName(decl, defined, funcName, kind)` helper で VarDecl / ArrayDecl / ConstDecl から名前抽出 + 重複判定を集約
- `Scope.Define()` 自体の semantics は変えず (= 影響範囲が広すぎ、後勝ち上書き前提のコードがあるかもしれないため)、VisitFuncDef 内に閉じた最低限の介入

## Codex review 反映

事前 review で指摘された 4 点をすべて反映:
- ✓ Bug 1 修正は IR だけでなく semantic 側も `param.IsArray` 反映 (PointerType wrap)
- ✓ Bug 2 重複検出は IR ではなく SemanticAnalyzer 側で先に行う
- ✓ ParamDecl → LocalVarInfo / semantic type の helper を作って 2 箇所で同じ logic を使う
- ✓ `Scope.Define()` 全体の semantics は触らず、VisitFuncDef に閉じた検出

## Tests

`tests/SLANGCompiler.Tests/CodeGenTests.cs` に 5 件追加:

- `ByteArrayParam_ByteStep_ByteLoad`: `F(BYTE T[]) { B[0]=T[0]; B[1]=T[1]; }` が `LD L,(HL); LD H,$00 + INC HL` の BYTE 経路コードを出すこと、WORD load (`LD E,(HL); INC HL; LD D,(HL)`) を出さないこと
- `DuplicateName_ParamVsStaticDecl_Errors`: TEST3 相当
- `DuplicateName_ParamVsParam_Errors`: `F(T, T)` 相当
- `DuplicateName_CaseInsensitive_Errors`: `F(T, t)` 相当 (default の case-insensitive モードで重複扱い)
- `DuplicateName_StaticVsLocal_Errors`: `F() VAR X; { VAR X; }` 相当

## Test plan

- [x] `dotnet test` 245/245 pass (= 既存 240 + 新規 5、regression なし)
- [x] `examples/INDTEST.SL` 相当で TEST2 が 1-byte step + byte load コード生成、TEST3 が duplicate name エラーで reject される手動確認

## 影響範囲

- 修正対象: `src/SLANGCompiler.Core/IR/IrGenerator.cs`、`src/SLANGCompiler.Core/Semantics/SemanticAnalyzer.cs`、`tests/SLANGCompiler.Tests/CodeGenTests.cs`
- 既存 SLANG コードへの影響: BYTE 配列引数を使ってる既存 SL は WORD アクセスに依存していた wrong code が消えて意図通りに動くようになる (= behavior change だが正しい方向)。重複名を意図的に書いていた既存 SL があれば build エラーになる (= 修正対象、silent drop で動いていた挙動は本来未定義)

🤖 Generated with [Claude Code](https://claude.com/claude-code)