### PR TITLE
README / setupenv.sh に Linux/WSL の mono CP932 対応注意を追加

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@
   - mzd88 path は `--mzd88` 明示せず `ResolveMzd88` の auto fallback に任せる (= 配布物では `tools/mzd88(.exe)`、dev 環境では `tools/mzd88-{rid}(.exe)` を発見、他 tool との非対称な唯一の例外)
   - help target の ENV 一覧に sosmz2500 / mz25iocs 追加
 
+- README / setupenv.sh に Linux/WSL 環境での mono CP932 対応 (`libmono-i18n4.0-all`) 注意書きを追加 (= HuDisk 経路の sos / sosx1 / sosmz2500 で `Encoding 932 data could not be found` を踏むため、Debian/Ubuntu では `sudo apt install libmono-i18n4.0-all` で別途インストール必要、macOS Homebrew mono にはデフォルトで含まれるため不要)
+
 ## Version 0.23.0
 
 

--- a/README.md
+++ b/README.md
@@ -315,9 +315,10 @@ default では Linux/macOS は `~/.local/bin` (binary) + `~/.config/SLANG/` (lib
   - これらを使わない通常のコンパイル / 単一バイナリ実行には不要
 - **mono** (Linux / macOS で .NET assembly な disk ツール `HuDisk.exe` / `udostool.exe` を起動する場合に必須)
   - `setupenv.sh` が S-OS template 生成のため `HuDisk.exe` を mono 経由で実行する。Windows は .NET Framework で直接実行されるため不要
-  - **sos / sosx1** 環境で `slangbuild --emit disk` を使う場合 (= HuDisk.exe 起動)
+  - **sos / sosx1 / sosmz2500** 環境で `slangbuild --emit disk` を使う場合 (= HuDisk.exe 起動)
   - **pc88mk2sr** 環境で `slangbuild --emit disk` を使う場合 (= udostool.exe 起動、Bookworm's Library 由来の汎用ディスクルーチン用ツール)
   - lsx / x1 の ndc 経路だけ使うなら mono 不要
+  - **Linux / WSL**: デフォルトの mono は日本語 (CP932) コードページを含まないため、HuDisk が `Encoding 932 data could not be found` で失敗します。Debian/Ubuntu では `sudo apt install libmono-i18n4.0-all` で別途インストールしてください。macOS の Homebrew mono にはデフォルトで含まれているため不要
 
 ### ビルドとインストール
 

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -55,6 +55,13 @@ if [ $? -ne 0 ]; then
   CmdError
 fi
 
+# Linux/WSL では mono デフォルト install に CP932 (日本語) コードページが
+# 含まれていない場合がある。HuDisk が CP932 を要求するため、
+# `Encoding 932 data could not be found` で失敗するなら、
+#   sudo apt install libmono-i18n4.0-all   (Debian/Ubuntu)
+# を実行してから setupenv.sh を再実行してください。
+# macOS の Homebrew mono にはデフォルトで含まれているため不要。
+
 TOOLPATH=$(cd $(dirname $0);pwd)/tools/
 mkdir images
 mkdir -p images/templates


### PR DESCRIPTION
## Summary

PR #173 の動作確認で issaUt 氏が Ubuntu/WSL 環境で `Encoding 932 data could not be found` エラーを踏み、`libmono-i18n4.0-all` の追加 install で解決した報告を受け、同じ問題への注意書きを公式 docs に追加。

これは HuDisk 経路の env (sos / sosx1 / sosmz2500) すべてに影響する一般的な問題で、Linux の Mono デフォルト install には日本語 (CP932) コードページが含まれていないため発生する。`mzd88` 経路 (mz25iocs) には影響なし。

## 変更点

- **README.md**: mono 前提条件セクションに sosmz2500 を追記 + Linux/WSL では `libmono-i18n4.0-all` が必要な旨と Debian/Ubuntu install コマンドを記載
- **setupenv.sh**: `which mono` 直後にコメントで CP932 不足時の対応手順を案内
- **CHANGELOG.md**: Version 0.24.0 末尾に 1 項目追加

## Test plan

- [x] README / setupenv.sh の文面確認 (= 観測事実 + workaround コマンドの明示)
- [x] **未確認**: Ubuntu/WSL 実機での `libmono-i18n4.0-all` install 後の動作確認 (= ローカル環境なし、PR #173 で issaUt 氏報告済)

## Notes

- macOS の Homebrew mono にはデフォルトで CP932 含むため影響なし
- 関連 PR: #172 (MZ-2500 環境追加) / #173 (配布経路整備)

🤖 Generated with [Claude Code](https://claude.com/claude-code)