### PR TITLE
release: v0.24.1 (MZ-2500 MAGIC + IOCS 入力ランタイム拡充)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # 更新履歴
 
+## Version 0.24.1
+
+- MZ-2500 環境の MAGIC ライブラリ対応と IOCS 入力ランタイム拡充 (#175)
+  - `sosmz2500` 環境に MZ-2500 用 MAGIC ライブラリ (`runtime/libmz2500_magic.asm`) をリンクするよう追加。これにより S-OS / MZ-2500 上で MAGIC を使う SLANG コードがビルド可能 (`examples/MAGICSMPL.SL` がそのまま動作)
+  - `mz25iocs` 環境の入力ランタイム (`runtime/libmz25iocs_input.asm`) に `GETL` / `GETLIN` / `LINPUT` / `INPUT` を実装。IOCS `SVC_GETL` (call 0Ch) をベースに、`GETL` / `GETLIN` はカラム 0 から、`LINPUT` / `INPUT` は IOCS ワーク `$05E2` の現在カーソル X を読み飛ばして S-OS 版と同じ "プロンプト除去" 挙動に揃えた
+  - `INPUT` は `$` プレフィックスで 16 進数を、それ以外で 10 進数をパース。ESC / SHIFT+BREAK で `_CARRY=1` をセットして 0 を返す
+  - `mz25iocs` 環境に `LOCATE(x, y)` を実装 (`libmz25iocs_print.asm`) — IOCS `SVC_CMOV` (call 6Fh) を使用、`L=X` / `H=Y` で呼び出す
+  - 新サンプル: `examples/MZ25IOCS.SL` に `INPUT` / `GETL` / `GETLIN` / `LINPUT` の動作確認コードを追加
+  - `docs/MZ2500.md` に入力ランタイムの挙動 (`SVC_GETL` 仕様、`length` の下位 8bit 制約 / `0` = 256 文字扱い、推奨バッファサイズ、`LOCATE` の引数渡し) を追記
+
 ## Version 0.24.0
 
 - コンパイラ: BYTE 配列引数の型情報伝播 + 関数スコープ重複名検出 (#171)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SLANG-compiler
-SLANG Compiler (Z80) 0.24.0
+SLANG Compiler (Z80) 0.24.1
 
 # 概要
 
@@ -14,7 +14,7 @@ SLANG Compiler (Z80) 0.24.0
 # 使い方
 
 ```
-SLANG Compiler v0.24.0
+SLANG Compiler v0.24.1
 Usage: slangc [options] <input.sl>
 
 Options:

--- a/src/SLANGCompiler.Build/Program.cs
+++ b/src/SLANGCompiler.Build/Program.cs
@@ -13,7 +13,7 @@ namespace SLANGCompiler.Build;
 /// </summary>
 internal class Program
 {
-    private const string Version = "0.24.0";
+    private const string Version = "0.24.1";
 
     public static int Main(string[] args)
     {

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -9,7 +9,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.24.0";
+    const string Version = "0.24.1";
 
     static int Main(string[] args)
     {


### PR DESCRIPTION
## Summary

v0.24.1 リリース準備 PR。Version 表記 (CLI / Build / README) を 0.24.0 → 0.24.1 に bump、CHANGELOG に同梱変更点を追記。

実装本体は #175 (issaUt 作) を main に取り込み済みで、本 PR は version / CHANGELOG 更新のみ。

## v0.24.1 の主な変更 (CHANGELOG より)

- MZ-2500 環境の MAGIC ライブラリ対応と IOCS 入力ランタイム拡充 (#175)
  - `sosmz2500` 環境に MZ-2500 用 MAGIC ライブラリ (`runtime/libmz2500_magic.asm`) をリンク
  - `mz25iocs` 環境に `GETL` / `GETLIN` / `LINPUT` / `INPUT` を実装 (IOCS `SVC_GETL` ベース、S-OS 版互換のプロンプト除去挙動)
  - `mz25iocs` 環境に `LOCATE(x, y)` を実装 (IOCS `SVC_CMOV` 経由)
  - 新サンプル `examples/MZ25IOCS.SL` で入力系の動作確認コード追加
  - `docs/MZ2500.md` に入力ランタイムの挙動 / バッファサイズ推奨 / `LOCATE` 引数規約を追記

## Test plan

- [x] `make ENV=mz25iocs TARGET=examples/MZ25IOCS asm` 通過 (warning 0)
- [x] `make ENV=sosmz2500 TARGET=examples/FMANDEL asm` 通過 (warning 0)
- [x] `make ENV=sosmz2500 TARGET=examples/MAGICSMPL asm` 通過 (warning 0, MAGIC リンクで bin 14739 byte)
- [x] `./publish.sh 0.24.1` で 4 OS zip (linux-x64 / osx-x64 / osx-arm64 / win-x64) 生成済

🤖 Generated with [Claude Code](https://claude.com/claude-code)