### PR TITLE
Add C64 SID register direct + single SFX binding (v3b-A, #180 配下)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,8 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 - `runtime/env/c64.env` `c_bindings:` に 9 entry 追加、`c_runtime_files:` に
   `slang_sid.c` 追加
 - `runtime/c64/slang_runtime.h` に `#include "slang_sid.h"` chain
-- 新規 `tests/SLANGCompiler.Tests/SidBindingTests.cs`: 8 関数の extern
-  signature と呼出展開、実 `runtime/env/c64.env` 全 8 binding 列挙の golden
+- 新規 `tests/SLANGCompiler.Tests/SidBindingTests.cs`: 9 関数の extern
+  signature と呼出展開、実 `runtime/env/c64.env` 全 9 binding 列挙の golden
 - 新規 `examples/c64/SIDSFX.SL`: JOYSPR.SL 拡張、joystick 移動 + fire で SFX
   発射 + 1/2/3 キーで preset 切替 (laser/boom/noise) + sprite 色連動
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,54 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 - `examples/c64/FMANDEL.SL` (`examples/FMANDEL.SL` 80 桁版を C64 40 桁画面用に縮めた版、X 軸解像度半減を倍率 2 倍で補償)
 - `examples/c64/JOYSPR.SL` (= v3a) joystick port 2 で sprite 移動 + fire で色変更 (= ロードマップ v3a に対応、`JOY_DIR` bitmask + `JOY_B` 主、`JOY_X/Y` の signed `-1=$FFFF` パターン解説含む)
 - `examples/c64/HISCORE.SL` (= v3c) D64 disk image に `HISCORE,S,W` で save → `HISCORE,S,R` で read → 内容比較する KERNAL file I/O 往復 sample
+- `examples/c64/SIDSFX.SL` (= v3b-A) joystick で sprite 移動 + fire ボタンで voice 0 SFX 発射 + 1/2/3 キーで音色 preset 切替 (= laser/boom/noise の 3 種類)
+
+### v3b-A — SID 基盤 + 単発 SFX binding (#180 配下)
+
+ロードマップ #178 配下の v3b の 3 分割初回 (= SID 基盤 + 単発 SFX) を実装:
+
+- 新規 `runtime/c64/slang_sid.{h,c}`: oscar64 `c64/sid.h` の register direct 8 関数
+  + SFX wrapper 1 関数 (`slang_sid_init_quiet` / `_volume` / `_freq` / `_pwm`
+  / `_adsr` / `_ctrl` / `_gate_on` / `_gate_off` / `_sfx`)。oscar64 `c64/sid.h`
+  は hardware register memory map (= API レベル) のため SLANG MIT runtime に
+  取り込んでも GPL 影響なし。**PULSE 波形は事前に `SID_PWM` で pulse width を
+  設定する必要あり** (= pwm=0 だと duty 0% で無音、$0800 が標準矩形波)
+- 新規 `include/C64_SID.LIB`: voice 番号定数 3 個 + waveform 4 個 + CTRL bit 4 個
+  + ATK/DKY/SUS 各 16 段階 + pulse width preset 4 個 (`SID_PWM_NARROW/QUARTER/SQR/WIDE`)
+  + NOTE_C2..B6 5 オクターブ 60 個 (= PAL clock 基準の事前計算済 SID register
+  値、`SID_FREQ_PAL(NOTE_X(o))` 二段変換結果)
+- `runtime/env/c64.env` `c_bindings:` に 9 entry 追加、`c_runtime_files:` に
+  `slang_sid.c` 追加
+- `runtime/c64/slang_runtime.h` に `#include "slang_sid.h"` chain
+- 新規 `tests/SLANGCompiler.Tests/SidBindingTests.cs`: 8 関数の extern
+  signature と呼出展開、実 `runtime/env/c64.env` 全 8 binding 列挙の golden
+- 新規 `examples/c64/SIDSFX.SL`: JOYSPR.SL 拡張、joystick 移動 + fire で SFX
+  発射 + 1/2/3 キーで preset 切替 (laser/boom/noise) + sprite 色連動
+
+ライセンス整理:
+- oscar64 `c64/sid.h` は hardware register API なので borrow OK (= bridge 関数
+  はすべて SLANG 側オリジナル実装、`slang_*` 命名で明示)
+- oscar64 `audio/sidfx.c` (= GPL-3.0 の priority SFX player) は v3b-A では使わない
+  (= v3b-C で `#include <audio/sidfx.h>` の bridge 経由参照に限定、SLANG MIT
+  runtime に GPL コードを borrow しない方針継続)
+
+v3b-A 設計判断:
+- voice 番号 0..2、volume 0..15、frequency は PAL clock 基準の register 値 (=
+  NOTE_C4 等の事前計算済定数を C64_SID.LIB から取得)
+- ADSR pack は `SID_ATK_* OR SID_DKY_*` (attdec)、`SID_SUS_* OR SID_DKY_*` (susrel)
+  形式で SLANG コード側で組み立て
+- SFX wrapper は「gate on までの helper」と再定義 = release は user 明示
+  `SID_GATE_OFF(voice)` で開始、自動 release scheduling は v3b-C / v4f BGM player
+  の責務に分離
+- NOTE_B7 は 16-bit overflow (= $10249 = 66121) のため C7..AS7 のみ提供、B7 と
+  それ以上のオクターブは user 側で計算
+
+v3b roadmap (= 後続 PR):
+- v3b-B: HVSC .sid 取り込み + BGM 再生 (= slangbuild `--sid` option、`SID_LOAD` /
+  `SID_PLAYER_INIT` / `SID_PLAYER_PLAY` bridge、sample SIDBGM.SL)
+- v3b-C: oscar64 `audio/sidfx` bridge で priority SFX overlay (= `#include
+  <audio/sidfx.h>` 経由参照、SLANG MIT runtime に GPL コードを含めない方針継続、
+  sample SIDOVERLAY.SL)
 
 ### v3c — KERNAL file I/O binding (#181)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,12 +48,14 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 
 ロードマップ #178 配下の v3b の 3 分割初回 (= SID 基盤 + 単発 SFX) を実装:
 
-- 新規 `runtime/c64/slang_sid.{h,c}`: oscar64 `c64/sid.h` の register direct 8 関数
-  + SFX wrapper 1 関数 (`slang_sid_init_quiet` / `_volume` / `_freq` / `_pwm`
-  / `_adsr` / `_ctrl` / `_gate_on` / `_gate_off` / `_sfx`)。oscar64 `c64/sid.h`
-  は hardware register memory map (= API レベル) のため SLANG MIT runtime に
-  取り込んでも GPL 影響なし。**PULSE 波形は事前に `SID_PWM` で pulse width を
-  設定する必要あり** (= pwm=0 だと duty 0% で無音、$0800 が標準矩形波)
+- 新規 `runtime/c64/slang_sid.{h,c}`: 9 関数 (`slang_sid_init_quiet` / `_volume`
+  / `_freq` / `_pwm` / `_adsr` / `_ctrl` / `_gate_on` / `_gate_off` / `_sfx`)。
+  oscar64 `c64/sid.h` の hardware register memory map を public header として
+  `#include` 参照、bridge 実装はすべて SLANG 側オリジナル。oscar64 実装コードは
+  転載しない運用継続。**PULSE 波形は事前に `SID_PWM` で pulse width を設定する
+  必要あり** (= pwm=0 だと duty 0% で無音、$0800 が標準矩形波)。`SID_SFX` は
+  内部で GATE off → GATE on の 2 段書き込みで attack を re-trigger するため、
+  既に GATE が立っている voice に再呼出した場合も連射 SFX として動作する
 - 新規 `include/C64_SID.LIB`: voice 番号定数 3 個 + waveform 4 個 + CTRL bit 4 個
   + ATK/DKY/SUS 各 16 段階 + pulse width preset 4 個 (`SID_PWM_NARROW/QUARTER/SQR/WIDE`)
   + NOTE_C2..B6 5 オクターブ 60 個 (= PAL clock 基準の事前計算済 SID register
@@ -66,12 +68,12 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 - 新規 `examples/c64/SIDSFX.SL`: JOYSPR.SL 拡張、joystick 移動 + fire で SFX
   発射 + 1/2/3 キーで preset 切替 (laser/boom/noise) + sprite 色連動
 
-ライセンス整理:
-- oscar64 `c64/sid.h` は hardware register API なので borrow OK (= bridge 関数
-  はすべて SLANG 側オリジナル実装、`slang_*` 命名で明示)
-- oscar64 `audio/sidfx.c` (= GPL-3.0 の priority SFX player) は v3b-A では使わない
-  (= v3b-C で `#include <audio/sidfx.h>` の bridge 経由参照に限定、SLANG MIT
-  runtime に GPL コードを borrow しない方針継続)
+ライセンス運用方針 (= 既存 c64 backend と同じ規律を継続):
+- 公開 header (`c64/sid.h`) の API 参照に限定、oscar64 の実装コード (audio/sidfx.c
+  等) は SLANG runtime に転載しない
+- bridge 関数はすべて SLANG 側オリジナル実装 (`slang_*` 命名で明示)
+- v3b-C で `audio/sidfx` を扱う際も `#include <audio/sidfx.h>` の bridge 経由
+  参照に限定する方針
 
 v3b-A 設計判断:
 - voice 番号 0..2、volume 0..15、frequency は PAL clock 基準の register 値 (=

--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ slangbuild -E c64 -o examples/FMANDEL examples/FMANDEL.SL
 # → examples/FMANDEL.prg (+ oscar64 副産物 .asm/.map/.int/.lbl)
 ```
 
-**checkout 状態 (= repo root) からのビルド**: `#INCLUDE "C64_JOY.LIB"` 等の SLANG ライブラリを取り込むサンプルは `-I include` の追加が必要 (例: `slangbuild -E c64 -I include examples/c64/JOYSPR.SL -o examples/c64/JOYSPR`)。配布物 install 後 (= SLANG_HOME 設定済) は `-I include` 省略可。
+**checkout 状態 (= repo root) からのビルド**: `#INCLUDE "C64_VIC.LIB"` / `C64_JOY.LIB` / `C64_SID.LIB` / `C64_KIO.LIB` 等の SLANG ライブラリを取り込むサンプルは `-I include` の追加が必要 (例: `slangbuild -E c64 -I include examples/c64/SIDSFX.SL -o examples/c64/SIDSFX`)。配布物 install 後 (= SLANG_HOME 設定済) は `-I include` 省略可。
 
 **`-o` のセマンティクス**: `slangc -o <path>` は完全パス (`.c` 拡張子込み)、`slangbuild -o <prefix>` は prefix (`<prefix>.c` と `<prefix>.prg` を生成) という Z80 経路と同じ慣行です。
 
@@ -236,13 +236,13 @@ VIC 色定数 (`VCOL_BLACK..VCOL_LT_GREY`、16 色) は `#INCLUDE "C64_VIC.LIB"`
 サンプル: `examples/c64/SPRITE.SL` (sprite 1 個を VSYNC 同期で画面端バウンス) + `examples/c64/FMANDEL.SL` (40 桁テキストマンデルブロ、`examples/FMANDEL.SL` の 80 桁版を C64 画面用に縮めた版):
 
 ```sh
-# checkout 状態: -I include 必須 (= C64_VIC.LIB / C64_JOY.LIB / C64_KIO.LIB 取り込み用)
+# checkout 状態: -I include 必須 (= C64_VIC.LIB / C64_JOY.LIB / C64_SID.LIB / C64_KIO.LIB 取り込み用)
 slangbuild -E c64 -I include examples/c64/SPRITE.SL  -o examples/c64/SPRITE
 slangbuild -E c64 -I include examples/c64/FMANDEL.SL -o examples/c64/FMANDEL
 slangbuild -E c64 -I include examples/c64/JOYSPR.SL  -o examples/c64/JOYSPR
 slangbuild -E c64 -I include examples/c64/SIDSFX.SL  -o examples/c64/SIDSFX
 slangbuild -E c64 -I include examples/c64/HISCORE.SL -o examples/c64/HISCORE
-x64sc -autostart examples/c64/SPRITE.prg          # VICE (sprite/FMANDEL/JOYSPR)
+x64sc -autostart examples/c64/SPRITE.prg          # VICE (sprite/FMANDEL/JOYSPR/SIDSFX)
 # HISCORE は KERNAL file I/O で D64 が必要、autostart 不可 (= virtual drive モードで
 # 干渉する)。c1541 で空 D64 + PRG を入れて、x64sc -8 で attach + 手動 LOAD/RUN:
 c1541 -format "hiscore,01" d64 disks/hiscore.d64 -write examples/c64/HISCORE.prg hiscore

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ env file `c64.env` が以下を C backend builtin として公開しているた
 | I/O | `PRINT` 全構文 (`"..."` / `/` / `%(v)` / `!(s)` / `HEX2$(v)` / `HEX4$(v)` / `DECI$(v)` / `FORM$(v,n)` / `MSG$(p)` / `MSX$(p)` / `STR$(c,n)` / `CHR$(n)` / `SPC$(n)` / `CR$(n)` / `TAB$(n)` / `FL$(f)` / `PN$(v)`) |
 | 入力 | `INKEY(mode)` (即時状態取得、押下中=値、離した瞬間=0)、`INPUT()` (1 行入力 → 数値 parse、ESC=`$FFFF`)、`GETL(buf)` / `GETLIN(buf, x)` / `LINPUT(buf, x)` (1 行文字列入力、戻り値=入力文字数、ESC=`$FFFF`)。Z80 backend の `_CARRY` 機構は v1 未対応 |
 | ジョイスティック | `JOY_POLL(port)` (1 frame 1 回呼ぶ) + `JOY_DIR(port)` (5 bit bitmask) + `JOY_X(port)` / `JOY_Y(port)` (signed、-1=`$FFFF`) + `JOY_B(port)` (0/1 fire)。bitmask + port 定数は `#INCLUDE "C64_JOY.LIB"` で取得 (`JOY_UP/DOWN/LEFT/RIGHT/FIRE/PORT1/PORT2`)。色定数は別途 `C64_VIC.LIB` |
+| **SID 音源 (基盤)** | 初期化: `SID_INIT_QUIET()` (= 全 register 0 で停止状態)、master volume: `SID_VOLUME(v)` (0..15)、voice direct (voice = 0..2): `SID_FREQ(voice, f)` / `SID_PWM(voice, pw)` (= PULSE 波形時必須、duty 12-bit) / `SID_ADSR(voice, ad, sr)` / `SID_CTRL(voice, ctrl)` / `SID_GATE_ON(voice)` / `SID_GATE_OFF(voice)`、SFX wrapper: `SID_SFX(voice, freq, ad, sr, waveform)` (= ADSR + waveform 設定 + GATE on を 1 関数化、release は user 側 `SID_GATE_OFF` で開始)。frequency は PAL clock 基準の register 値、`NOTE_C2..NOTE_B6` 60 個と ADSR/waveform/CTRL/pwm preset 定数は `#INCLUDE "C64_SID.LIB"` で取得 (= `SID_PWM_SQR` = $0800 で 50% duty)。**PULSE 波形は事前に `SID_PWM` 設定必須** (= pwm=0 だと duty 0% で無音)。HVSC `.sid` 取り込み + BGM 再生は v3b-B で、priority SFX overlay (oscar64 `audio/sidfx` bridge) は v3b-C で対応予定 |
 | **KERNAL file I/O** | open/close: `KIO_OPEN_NAMED(fnum, dev, ch, name)` / `KIO_OPEN(fnum, dev, ch)` / `KIO_SETNAM(name)` / `KIO_CLOSE(fnum)`、channel: `KIO_CHKIN(fnum)` / `KIO_CHKOUT(fnum)` / `KIO_CLRCHN()`、1 byte: `KIO_CHRIN()` / `KIO_CHROUT(ch)` / `KIO_GETCH(fnum)` / `KIO_PUTCH(fnum, ch)`、buffer: `KIO_READ(fnum, buf, n)` / `KIO_WRITE(fnum, buf, n)`、文字列: `KIO_GETS(fnum, buf, n)` / `KIO_PUTS(fnum, str)`、status: `KIO_STATUS()` (= krnioerr 取得)。文字列は NUL terminated PETSCII で **全小文字** で書く (= SLANG リテラル `"score,s,r"` が oscar64 `-psci` 経由で PETSCII unshifted 大文字に変換され 1541 の `,S,R` token parse と整合)。SEQ ファイルの主部は起動 PRG と別名にする (= 1541 emu の同主部 PRG/SEQ 共存制約回避)。bool 系は 0/1、I/O 系はエラー時 SLANG WORD で `$FFFx` (sign extension で届く)。krnioerr / device / channel 定数は `#INCLUDE "C64_KIO.LIB"` で取得。raw address 用 (`KIO_*_ADDR`) も併設 |
 | 端末 | `WIDTH(w)` (no-op = C64 は 40 桁固定)、`LOCATE(x, y)`、`SCREEN(x, y)`、`PRMODE(m)` |
 | 数学 | `ABS / SQR / SIN / COS / TAN / LOG / EXP / ATN / RND / SRND` |
@@ -239,6 +240,7 @@ VIC 色定数 (`VCOL_BLACK..VCOL_LT_GREY`、16 色) は `#INCLUDE "C64_VIC.LIB"`
 slangbuild -E c64 -I include examples/c64/SPRITE.SL  -o examples/c64/SPRITE
 slangbuild -E c64 -I include examples/c64/FMANDEL.SL -o examples/c64/FMANDEL
 slangbuild -E c64 -I include examples/c64/JOYSPR.SL  -o examples/c64/JOYSPR
+slangbuild -E c64 -I include examples/c64/SIDSFX.SL  -o examples/c64/SIDSFX
 slangbuild -E c64 -I include examples/c64/HISCORE.SL -o examples/c64/HISCORE
 x64sc -autostart examples/c64/SPRITE.prg          # VICE (sprite/FMANDEL/JOYSPR)
 # HISCORE は KERNAL file I/O で D64 が必要、autostart 不可 (= virtual drive モードで
@@ -299,9 +301,9 @@ slangbuild -E c64 myapp.SL --c-source mylib.c -o myapp
 
 ### v1 スコープと制約
 
-**動作確認済**: PRINT / INPUT / 整数算術 / FLOAT 演算 / リアルタイム key 入力 / sprite (1 個アニメ、VSYNC 同期) / joystick 入力 / KERNAL file I/O (save/load 往復) + ユーザー C 任意関数 (= CFUNC + `--c-source`)。`examples/FMANDEL.SL` / `examples/FURUI.SL` / `examples/STARS.SL` / `examples/c64/SPRITE.SL` / `examples/c64/FMANDEL.SL` (= 40 桁版) / `examples/c64/JOYSPR.SL` (= joystick) / `examples/c64/HISCORE.SL` (= KERNAL file I/O) が実機 (VICE) で動作。
+**動作確認済**: PRINT / INPUT / 整数算術 / FLOAT 演算 / リアルタイム key 入力 / sprite (1 個アニメ、VSYNC 同期) / joystick 入力 / KERNAL file I/O (save/load 往復) / SID 単発 SFX (= 音色 preset 切替) + ユーザー C 任意関数 (= CFUNC + `--c-source`)。`examples/FMANDEL.SL` / `examples/FURUI.SL` / `examples/STARS.SL` / `examples/c64/SPRITE.SL` / `examples/c64/FMANDEL.SL` (= 40 桁版) / `examples/c64/JOYSPR.SL` (= joystick) / `examples/c64/SIDSFX.SL` (= SID 単発 SFX) / `examples/c64/HISCORE.SL` (= KERNAL file I/O) が実機 (VICE) で動作。
 
-**未対応 / 今後の拡張**: sprite multiplex / VIC bitmap mode / SID sound / CRT / overlay (`#MODULE`)。これらは bridge 関数を追加する形で順次対応予定。
+**未対応 / 今後の拡張**: sprite multiplex / VIC bitmap mode / HVSC `.sid` BGM 再生 (= v3b-B 予定) / priority SFX overlay (= v3b-C 予定、oscar64 `audio/sidfx` bridge) / CRT / overlay (`#MODULE`)。これらは bridge 関数を追加する形で順次対応予定。
 
 **Z80 固有機能**: `MACHINE` 宣言 / inline `#ASM` ブロック / `PORT IN/OUT` / `#MODULE` を含む SLANG コードは C backend では診断 error。`#IF BACKEND==1` (= OscarC) または `#IF ENV_TYPE==7` (= c64) で C backend 専用コードを gate できます (`BACKEND` は env で自動定義: 0=Z80、1=OscarC)。
 
@@ -309,7 +311,7 @@ slangbuild -E c64 myapp.SL --c-source mylib.c -o myapp
 
 **FLOAT 精度**: SLANG FLOAT (24-bit f24) は oscar64 の `float` (32-bit IEEE 754) にマップされるため、Z80 backend と完全に同一の結果ではなくほぼ等価な精度になります。整数→FLOAT 変換は Z80 backend の `i16tof24` と同じ signed 解釈 (`(float)(short)(...)` 経由)。
 
-**runtime 構成**: `runtime/c64/slang_runtime.{h,c}` (I/O + 数学 + ビット) + `runtime/c64/slang_sprite.{h,c}` (VIC sprite bridge + VSYNC) + `runtime/c64/slang_joystick.{h,c}` (joystick bridge) + `runtime/c64/slang_kio.{h,c}` (KERNAL file I/O bridge)。slang_runtime.h は slang_sprite.h / slang_joystick.h / slang_kio.h を chain include しているため、生成 C 側 extern と bridge 実装の signature drift が発生しません。
+**runtime 構成**: `runtime/c64/slang_runtime.{h,c}` (I/O + 数学 + ビット) + `runtime/c64/slang_sprite.{h,c}` (VIC sprite bridge + VSYNC) + `runtime/c64/slang_joystick.{h,c}` (joystick bridge) + `runtime/c64/slang_kio.{h,c}` (KERNAL file I/O bridge) + `runtime/c64/slang_sid.{h,c}` (SID register direct + 単発 SFX bridge)。slang_runtime.h は slang_sprite.h / slang_joystick.h / slang_kio.h / slang_sid.h を chain include しているため、生成 C 側 extern と bridge 実装の signature drift が発生しません。
 
 # ランタイムについて
 

--- a/examples/c64/SIDSFX.SL
+++ b/examples/c64/SIDSFX.SL
@@ -1,0 +1,149 @@
+// Commodore 64 SID 単発 SFX demo (oscar64 backend、env c_bindings: 経由)
+//
+// JOYSPR.SL を拡張: joystick で sprite 移動 + fire ボタンで voice 0 SFX 発射 +
+// 1/2/3 キーで音色 (preset) 切替。SID register direct API + 単発 SFX wrapper
+// の v3b-A スコープを動作確認するための sample。
+//
+// SFX preset (= 3 種類、SLANG コード内で切替):
+//   preset 0 = laser:    NOTE_C5 + SAW + 速い attack/decay + 中 sustain (= 押してる間ピーと鳴り続ける)
+//   preset 1 = boom:     NOTE_C3 + PULSE + 50% duty pwm + 短 sustain (= 押してる間ボーと低音持続)
+//   preset 2 = noise:    NOTE_E4 + NOISE + sustain 0 (= 押した瞬間ザッと鳴って即減衰、押し続けても無音)
+//
+// SID 注意: PULSE 波形は pulse width register (= SID_PWM) を設定しないと
+// duty 0% で無音になる。boom (preset 1) は MAIN 冒頭で SID_PWM(SFX_VOICE,
+// SID_PWM_SQR) で 50% duty を設定済 = 押下中ずっと矩形波が鳴る。
+// preset 2 (noise) は sustain = 0 設計なので gate on 直後にすぐ無音になる
+// 仕様、これは「短い SFX 効果音」用途。長く鳴らしたければ susrel の上位 4bit
+// (= SID_SUS_*) を上げる。
+//
+// 操作:
+//   joystick port 2 = 8 方向移動 (JOYSPR.SL と同じ)
+//   fire = 現在 preset の SFX 発射 (押下で gate on、離して gate off で release)
+//   1 = preset 0 (laser)、2 = preset 1 (boom)、3 = preset 2 (noise)
+//
+// SID 周波数 / ADSR / waveform 定数は C64_SID.LIB から取得 (= SID register
+// 値は PAL clock 基準で事前計算済、NTSC 機では音高が約 4% 高くなる)。
+// HVSC .sid 取り込み + BGM 再生は v3b-B、priority SFX overlay は v3b-C で対応予定。
+//
+// Build (= checkout 状態 / repo root から実行):
+//   slangbuild -E c64 -I include examples/c64/SIDSFX.SL -o examples/c64/SIDSFX
+//   x64sc -autostart examples/c64/SIDSFX.prg
+// 配布物 install 後 (= SLANG_HOME 設定済) は -I include 省略可。
+
+#INCLUDE "C64_VIC.LIB"
+#INCLUDE "C64_JOY.LIB"
+#INCLUDE "C64_SID.LIB"
+
+// sprite block 192 = $3000 (SPRITE.SL / JOYSPR.SL と同じ慣行)
+CONST SPRITE_IMG_BLOCK = 192;
+CONST SPRITE_IMG_ADDR  = $3000;
+CONST SPEED            = 2;
+
+// SFX voice 番号: voice 0 = SFX 専用 (= v3b-A は単発のみ、voice 1-2 は v3b-B/C で
+// BGM 用に予約する想定。先取りで voice 0 を SFX 用に固定しておく)
+CONST SFX_VOICE = SID_VOICE_1;
+
+VAR X, Y, COLOR, DIR, K, PRESET, SFX_ACTIVE;
+ARRAY BYTE SPRDATA[63];
+
+// SFX 発射 helper: preset 番号に応じた (freq, ADSR, waveform) を SID_SFX に渡す。
+// ADSR pack: SID_ATK_* (上位 4bit) OR SID_DKY_* (下位 4bit) で attdec byte、
+// SID_SUS_* (上位 4bit) OR SID_DKY_* (下位 4bit) で susrel byte を組み立てる。
+FIRE_SFX(P)
+{
+    IF P == 0 THEN
+    {
+        // laser: 高音 saw、短 attack + 中 decay、sustain 8/15 + 中 release
+        SID_SFX(SFX_VOICE, NOTE_C5,
+                SID_ATK_2 OR SID_DKY_168,
+                SID_SUS_8 OR SID_DKY_300,
+                SID_WF_SAW);
+    }
+    IF P == 1 THEN
+    {
+        // boom: 低音 pulse、短 attack + 中 decay、sustain 8/15 (=押下中持続) + 長 release
+        // pwm は MAIN 冒頭で SID_PWM_SQR (50% duty) に設定済
+        SID_SFX(SFX_VOICE, NOTE_C3,
+                SID_ATK_2 OR SID_DKY_300,
+                SID_SUS_8 OR SID_DKY_1500,
+                SID_WF_PULSE);
+    }
+    IF P == 2 THEN
+    {
+        // noise: 中音 noise、瞬時 attack + 短 decay、no sustain + 短 release
+        SID_SFX(SFX_VOICE, NOTE_E4,
+                SID_ATK_2 OR SID_DKY_72,
+                SID_SUS_0 OR SID_DKY_168,
+                SID_WF_NOISE);
+    }
+}
+
+MAIN()
+{
+    VAR I;
+
+    // sprite データ生成 + $3000 配置 (= SPRITE.SL と同じ全 $FF パターン)
+    FOR I = 0 TO 63 { SPRDATA[I] = $FF; }
+    FOR I = 0 TO 63 { MEM[SPRITE_IMG_ADDR + I] = SPRDATA[I]; }
+
+    SPR_INIT($0400);
+    SPR_SET(0, 1, 160, 130, SPRITE_IMG_BLOCK, VCOL_WHITE, 0, 0, 0);
+    COLOR = VCOL_WHITE;
+
+    // SID 初期化 + master volume max。preset 0 (laser) で開始。
+    SID_INIT_QUIET();
+    SID_VOLUME(15);
+    // PULSE wave (= preset 1 boom) 用に pwm を 50% duty に設定 (= 設定しないと無音)。
+    // SFX_VOICE 1 つだけで全 preset を回すので、起動時 1 回設定で OK。
+    SID_PWM(SFX_VOICE, SID_PWM_SQR);
+    PRESET = 0;
+    SFX_ACTIVE = 0;
+
+    X = 160; Y = 130;
+    LOOP
+    {
+        VIC_WAIT();
+        JOY_POLL(JOY_PORT2);
+        DIR = JOY_DIR(JOY_PORT2);
+
+        // 方向移動 (JOYSPR.SL と同じ、斜め時は両軸更新)
+        IF DIR AND JOY_LEFT  THEN X = X - SPEED;
+        IF DIR AND JOY_RIGHT THEN X = X + SPEED;
+        IF DIR AND JOY_UP    THEN Y = Y - SPEED;
+        IF DIR AND JOY_DOWN  THEN Y = Y + SPEED;
+        IF X < 24  THEN X = 24;
+        IF X > 320 THEN X = 320;
+        IF Y < 50  THEN Y = 50;
+        IF Y > 220 THEN Y = 220;
+        SPR_MOVE(0, X, Y);
+
+        // fire = SFX 発射 + 押下中は active flag 立てる、離れたら gate off (release 開始)
+        IF DIR AND JOY_FIRE
+        {
+            IF SFX_ACTIVE == 0
+            {
+                FIRE_SFX(PRESET);
+                SFX_ACTIVE = 1;
+                // sprite 色も preset と連動 (= 視覚 feedback)
+                IF PRESET == 0 THEN SPR_COLOR(0, VCOL_CYAN);
+                IF PRESET == 1 THEN SPR_COLOR(0, VCOL_RED);
+                IF PRESET == 2 THEN SPR_COLOR(0, VCOL_YELLOW);
+            }
+        }
+        ELSE
+        {
+            IF SFX_ACTIVE
+            {
+                SID_GATE_OFF(SFX_VOICE);
+                SFX_ACTIVE = 0;
+                SPR_COLOR(0, VCOL_WHITE);
+            }
+        }
+
+        // 1/2/3 キーで preset 切替 (= INKEY non-blocking 読み)
+        K = INKEY(0);
+        IF K == 49 THEN PRESET = 0;   // '1'
+        IF K == 50 THEN PRESET = 1;   // '2'
+        IF K == 51 THEN PRESET = 2;   // '3'
+    }
+}

--- a/include/C64_SID.LIB
+++ b/include/C64_SID.LIB
@@ -1,0 +1,155 @@
+// C64 SID 定数 (SLANG c64 backend、env c_bindings: SID_* と組み合わせて使う)
+// `#INCLUDE "C64_SID.LIB"` で SLANG コードに取り込み。Z80 backend で
+// include しても CONST 定義のみで害なし。
+
+// === voice 番号 (= 0..2、ハードウェア仕様で 3 voice 固定) ===
+CONST SID_VOICE_1 = 0;
+CONST SID_VOICE_2 = 1;
+CONST SID_VOICE_3 = 2;
+
+// === waveform (= ctrl register 上位 bit、1 つだけ立てる or mix 可) ===
+CONST SID_WF_TRI    = $10;   // triangle、滑らかな波形
+CONST SID_WF_SAW    = $20;   // sawtooth、明るい音
+CONST SID_WF_PULSE  = $40;   // rectangle/pulse、PWM 制御可能
+CONST SID_WF_NOISE  = $80;   // noise、SFX 用
+
+// === control register bit (= ctrl register 全体、waveform + 制御 bit) ===
+CONST SID_CTRL_GATE = $01;   // attack 開始 (= 1)、release 開始 (= 0)
+CONST SID_CTRL_SYNC = $02;   // voice N+1 と同期
+CONST SID_CTRL_RING = $04;   // voice N+1 とリング変調
+CONST SID_CTRL_TEST = $08;   // テスト bit (= phase reset)
+
+// === pulse width preset (= PULSE wave 専用、SID_PWM(voice, pwm) で設定) ===
+// PULSE 波形は pwm = 0 だと duty 0% で無音。SID_GATE_ON / SID_SFX で PULSE を
+// 鳴らす前に必ず SID_PWM(voice, value) を呼ぶこと。標準的な矩形波は SID_PWM_SQR
+// (= $0800 = 50% duty)。細い値ほど音色が硬く / 太い値ほど柔らかくなる。
+CONST SID_PWM_NARROW = $0200;   // 12.5% duty、鋭い音
+CONST SID_PWM_QUARTER = $0400;  // 25% duty、明るい音
+CONST SID_PWM_SQR    = $0800;   // 50% duty、標準矩形波
+CONST SID_PWM_WIDE   = $0C00;   // 75% duty、柔らかい音
+
+// === ADSR attack time (= attdec register 上位 4 bit) ===
+// 値は SID チップ仕様で固定 (ms = 0V → ピークに到達する時間)
+CONST SID_ATK_2     = $00;   //    2 ms
+CONST SID_ATK_8     = $10;   //    8 ms
+CONST SID_ATK_16    = $20;   //   16 ms
+CONST SID_ATK_24    = $30;   //   24 ms
+CONST SID_ATK_38    = $40;   //   38 ms
+CONST SID_ATK_56    = $50;   //   56 ms
+CONST SID_ATK_68    = $60;   //   68 ms
+CONST SID_ATK_80    = $70;   //   80 ms
+CONST SID_ATK_100   = $80;   //  100 ms
+CONST SID_ATK_250   = $90;   //  250 ms
+CONST SID_ATK_500   = $A0;   //  500 ms
+CONST SID_ATK_800   = $B0;   //  800 ms
+CONST SID_ATK_1000  = $C0;   // 1000 ms
+CONST SID_ATK_3000  = $D0;   // 3000 ms
+CONST SID_ATK_5000  = $E0;   // 5000 ms
+CONST SID_ATK_8000  = $F0;   // 8000 ms
+
+// === ADSR decay/release time (= attdec/susrel register 下位 4 bit) ===
+// decay = attdec の下位 4bit、release = susrel の下位 4bit、同じ値域。
+CONST SID_DKY_6     = $00;   //    6 ms
+CONST SID_DKY_24    = $01;   //   24 ms
+CONST SID_DKY_48    = $02;   //   48 ms
+CONST SID_DKY_72    = $03;   //   72 ms
+CONST SID_DKY_114   = $04;   //  114 ms
+CONST SID_DKY_168   = $05;   //  168 ms
+CONST SID_DKY_204   = $06;   //  204 ms
+CONST SID_DKY_240   = $07;   //  240 ms
+CONST SID_DKY_300   = $08;   //  300 ms
+CONST SID_DKY_750   = $09;   //  750 ms
+CONST SID_DKY_1500  = $0A;   // 1500 ms
+CONST SID_DKY_2400  = $0B;   // 2400 ms
+CONST SID_DKY_3000  = $0C;   // 3000 ms
+CONST SID_DKY_9000  = $0D;   // 9000 ms
+CONST SID_DKY_15000 = $0E;   // 15000 ms
+CONST SID_DKY_24000 = $0F;   // 24000 ms
+
+// === sustain level pack (= susrel register 上位 4 bit) ===
+// sustain は volume 比 0..15、SLANG コード側で SID_SUS_15 OR SID_DKY_300 のように
+// OR して susrel byte を組み立てる。
+CONST SID_SUS_0  = $00;
+CONST SID_SUS_1  = $10;
+CONST SID_SUS_2  = $20;
+CONST SID_SUS_3  = $30;
+CONST SID_SUS_4  = $40;
+CONST SID_SUS_5  = $50;
+CONST SID_SUS_6  = $60;
+CONST SID_SUS_7  = $70;
+CONST SID_SUS_8  = $80;
+CONST SID_SUS_9  = $90;
+CONST SID_SUS_10 = $A0;
+CONST SID_SUS_11 = $B0;
+CONST SID_SUS_12 = $C0;
+CONST SID_SUS_13 = $D0;
+CONST SID_SUS_14 = $E0;
+CONST SID_SUS_15 = $F0;
+
+// === NOTE 定数 (= SID frequency register 値、PAL clock 基準で事前計算済) ===
+// 半音 12 × オクターブ 5 (C2..B6) = 60 個。値は SID_FREQ_PAL(NOTE_X(o)) を
+// oscar64 sid.h の式で計算した結果 (= PAL 50Hz 想定)。
+// NTSC 機 (= NTSC 60Hz クロック) で再生すると音高が約 4% 高くなる、
+// 厳密同期が必要なら user 側で 16-bit 範囲内に収まる値を別途計算。
+// C7..B7 オクターブが必要なら user 側で SID_FREQ_PAL(NOTE_C(7)) 等を
+// 自前展開 (= B7 は 16-bit overflow なので SLANG WORD では表現不可)。
+CONST NOTE_C2  = $0452;
+CONST NOTE_CS2 = $0496;
+CONST NOTE_D2  = $04DB;
+CONST NOTE_DS2 = $051F;
+CONST NOTE_E2  = $0574;
+CONST NOTE_F2  = $05C9;
+CONST NOTE_FS2 = $061E;
+CONST NOTE_G2  = $0673;
+CONST NOTE_GS2 = $06D9;
+CONST NOTE_A2  = $0751;
+CONST NOTE_AS2 = $07B7;
+CONST NOTE_B2  = $080C;
+CONST NOTE_C3  = $08A5;
+CONST NOTE_CS3 = $092D;
+CONST NOTE_D3  = $09B6;
+CONST NOTE_DS3 = $0A4F;
+CONST NOTE_E3  = $0AE8;
+CONST NOTE_F3  = $0B92;
+CONST NOTE_FS3 = $0C4E;
+CONST NOTE_G3  = $0CF8;
+CONST NOTE_GS3 = $0DC4;
+CONST NOTE_A3  = $0EA2;
+CONST NOTE_AS3 = $0F7F;
+CONST NOTE_B3  = $1018;
+CONST NOTE_C4  = $115C;
+CONST NOTE_CS4 = $126C;
+CONST NOTE_D4  = $137D;
+CONST NOTE_DS4 = $14AF;
+CONST NOTE_E4  = $15E2;
+CONST NOTE_F4  = $1736;
+CONST NOTE_FS4 = $189C;
+CONST NOTE_G4  = $1A02;
+CONST NOTE_GS4 = $1B9A;
+CONST NOTE_A4  = $1D44;   // A4 = 440 Hz、世界標準音
+CONST NOTE_AS4 = $1EFF;
+CONST NOTE_B4  = $2042;
+CONST NOTE_C5  = $22C9;
+CONST NOTE_CS5 = $24D9;
+CONST NOTE_D5  = $270B;
+CONST NOTE_DS5 = $295F;
+CONST NOTE_E5  = $2BD5;
+CONST NOTE_F5  = $2E6D;
+CONST NOTE_FS5 = $3139;
+CONST NOTE_G5  = $3415;
+CONST NOTE_GS5 = $3735;
+CONST NOTE_A5  = $3A89;
+CONST NOTE_AS5 = $3DFE;
+CONST NOTE_B5  = $4085;
+CONST NOTE_C6  = $4593;
+CONST NOTE_CS6 = $49B3;
+CONST NOTE_D6  = $4E17;
+CONST NOTE_DS6 = $52BF;
+CONST NOTE_E6  = $57AB;
+CONST NOTE_F6  = $5CDB;
+CONST NOTE_FS6 = $6272;
+CONST NOTE_G6  = $683B;
+CONST NOTE_GS6 = $6E7C;
+CONST NOTE_A6  = $7512;
+CONST NOTE_AS6 = $7BFC;
+CONST NOTE_B6  = $811C;

--- a/runtime/c64/slang_runtime.h
+++ b/runtime/c64/slang_runtime.h
@@ -24,6 +24,10 @@
  * drift 防止のため slang_runtime.h から chain include。 */
 #include "slang_kio.h"
 
+/* SID register direct + 単発 SFX bridge API (= env c_bindings: で公開)。
+ * 同じく signature drift 防止のため slang_runtime.h から chain include。 */
+#include "slang_sid.h"
+
 /* === PRINT === */
 
 void slang_print_str(const char *s);          /* NUL-terminated 文字列 */

--- a/runtime/c64/slang_sid.c
+++ b/runtime/c64/slang_sid.c
@@ -1,0 +1,72 @@
+/*
+ * SLANG SID bridge for C64 (oscar64).
+ * See slang_sid.h for API contract.
+ *
+ * oscar64 <c64/sid.h> の struct SID memory map (= 0xd400) を直接操作する。
+ * struct SID 自体は hardware register 配置の API なので、SLANG MIT runtime に
+ * 取り込んでも GPL 影響なし (= header level の参照のみ)。
+ */
+
+#include "slang_sid.h"
+#include <c64/sid.h>
+
+void slang_sid_init_quiet(void)
+{
+    /* SID register 25 個 (0xD400-0xD418) を全 0 でクリア。
+     * 既存の音を止めて安全状態に。 */
+    volatile unsigned char *p = (volatile unsigned char *)0xD400;
+    for (unsigned char i = 0; i < 25; i++) p[i] = 0;
+}
+
+void slang_sid_volume(unsigned char vol)
+{
+    /* fmodevol register: 下位 4bit = volume、上位 4bit = filter mode。
+     * 上位 4bit を保持して下位だけ更新。 */
+    sid.fmodevol = (sid.fmodevol & 0xF0) | (vol & 0x0F);
+}
+
+void slang_sid_freq(unsigned char voice, unsigned int freq)
+{
+    if (voice < 3) sid.voices[voice].freq = freq;
+}
+
+void slang_sid_pwm(unsigned char voice, unsigned int pwm)
+{
+    /* pwm register (12-bit、上位 4 bit は HW 側で無視)。 */
+    if (voice < 3) sid.voices[voice].pwm = pwm;
+}
+
+void slang_sid_adsr(unsigned char voice, unsigned char ad, unsigned char sr)
+{
+    if (voice < 3) {
+        sid.voices[voice].attdec = ad;
+        sid.voices[voice].susrel = sr;
+    }
+}
+
+void slang_sid_ctrl(unsigned char voice, unsigned char ctrl)
+{
+    if (voice < 3) sid.voices[voice].ctrl = ctrl;
+}
+
+void slang_sid_gate_on(unsigned char voice)
+{
+    if (voice < 3) sid.voices[voice].ctrl |= SID_CTRL_GATE;
+}
+
+void slang_sid_gate_off(unsigned char voice)
+{
+    if (voice < 3) sid.voices[voice].ctrl &= (unsigned char)~SID_CTRL_GATE;
+}
+
+void slang_sid_sfx(unsigned char voice, unsigned int freq,
+                   unsigned char ad, unsigned char sr, unsigned char waveform)
+{
+    if (voice < 3) {
+        sid.voices[voice].freq = freq;
+        sid.voices[voice].attdec = ad;
+        sid.voices[voice].susrel = sr;
+        /* waveform に GATE bit を OR して書き込み = 即時 attack 開始。 */
+        sid.voices[voice].ctrl = (unsigned char)(waveform | SID_CTRL_GATE);
+    }
+}

--- a/runtime/c64/slang_sid.c
+++ b/runtime/c64/slang_sid.c
@@ -3,8 +3,8 @@
  * See slang_sid.h for API contract.
  *
  * oscar64 <c64/sid.h> の struct SID memory map (= 0xd400) を直接操作する。
- * struct SID 自体は hardware register 配置の API なので、SLANG MIT runtime に
- * 取り込んでも GPL 影響なし (= header level の参照のみ)。
+ * 本 bridge の実装はすべて SLANG 側オリジナルで、oscar64 の実装コード
+ * (audio/sidfx.c 等) は転載しない運用方針。公開 header の API 参照に限定。
  */
 
 #include "slang_sid.h"
@@ -66,7 +66,11 @@ void slang_sid_sfx(unsigned char voice, unsigned int freq,
         sid.voices[voice].freq = freq;
         sid.voices[voice].attdec = ad;
         sid.voices[voice].susrel = sr;
-        /* waveform に GATE bit を OR して書き込み = 即時 attack 開始。 */
+        /* SID envelope は GATE bit の 0→1 transition で attack を re-trigger
+         * するため、既に GATE が立っている voice に再呼出されても確実に
+         * attack をやり直せるよう、まず GATE off (= ctrl に waveform のみ) を
+         * 書いてから GATE on (= waveform | GATE) を書く 2 段書き込み。 */
+        sid.voices[voice].ctrl = (unsigned char)waveform;
         sid.voices[voice].ctrl = (unsigned char)(waveform | SID_CTRL_GATE);
     }
 }

--- a/runtime/c64/slang_sid.h
+++ b/runtime/c64/slang_sid.h
@@ -71,7 +71,9 @@ void slang_sid_gate_off(unsigned char voice);
  * release は user 明示の slang_sid_gate_off で開始する (= 自動 release scheduling
  * は v4f BGM player の責務、v3b-A では「鳴らしっぱなしになるので user が
  * gate off を呼ぶ」と明示)。
- * waveform は SID_WF_TRI / SAW / PULSE / NOISE のいずれか (= ctrl の上位 bit)。 */
+ * waveform は SID_WF_TRI / SAW / PULSE / NOISE のいずれか (= ctrl の上位 bit)。
+ * 内部で GATE off → GATE on の 2 段書き込みを行うため、既に GATE が立っている
+ * voice に再呼出した場合も attack が確実に re-trigger される (= 連射 SFX OK)。 */
 void slang_sid_sfx(unsigned char voice, unsigned int freq,
                    unsigned char ad, unsigned char sr, unsigned char waveform);
 

--- a/runtime/c64/slang_sid.h
+++ b/runtime/c64/slang_sid.h
@@ -1,0 +1,78 @@
+/*
+ * SLANG SID bridge API for C64 (oscar64).
+ *
+ * oscar64 <c64/sid.h> の薄い wrapper。SID register direct access + 単発 SFX
+ * helper を SLANG WORD 経由で SLANG コードから扱えるよう型整合を吸収する。
+ *
+ * v3b-A スコープ: register direct (FREQ / ADSR / CTRL / VOLUME / GATE) +
+ * 単発 SFX wrapper (= ADSR + waveform + GATE on 1 行)。HVSC .sid 取り込みは
+ * v3b-B、priority SFX overlay (oscar64 audio/sidfx bridge) は v3b-C。
+ *
+ * 使い方 (SLANG 側、典型):
+ *   #INCLUDE "C64_SID.LIB"
+ *   SID_VOLUME(15);                     ; master volume max
+ *   SID_SFX(SID_VOICE_1, NOTE_C4,       ; voice 1 で C4 を C major triangle
+ *           SID_ATK_8 OR SID_DKY_240,   ; attack 8ms + decay 240ms
+ *           ($F * 16) OR SID_DKY_300,   ; sustain 15/15 + release 300ms
+ *           SID_WF_TRI);
+ *   ; ... 一定 frame 後
+ *   SID_GATE_OFF(SID_VOICE_1);          ; release 開始
+ *
+ * voice 番号: 0..2 (= SID_VOICE_1/2/3 で別名提供)。範囲外は無視 (= bridge 内 if)。
+ * volume: 0..15 (= 下位 4bit)。
+ * frequency: SID register 値 (= PAL clock 基準の 16-bit WORD、NOTE_C4 等の
+ *            事前計算済 register 値を C64_SID.LIB から取得して渡す)。
+ * ADSR pack: attdec = (attack << 4) | decay、susrel = (sustain << 4) | release。
+ *            SID_ATK_* / SID_DKY_* 定数を OR で組み合わせ (C64_SID.LIB 参照)。
+ * waveform: SID_WF_TRI / SAW / PULSE / NOISE のいずれか (= ctrl の上位 bit)。
+ */
+#ifndef SLANG_SID_H
+#define SLANG_SID_H
+
+/* === 初期化 === */
+
+/* SID register を全 0 で初期化 (= 既存音停止 + 安全状態)。
+ * 起動直後やゲーム reset で 1 回呼んでから個別 voice 設定する。 */
+void slang_sid_init_quiet(void);
+
+/* === Master === */
+
+/* master volume 設定 (0..15、下位 4bit のみ有効、上位 bit (filter mode) は保持)。 */
+void slang_sid_volume(unsigned char vol);
+
+/* === Voice direct (= register 直接アクセス) === */
+
+/* voice N (0..2) の frequency register (16-bit)。 NOTE_C4 等の事前計算値を渡す。 */
+void slang_sid_freq(unsigned char voice, unsigned int freq);
+
+/* voice N の pulse width register (= 12-bit、PULSE wave 時のみ意味あり)。
+ * PULSE 波形を使うときは sound 出力前に必須 (= 0 のまま PULSE を gate on すると
+ * duty 0% で無音、$0800 = 50% duty が標準的な矩形波)。範囲は 0..$0FFF (上位
+ * 4 bit は無視)、$0001 (極狭) ~ $0FFF (極広) で音色が変わる。 */
+void slang_sid_pwm(unsigned char voice, unsigned int pwm);
+
+/* voice N の ADSR pack 設定:
+ *   ad = (attack << 4) | decay   (attdec register)
+ *   sr = (sustain << 4) | release (susrel register)
+ * 各 4bit 値は SID_ATK_* / SID_DKY_* 定数で時定数指定可能。 */
+void slang_sid_adsr(unsigned char voice, unsigned char ad, unsigned char sr);
+
+/* voice N の control register (waveform + GATE + sync 等の bit 集合)。 */
+void slang_sid_ctrl(unsigned char voice, unsigned char ctrl);
+
+/* voice N の GATE bit を立てる/降ろす (= 既存 ctrl register 維持で gate のみ操作)。
+ * gate_on で attack 開始、gate_off で release 開始。 */
+void slang_sid_gate_on(unsigned char voice);
+void slang_sid_gate_off(unsigned char voice);
+
+/* === SFX wrapper === */
+
+/* 単発 SFX 発射: freq + ADSR + waveform を 1 関数で設定し GATE on まで実行。
+ * release は user 明示の slang_sid_gate_off で開始する (= 自動 release scheduling
+ * は v4f BGM player の責務、v3b-A では「鳴らしっぱなしになるので user が
+ * gate off を呼ぶ」と明示)。
+ * waveform は SID_WF_TRI / SAW / PULSE / NOISE のいずれか (= ctrl の上位 bit)。 */
+void slang_sid_sfx(unsigned char voice, unsigned int freq,
+                   unsigned char ad, unsigned char sr, unsigned char waveform);
+
+#endif /* SLANG_SID_H */

--- a/runtime/env/c64.env
+++ b/runtime/env/c64.env
@@ -17,6 +17,7 @@ c_runtime_files:
   - ../c64/slang_sprite.c
   - ../c64/slang_joystick.c
   - ../c64/slang_kio.c
+  - ../c64/slang_sid.c
 c_runtime_includes:
   - ../c64
 
@@ -193,6 +194,50 @@ c_bindings:
     c_name: slang_kio_write_addr
     params: [byte, word, word]
     return: word
+
+  # === SID register direct + 単発 SFX (oscar64 c64/sid.h、v3b-A) ===
+  # SID register を直接叩く API + SFX wrapper。HVSC .sid 取り込みは v3b-B、
+  # priority SFX overlay は v3b-C で追加予定。
+  # voice 番号 0..2、volume 0..15。frequency は PAL clock 基準の register 値
+  # (= NOTE_C4 等の事前計算済定数を C64_SID.LIB から取得して渡す)。
+  # waveform / ADSR / CTRL の bit 構成は C64_SID.LIB の SID_WF_* / SID_ATK_*
+  # / SID_DKY_* / SID_SUS_* / SID_CTRL_* 定数で組み立てる。
+  - name: SID_INIT_QUIET
+    c_name: slang_sid_init_quiet
+    params: []
+    return: void
+  - name: SID_VOLUME
+    c_name: slang_sid_volume
+    params: [byte]
+    return: void
+  - name: SID_FREQ
+    c_name: slang_sid_freq
+    params: [byte, word]
+    return: void
+  - name: SID_PWM
+    c_name: slang_sid_pwm
+    params: [byte, word]
+    return: void
+  - name: SID_ADSR
+    c_name: slang_sid_adsr
+    params: [byte, byte, byte]
+    return: void
+  - name: SID_CTRL
+    c_name: slang_sid_ctrl
+    params: [byte, byte]
+    return: void
+  - name: SID_GATE_ON
+    c_name: slang_sid_gate_on
+    params: [byte]
+    return: void
+  - name: SID_GATE_OFF
+    c_name: slang_sid_gate_off
+    params: [byte]
+    return: void
+  - name: SID_SFX
+    c_name: slang_sid_sfx
+    params: [byte, word, byte, byte, byte]
+    return: void
 
   # INPUT / GETL / GETLIN / LINPUT (SLANG Z80 backend と signature 互換)
   # ESC キーで $FFFF を返す。Z80 backend の `_CARRY` 機構は v1 未対応。

--- a/tests/SLANGCompiler.Tests/SidBindingTests.cs
+++ b/tests/SLANGCompiler.Tests/SidBindingTests.cs
@@ -79,7 +79,7 @@ public class SidBindingTests
     [Fact]
     public void SidAll_EmitsExternsAndCalls()
     {
-        // SID 8 binding を SLANG コード上で実呼出して CTranspiler が extern を
+        // SID 9 binding を SLANG コード上で実呼出して CTranspiler が extern を
         // 必ず emit するパスを通す。byte / word 引数の組合せ + void return を網羅。
         var src = TranspileWithEnv("""
             MAIN() {
@@ -100,7 +100,7 @@ public class SidBindingTests
             $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
 
         // bridge header (runtime/c64/slang_sid.h) の signature と env c_bindings: が
-        // drift していないことを 8 entry すべての extern 出力で確認。
+        // drift していないことを 9 entry すべての extern 出力で確認。
         Assert.Contains("extern void slang_sid_init_quiet(void);", src);
         Assert.Contains("extern void slang_sid_volume(unsigned char);", src);
         Assert.Contains("extern void slang_sid_freq(unsigned char, unsigned int);", src);
@@ -111,7 +111,7 @@ public class SidBindingTests
         Assert.Contains("extern void slang_sid_gate_off(unsigned char);", src);
         Assert.Contains("extern void slang_sid_sfx(unsigned char, unsigned int, unsigned char, unsigned char, unsigned char);", src);
 
-        // 呼出が C 関数として展開される (8 個すべて)
+        // 呼出が C 関数として展開される (9 個すべて)
         Assert.Contains("slang_sid_init_quiet(", src);
         Assert.Contains("slang_sid_volume(",     src);
         Assert.Contains("slang_sid_freq(",       src);
@@ -141,7 +141,7 @@ public class SidBindingTests
         Assert.Contains(config.CRuntimeFiles!,
             p => Path.GetFileName(p).Equals("slang_sid.c", StringComparison.OrdinalIgnoreCase));
 
-        // c_bindings に SID_* 8 entry がすべて含まれる
+        // c_bindings に SID_* 9 entry がすべて含まれる
         Assert.NotNull(config.CBindings);
         var bindingNames = config.CBindings!.Select(b => b.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
         foreach (var expected in new[]

--- a/tests/SLANGCompiler.Tests/SidBindingTests.cs
+++ b/tests/SLANGCompiler.Tests/SidBindingTests.cs
@@ -1,0 +1,194 @@
+using SLANGCompiler;
+using SLANGCompiler.CodeGen.C;
+using SLANGCompiler.Lexer;
+using SLANGCompiler.Parser;
+using SLANGCompiler.Runtime;
+using SLANGCompiler.Semantics;
+using Xunit;
+
+namespace SLANGCompiler.Tests;
+
+/// <summary>
+/// v3b-A SID register direct + 単発 SFX binding の signature drift / 呼出 emit を
+/// golden 化する。env c_bindings: と bridge header (runtime/c64/slang_sid.h)
+/// の一致確認も兼ねる。
+/// </summary>
+public class SidBindingTests
+{
+    private static EnvironmentConfig MakeC64EnvWithSid()
+    {
+        // 実 runtime/env/c64.env をパースする代わりに、テスト独立性のために
+        // 必要 binding だけ手組み (= env file 解析テストは EnvCBindingsTests で別途網羅)。
+        // v3b-A スコープの 8 entry (= SID register + 単発 SFX wrapper) を網羅。
+        return new EnvironmentConfig
+        {
+            Name = "c64",
+            Backend = BackendKind.OscarC,
+            OutputFormat = "c_source",
+            CBindings = new List<CBindingDef>
+            {
+                new() { Name = "SID_INIT_QUIET", CName = "slang_sid_init_quiet",
+                        Params = new List<CBindingType>(),
+                        Return = CBindingType.Void },
+                new() { Name = "SID_VOLUME", CName = "slang_sid_volume",
+                        Params = new List<CBindingType> { CBindingType.Byte },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_FREQ", CName = "slang_sid_freq",
+                        Params = new List<CBindingType> { CBindingType.Byte, CBindingType.Word },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_PWM", CName = "slang_sid_pwm",
+                        Params = new List<CBindingType> { CBindingType.Byte, CBindingType.Word },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_ADSR", CName = "slang_sid_adsr",
+                        Params = new List<CBindingType> { CBindingType.Byte, CBindingType.Byte, CBindingType.Byte },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_CTRL", CName = "slang_sid_ctrl",
+                        Params = new List<CBindingType> { CBindingType.Byte, CBindingType.Byte },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_GATE_ON", CName = "slang_sid_gate_on",
+                        Params = new List<CBindingType> { CBindingType.Byte },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_GATE_OFF", CName = "slang_sid_gate_off",
+                        Params = new List<CBindingType> { CBindingType.Byte },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_SFX", CName = "slang_sid_sfx",
+                        Params = new List<CBindingType> { CBindingType.Byte, CBindingType.Word, CBindingType.Byte, CBindingType.Byte, CBindingType.Byte },
+                        Return = CBindingType.Void },
+            },
+        };
+    }
+
+    private static string TranspileWithEnv(string source, EnvironmentConfig env, out DiagnosticBag diag)
+    {
+        diag = new DiagnosticBag();
+        var lexer = new Lexer.Lexer(source, "<test>");
+        var tokens = lexer.Tokenize();
+        var preproc = new Preprocessor(diag, new List<string>());
+        preproc.DefineConst("BACKEND", 1);
+        preproc.DefineConst("ENV_TYPE", 7);
+        tokens = preproc.Process(tokens, ".");
+        var parser = new Parser.Parser(tokens, diag);
+        var ast = parser.ParseCompilationUnit();
+        var analyzer = new SemanticAnalyzer(diag);
+        analyzer.Analyze(ast);
+        if (diag.HasErrors) return "";
+        var transpiler = new CTranspiler(analyzer.Symbols, env, diag);
+        return transpiler.Transpile(ast);
+    }
+
+    [Fact]
+    public void SidAll_EmitsExternsAndCalls()
+    {
+        // SID 8 binding を SLANG コード上で実呼出して CTranspiler が extern を
+        // 必ず emit するパスを通す。byte / word 引数の組合せ + void return を網羅。
+        var src = TranspileWithEnv("""
+            MAIN() {
+                VAR I, F;
+                SID_INIT_QUIET();
+                SID_VOLUME(15);
+                SID_FREQ(0, $1D44);
+                SID_PWM(0, $0800);
+                SID_ADSR(0, $10, $F8);
+                SID_CTRL(0, $11);
+                SID_GATE_ON(0);
+                SID_GATE_OFF(1);
+                SID_SFX(2, $22C9, $20, $A8, $80);
+            }
+            """, MakeC64EnvWithSid(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+
+        // bridge header (runtime/c64/slang_sid.h) の signature と env c_bindings: が
+        // drift していないことを 8 entry すべての extern 出力で確認。
+        Assert.Contains("extern void slang_sid_init_quiet(void);", src);
+        Assert.Contains("extern void slang_sid_volume(unsigned char);", src);
+        Assert.Contains("extern void slang_sid_freq(unsigned char, unsigned int);", src);
+        Assert.Contains("extern void slang_sid_pwm(unsigned char, unsigned int);", src);
+        Assert.Contains("extern void slang_sid_adsr(unsigned char, unsigned char, unsigned char);", src);
+        Assert.Contains("extern void slang_sid_ctrl(unsigned char, unsigned char);", src);
+        Assert.Contains("extern void slang_sid_gate_on(unsigned char);", src);
+        Assert.Contains("extern void slang_sid_gate_off(unsigned char);", src);
+        Assert.Contains("extern void slang_sid_sfx(unsigned char, unsigned int, unsigned char, unsigned char, unsigned char);", src);
+
+        // 呼出が C 関数として展開される (8 個すべて)
+        Assert.Contains("slang_sid_init_quiet(", src);
+        Assert.Contains("slang_sid_volume(",     src);
+        Assert.Contains("slang_sid_freq(",       src);
+        Assert.Contains("slang_sid_pwm(",        src);
+        Assert.Contains("slang_sid_adsr(",       src);
+        Assert.Contains("slang_sid_ctrl(",       src);
+        Assert.Contains("slang_sid_gate_on(",    src);
+        Assert.Contains("slang_sid_gate_off(",   src);
+        Assert.Contains("slang_sid_sfx(",        src);
+    }
+
+    [Fact]
+    public void RealC64Env_HasAllSidBindings()
+    {
+        // 実 runtime/env/c64.env を EnvironmentLoader でパースして SID_* entry
+        // と c_runtime_files に slang_sid.c が含まれていることを確認。
+        // 手組み env では捕捉できない drift (= env file 編集忘れや typo) を防ぐ。
+        var repoRoot = FindRepoRoot();
+        var envPath = Path.Combine(repoRoot, "runtime", "env", "c64.env");
+        Assert.True(File.Exists(envPath), $"runtime/env/c64.env not found at {envPath}");
+
+        var config = EnvironmentLoader.Load(envPath);
+        Assert.Equal(BackendKind.OscarC, config.Backend);
+
+        // c_runtime_files に slang_sid.c
+        Assert.NotNull(config.CRuntimeFiles);
+        Assert.Contains(config.CRuntimeFiles!,
+            p => Path.GetFileName(p).Equals("slang_sid.c", StringComparison.OrdinalIgnoreCase));
+
+        // c_bindings に SID_* 8 entry がすべて含まれる
+        Assert.NotNull(config.CBindings);
+        var bindingNames = config.CBindings!.Select(b => b.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        foreach (var expected in new[]
+        {
+            "SID_INIT_QUIET", "SID_VOLUME", "SID_FREQ", "SID_PWM", "SID_ADSR",
+            "SID_CTRL", "SID_GATE_ON", "SID_GATE_OFF", "SID_SFX",
+        })
+        {
+            Assert.Contains(expected, bindingNames);
+        }
+
+        // signature ピン留め (= 代表的な entry の c_name + 型)
+        var sidSfx = config.CBindings!.First(b => b.Name == "SID_SFX");
+        Assert.Equal("slang_sid_sfx", sidSfx.CName);
+        Assert.Equal(5, sidSfx.Params.Count);
+        Assert.Equal(CBindingType.Byte, sidSfx.Params[0]);
+        Assert.Equal(CBindingType.Word, sidSfx.Params[1]);
+        Assert.Equal(CBindingType.Byte, sidSfx.Params[2]);
+        Assert.Equal(CBindingType.Byte, sidSfx.Params[3]);
+        Assert.Equal(CBindingType.Byte, sidSfx.Params[4]);
+        Assert.Equal(CBindingType.Void, sidSfx.Return);
+
+        var sidInit = config.CBindings!.First(b => b.Name == "SID_INIT_QUIET");
+        Assert.Equal("slang_sid_init_quiet", sidInit.CName);
+        Assert.Empty(sidInit.Params);
+        Assert.Equal(CBindingType.Void, sidInit.Return);
+
+        var sidFreq = config.CBindings!.First(b => b.Name == "SID_FREQ");
+        Assert.Equal("slang_sid_freq", sidFreq.CName);
+        Assert.Equal(2, sidFreq.Params.Count);
+        Assert.Equal(CBindingType.Byte, sidFreq.Params[0]);
+        Assert.Equal(CBindingType.Word, sidFreq.Params[1]);
+    }
+
+    /// <summary>
+    /// テスト実行 cwd から SLANG-compiler repo root を遡って探す。bin/Debug/net8.0
+    /// から実行されるため複数階層上に上がる必要あり。
+    /// </summary>
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "runtime", "env", "c64.env")))
+                return dir.FullName;
+            dir = dir.Parent;
+        }
+        throw new InvalidOperationException("Could not locate SLANG-compiler repo root containing runtime/env/c64.env");
+    }
+}

--- a/tests/SLANGCompiler.Tests/SidBindingTests.cs
+++ b/tests/SLANGCompiler.Tests/SidBindingTests.cs
@@ -19,7 +19,7 @@ public class SidBindingTests
     {
         // 実 runtime/env/c64.env をパースする代わりに、テスト独立性のために
         // 必要 binding だけ手組み (= env file 解析テストは EnvCBindingsTests で別途網羅)。
-        // v3b-A スコープの 8 entry (= SID register + 単発 SFX wrapper) を網羅。
+        // v3b-A スコープの 9 entry (= SID register direct 8 + 単発 SFX wrapper 1) を網羅。
         return new EnvironmentConfig
         {
             Name = "c64",


### PR DESCRIPTION
## Summary

ロードマップ #178 配下の **v3b (Issue #180)** を 3 分割した初回 **v3b-A** として、oscar64 `c64/sid.h` の SLANG bridge と動作確認 sample を追加します。SLANG コードから SID 音源で単発 SFX (= laser / boom / noise の 3 preset) が鳴らせるようになります (実機 VICE で fire ボタンで音出し動作確認済)。

- `runtime/c64/slang_sid.{h,c}`: register direct 8 関数 (`SID_INIT_QUIET` / `_VOLUME` / `_FREQ` / `_PWM` / `_ADSR` / `_CTRL` / `_GATE_ON` / `_GATE_OFF`) + SFX wrapper 1 関数 (`SID_SFX`)
- `runtime/env/c64.env`: c_bindings に 9 entry 追加
- `include/C64_SID.LIB`: voice/waveform/CTRL/ATK/DKY/SUS 各定数 + pulse width preset 4 個 + `NOTE_C2..B6` 60 個 (= PAL clock 基準の事前計算済 SID register 値)
- `examples/c64/SIDSFX.SL`: JOYSPR 拡張、joystick 移動 + fire ボタンで SFX 発射 + 1/2/3 キーで preset 切替 + sprite 色連動
- `tests/SLANGCompiler.Tests/SidBindingTests.cs`: 9 関数の extern signature + 呼出展開 + 実 env file 全 9 binding pin 留め

frequency は PAL clock 基準の事前計算済 register 値 (= NOTE_C2..B6 60 個を C64_SID.LIB から取得)。**PULSE 波形は事前に `SID_PWM` 設定必須** (= pwm=0 だと duty 0% で無音、`SID_PWM_SQR` = $0800 で 50% duty)。

## license 整理 (= MIT × GPL-3.0)

調査結果:
- oscar64 `c64/sid.h` = **hardware register memory map (API レベル)** のため SLANG MIT runtime に取り込んでも GPL 影響なし (= bridge 関数はすべて SLANG 側オリジナル実装、`slang_*` 命名)
- oscar64 `audio/sidfx.c` = **GPL-3.0 の priority SFX player**、v3b-A では使わない (= v3b-C で `#include <audio/sidfx.h>` の bridge 経由参照に限定、SLANG MIT runtime に GPL コードを borrow しない方針継続)

## v3b roadmap (= 後続 PR)

- **v3b-B**: HVSC `.sid` 取り込み + BGM 再生 (slangbuild `--sid` + `SID_LOAD/PLAYER_INIT/PLAY` bridge + sample SIDBGM.SL)
- **v3b-C**: oscar64 `audio/sidfx` bridge で priority SFX overlay (= `#include <audio/sidfx.h>` 経由参照、sample SIDOVERLAY.SL)

## Test plan

- [x] dotnet test 全 **376 tests pass** (= 既存 374 + 新規 SidBindingTests 2 件、regression なし)
- [x] smoke build (Os 最適化、size 1037 byte = JOYSPR 比 +400 byte)
- [x] 実機 VICE で 3 preset 動作確認 (= preset 0/1 は press 中持続音、preset 2 は短 burst 設計)
- [ ] 配布版 install 後 (= SLANG_HOME 設定済) で `-I include` 省略可動作 (= 別途配布版テスト)
- [ ] Codex review 反映 (= レビュー依頼後)

Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)