### PR TITLE
Add C64 HVSC .sid disk load + BGM playback (v3b-B, #180 配下)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,71 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 - `examples/c64/JOYSPR.SL` (= v3a) joystick port 2 で sprite 移動 + fire で色変更 (= ロードマップ v3a に対応、`JOY_DIR` bitmask + `JOY_B` 主、`JOY_X/Y` の signed `-1=$FFFF` パターン解説含む)
 - `examples/c64/HISCORE.SL` (= v3c) D64 disk image に `HISCORE,S,W` で save → `HISCORE,S,R` で read → 内容比較する KERNAL file I/O 往復 sample
 - `examples/c64/SIDSFX.SL` (= v3b-A) joystick で sprite 移動 + fire ボタンで voice 0 SFX 発射 + 1/2/3 キーで音色 preset 切替 (= laser/boom/noise の 3 種類)
+- `examples/c64/SIDBGM.SL` (= v3b-B) disk から PSID v2 `.sid` file を KIO 経由で読み込み → header parse + payload 配置 → VSYNC loop で player 駆動して BGM 再生 (= HVSC tune を user 持込で動作確認)
+
+### v3b-B — HVSC .sid disk load + BGM 再生 (#180 配下)
+
+ロードマップ #178 配下の v3b の 3 分割 2 回目 (= disk load 経由の BGM 再生) を実装:
+
+- `runtime/c64/slang_sid.{h,c}` に 5 関数追加: `slang_sid_load_from_buf` (= PSID
+  v2 header parse + payload を loadAddress に memcpy + init/play addr を bridge
+  内 static 保持) / `slang_sid_load_from_buf_addr` (= 上記の raw addr 版、SLANG
+  `ARRAY BYTE` を経由せず KIO_READ_ADDR で直接 free RAM ($C000) に load する
+  ケース用) / `slang_sid_player_init` (= 保存 init addr に JMP indirect 経由
+  jump、song 番号を A レジスタ、zp $FB/$FC vector を経由するのは oscar64 の
+  C 関数ポインタ呼出が bytecode interpreter に流れて raw 6502 に届かないため)
+  / `slang_sid_player_play` (= 保存 play addr に同じく JMP indirect で jump、
+  毎フレーム VSYNC 後呼出) / `slang_sid_player_ready` (= load 成功状態の判定)
+- `runtime/env/c64.env` `c_bindings:` に 5 entry 追加 (= SID 全体で 14 entry に)
+- 新規 `examples/c64/SIDBGM.SL`: KIO で disk から "music" PRG を $C000 領域
+  (= C64 伝統的 free RAM、SLANG runtime と衝突しない) に直 read → 
+  SID_LOAD_FROM_BUF_ADDR → SID_PLAYER_INIT(0) → VSYNC loop で SID_PLAYER_PLAY、
+  1-9 キーで song 切替
+- `tests/SLANGCompiler.Tests/SidBindingTests.cs` を v3b-B 5 entry 追加で拡張
+  (= 計 14 binding の extern + 呼出展開 + signature pin 留め)
+
+設計判断:
+- slangbuild 拡張は行わない (= PRG に SID embed せず、disk load 一択。最終的に
+  は crt/ROM コピーも視野だが今回は disk load のみ。memory `feedback_pr_split_codex_review`
+  の scope 縮小規律と整合)
+- PSID v2 only (= RSID = playAddress=0 の IRQ-driven 形式は非対応、別 PR で
+  検討)、シングル SID のみ (= multi-SID は非対応)
+- PAL 50Hz 想定 (= VIC_WAIT 経由)、NTSC では音高ずれ許容
+- header parse 失敗時 (= magic 不一致 / version 不正 / RSID 等) は init/play
+  addr を 0 のまま保持、PLAYER_INIT/PLAY は no-op 化、`SID_PLAYER_READY` で
+  状態確認可能
+
+着手中に踏んだ 3 つの bug と修正 (= v3a/c で未経験の領域):
+1. **char literal の PETSCII 変換**: bridge 内 `psid_eq(buf, 'P', 'S', 'I', 'D')` を
+   書いたが oscar64 `-psci` は char literal も PETSCII 化 (`'P'` → 0xD0) するため
+   disk から読んだ ASCII 0x50 と mismatch して常に false。**16 進値直書きの
+   `is_psid_magic(buf)` (= `p[0] == 0x50 && ...`)** に変更して PETSCII 変換から独立
+2. **C 関数ポインタ呼出が bytecode interpreter (bcexec) に流れる**: oscar64 で
+   `((void(*)(byte))addr)(song)` を書いたが asm 出力で `JSR bcexec` (= oscar64
+   bytecode 実行 routine) に行く → raw 6502 native code に届かず hang。**zp
+   $FB/$FC に target addr 保存 + `__asm { jmp ($00fb) }` 6502 indirect jump** で
+   動的 addr 対応 (= oscar64 sample にある `__asm { jsr $a000 }` literal pattern を
+   そのまま使えない動的 addr ケースの正攻法)
+3. **SLANG `ARRAY BYTE` が $1000 領域を侵食 (= self-destruction)**: SLANG コード
+   で `ARRAY BYTE SID_BUF[4096]` を declare すると oscar64 BSS が $0F90-$1F91 を
+   占有、HVSC tune (= loadAddress $1000 が大半) と完全 overlap。payload memcpy
+   で SID_BUF 自身 + SLANG runtime の global 変数を破壊して reset 様の挙動に。
+   **SLANG コードで ARRAY BYTE を消し、`KIO_READ_ADDR` で $C000 (= 伝統的 free
+   RAM) に直接 disk read + `SID_LOAD_FROM_BUF_ADDR` で raw word addr を bridge
+   に渡す流儀** を採用。 BSS area は $0DA9-$0DC1 (24 byte) まで縮小、$1000 領域
+   free
+
+license 整理:
+- bridge / sample SLANG コードはすべて SLANG 側オリジナル実装、MIT 維持
+- HVSC tune は **同梱しない** (= HVSC は全 tune copyright 残存、FAQ Q29 で
+  個別 publisher 許諾必要と明示。SLANG repo に法的 PD 不明な binary を置く
+  ことを避ける)
+- ユーザーが持ち込む `.sid` の copyright / license 整合は user 責務、README
+  / sample コメントに明記
+
+v3b roadmap (= 後続 PR):
+- v3b-C: oscar64 `audio/sidfx` bridge で priority SFX overlay (= `#include
+  <audio/sidfx.h>` 経由参照、sample SIDOVERLAY.SL)
 
 ### v3b-A — SID 基盤 + 単発 SFX binding (#180 配下)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,67 +47,36 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 
 ### v3b-B — HVSC .sid disk load + BGM 再生 (#180 配下)
 
-ロードマップ #178 配下の v3b の 3 分割 2 回目 (= disk load 経由の BGM 再生) を実装:
-
 - `runtime/c64/slang_sid.{h,c}` に 5 関数追加: `slang_sid_load_from_buf` (= PSID
   v2 header parse + payload を loadAddress に memcpy + init/play addr を bridge
-  内 static 保持) / `slang_sid_load_from_buf_addr` (= 上記の raw addr 版、SLANG
-  `ARRAY BYTE` を経由せず KIO_READ_ADDR で直接 free RAM ($C000) に load する
-  ケース用) / `slang_sid_player_init` (= 保存 init addr に JMP indirect 経由
-  jump、song 番号を A レジスタ、zp $FB/$FC vector を経由するのは oscar64 の
-  C 関数ポインタ呼出が bytecode interpreter に流れて raw 6502 に届かないため)
-  / `slang_sid_player_play` (= 保存 play addr に同じく JMP indirect で jump、
-  毎フレーム VSYNC 後呼出) / `slang_sid_player_ready` (= load 成功状態の判定)
-- `runtime/env/c64.env` `c_bindings:` に 5 entry 追加 (= SID 全体で 14 entry に)
-- 新規 `examples/c64/SIDBGM.SL`: KIO で disk から "music" PRG を $C000 領域
-  (= C64 伝統的 free RAM、SLANG runtime と衝突しない) に直 read → 
-  SID_LOAD_FROM_BUF_ADDR → SID_PLAYER_INIT(0) → VSYNC loop で SID_PLAYER_PLAY、
-  1-9 キーで song 切替
-- `tests/SLANGCompiler.Tests/SidBindingTests.cs` を v3b-B 5 entry 追加で拡張
-  (= 計 14 binding の extern + 呼出展開 + signature pin 留め)
+  内 static 保持、`byte_ptr` 引数) / `slang_sid_load_from_buf_addr` (= 同等機能の
+  raw word addr 引数版) / `slang_sid_player_init` (= 保存 init addr へ song 番号
+  (A レジスタ) で jump、内部は zp $FB/$FC vector + `JMP ($00fb)` 6502 indirect
+  経由) / `slang_sid_player_play` (= 保存 play addr へ jump、毎フレーム VSYNC 後
+  呼出) / `slang_sid_player_ready` (= load 成功状態判定)
+- `runtime/env/c64.env` `c_bindings:` に 5 entry 追加 (= SID 全体で 14 entry)
+- 新規 `examples/c64/SIDBGM.SL`: disk から "music" PRG を `KIO_READ_ADDR` で
+  $C000 (= C64 伝統的 free RAM area) に直接 read → `SID_LOAD_FROM_BUF_ADDR` →
+  `SID_PLAYER_INIT(0)` → VSYNC loop で `SID_PLAYER_PLAY`、1-9 キーで song 切替
+- `tests/SLANGCompiler.Tests/SidBindingTests.cs` 拡張 (= 計 14 binding の extern
+  + 呼出展開 + signature pin)
 
-設計判断:
-- slangbuild 拡張は行わない (= PRG に SID embed せず、disk load 一択。最終的に
-  は crt/ROM コピーも視野だが今回は disk load のみ。memory `feedback_pr_split_codex_review`
-  の scope 縮小規律と整合)
-- PSID v2 only (= RSID = playAddress=0 の IRQ-driven 形式は非対応、別 PR で
-  検討)、シングル SID のみ (= multi-SID は非対応)
-- PAL 50Hz 想定 (= VIC_WAIT 経由)、NTSC では音高ずれ許容
-- header parse 失敗時 (= magic 不一致 / version 不正 / RSID 等) は init/play
-  addr を 0 のまま保持、PLAYER_INIT/PLAY は no-op 化、`SID_PLAYER_READY` で
-  状態確認可能
+**設計判断**:
+- PSID v2 only (= RSID = playAddress=0 形式は非対応)、シングル SID のみ
+- PAL 50Hz 想定 (= VIC_WAIT 連動)、NTSC では音高ずれ許容
+- header parse 失敗時 (= magic 不一致 / version 不正 / RSID 等) は init/play addr
+  を 0 のまま保持、PLAYER_INIT/PLAY は no-op 化、`SID_PLAYER_READY` で状態確認可
+- sample は SLANG `ARRAY BYTE` でなく `KIO_READ_ADDR` + raw addr ($C000) 流儀で
+  実装 (= ARRAY BYTE 経由だと oscar64 BSS が $1000 領域を占有して HVSC tune
+  loadAddress $1000 系と衝突するため)
+- 任意 6502 addr への動的 jump は oscar64 の C 関数ポインタ呼出経路ではなく
+  zp vector + `JMP ($00fb)` indirect 形式を採用 (= player code を raw 6502 native
+  として直接実行するため)
 
-着手中に踏んだ 3 つの bug と修正 (= v3a/c で未経験の領域):
-1. **char literal の PETSCII 変換**: bridge 内 `psid_eq(buf, 'P', 'S', 'I', 'D')` を
-   書いたが oscar64 `-psci` は char literal も PETSCII 化 (`'P'` → 0xD0) するため
-   disk から読んだ ASCII 0x50 と mismatch して常に false。**16 進値直書きの
-   `is_psid_magic(buf)` (= `p[0] == 0x50 && ...`)** に変更して PETSCII 変換から独立
-2. **C 関数ポインタ呼出が bytecode interpreter (bcexec) に流れる**: oscar64 で
-   `((void(*)(byte))addr)(song)` を書いたが asm 出力で `JSR bcexec` (= oscar64
-   bytecode 実行 routine) に行く → raw 6502 native code に届かず hang。**zp
-   $FB/$FC に target addr 保存 + `__asm { jmp ($00fb) }` 6502 indirect jump** で
-   動的 addr 対応 (= oscar64 sample にある `__asm { jsr $a000 }` literal pattern を
-   そのまま使えない動的 addr ケースの正攻法)
-3. **SLANG `ARRAY BYTE` が $1000 領域を侵食 (= self-destruction)**: SLANG コード
-   で `ARRAY BYTE SID_BUF[4096]` を declare すると oscar64 BSS が $0F90-$1F91 を
-   占有、HVSC tune (= loadAddress $1000 が大半) と完全 overlap。payload memcpy
-   で SID_BUF 自身 + SLANG runtime の global 変数を破壊して reset 様の挙動に。
-   **SLANG コードで ARRAY BYTE を消し、`KIO_READ_ADDR` で $C000 (= 伝統的 free
-   RAM) に直接 disk read + `SID_LOAD_FROM_BUF_ADDR` で raw word addr を bridge
-   に渡す流儀** を採用。 BSS area は $0DA9-$0DC1 (24 byte) まで縮小、$1000 領域
-   free
-
-license 整理:
+**ライセンス運用方針** (= v3b-A と同じ規律継続):
 - bridge / sample SLANG コードはすべて SLANG 側オリジナル実装、MIT 維持
-- HVSC tune は **同梱しない** (= HVSC は全 tune copyright 残存、FAQ Q29 で
-  個別 publisher 許諾必要と明示。SLANG repo に法的 PD 不明な binary を置く
-  ことを避ける)
-- ユーザーが持ち込む `.sid` の copyright / license 整合は user 責務、README
-  / sample コメントに明記
-
-v3b roadmap (= 後続 PR):
-- v3b-C: oscar64 `audio/sidfx` bridge で priority SFX overlay (= `#include
-  <audio/sidfx.h>` 経由参照、sample SIDOVERLAY.SL)
+- HVSC tune は同梱しない、user が手元で個別に持ち込む形態 (= HVSC tune の
+  copyright 整合は user 責務、README / sample コメントで明記)
 
 ### v3b-A — SID 基盤 + 単発 SFX binding (#180 配下)
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ env file `c64.env` が以下を C backend builtin として公開しているた
 | I/O | `PRINT` 全構文 (`"..."` / `/` / `%(v)` / `!(s)` / `HEX2$(v)` / `HEX4$(v)` / `DECI$(v)` / `FORM$(v,n)` / `MSG$(p)` / `MSX$(p)` / `STR$(c,n)` / `CHR$(n)` / `SPC$(n)` / `CR$(n)` / `TAB$(n)` / `FL$(f)` / `PN$(v)`) |
 | 入力 | `INKEY(mode)` (即時状態取得、押下中=値、離した瞬間=0)、`INPUT()` (1 行入力 → 数値 parse、ESC=`$FFFF`)、`GETL(buf)` / `GETLIN(buf, x)` / `LINPUT(buf, x)` (1 行文字列入力、戻り値=入力文字数、ESC=`$FFFF`)。Z80 backend の `_CARRY` 機構は v1 未対応 |
 | ジョイスティック | `JOY_POLL(port)` (1 frame 1 回呼ぶ) + `JOY_DIR(port)` (5 bit bitmask) + `JOY_X(port)` / `JOY_Y(port)` (signed、-1=`$FFFF`) + `JOY_B(port)` (0/1 fire)。bitmask + port 定数は `#INCLUDE "C64_JOY.LIB"` で取得 (`JOY_UP/DOWN/LEFT/RIGHT/FIRE/PORT1/PORT2`)。色定数は別途 `C64_VIC.LIB` |
-| **SID 音源 (基盤)** | 初期化: `SID_INIT_QUIET()` (= 全 register 0 で停止状態)、master volume: `SID_VOLUME(v)` (0..15)、voice direct (voice = 0..2): `SID_FREQ(voice, f)` / `SID_PWM(voice, pw)` (= PULSE 波形時必須、duty 12-bit) / `SID_ADSR(voice, ad, sr)` / `SID_CTRL(voice, ctrl)` / `SID_GATE_ON(voice)` / `SID_GATE_OFF(voice)`、SFX wrapper: `SID_SFX(voice, freq, ad, sr, waveform)` (= ADSR + waveform 設定 + GATE on を 1 関数化、release は user 側 `SID_GATE_OFF` で開始)。frequency は PAL clock 基準の register 値、`NOTE_C2..NOTE_B6` 60 個と ADSR/waveform/CTRL/pwm preset 定数は `#INCLUDE "C64_SID.LIB"` で取得 (= `SID_PWM_SQR` = $0800 で 50% duty)。**PULSE 波形は事前に `SID_PWM` 設定必須** (= pwm=0 だと duty 0% で無音)。HVSC `.sid` 取り込み + BGM 再生は v3b-B で、priority SFX overlay (oscar64 `audio/sidfx` bridge) は v3b-C で対応予定 |
+| **SID 音源 (基盤)** | 初期化: `SID_INIT_QUIET()` (= 全 register 0 で停止状態)、master volume: `SID_VOLUME(v)` (0..15)、voice direct (voice = 0..2): `SID_FREQ(voice, f)` / `SID_PWM(voice, pw)` (= PULSE 波形時必須、duty 12-bit) / `SID_ADSR(voice, ad, sr)` / `SID_CTRL(voice, ctrl)` / `SID_GATE_ON(voice)` / `SID_GATE_OFF(voice)`、SFX wrapper: `SID_SFX(voice, freq, ad, sr, waveform)` (= ADSR + waveform 設定 + GATE on を 1 関数化、release は user 側 `SID_GATE_OFF` で開始)。frequency は PAL clock 基準の register 値、`NOTE_C2..NOTE_B6` 60 個と ADSR/waveform/CTRL/pwm preset 定数は `#INCLUDE "C64_SID.LIB"` で取得 (= `SID_PWM_SQR` = $0800 で 50% duty)。**PULSE 波形は事前に `SID_PWM` 設定必須** (= pwm=0 だと duty 0% で無音)。priority SFX overlay (oscar64 `audio/sidfx` bridge) は v3b-C で対応予定 |
+| **SID 音源 (BGM 再生)** | PSID v2 形式 `.sid` file を disk から KIO で読み込み → `SID_LOAD_FROM_BUF(buf, len)` (= byte_ptr 経由) または `SID_LOAD_FROM_BUF_ADDR(buf_addr, len)` (= raw word addr 経由) で header parse + payload を loadAddress に memcpy + init/play address を bridge 内 static 保存 → `SID_PLAYER_INIT(song)` (= 任意 song で再生開始、内部は zp $FB/$FC vector + `JMP ($00fb)` で raw 6502 indirect jump) → VSYNC loop で `SID_PLAYER_PLAY()` を毎フレーム呼出。`SID_PLAYER_READY()` で load 状態確認可。**重要**: SLANG `ARRAY BYTE BUF[]` 経由だと oscar64 BSS が $1000 領域を占有し loadAddress $1000 系の HVSC tune と衝突するため、sample (SIDBGM.SL) は `KIO_READ_ADDR` で $C000 (= C64 伝統的 free RAM) に直 read + `SID_LOAD_FROM_BUF_ADDR` で raw addr 渡し流儀を採用。RSID (= IRQ-driven、playAddress=0) と multi-SID は v3b-B 非対応。HVSC tune の copyright は残存する (= FAQ Q29、配布は user 責務) ため、SLANG repo に `.sid` 同梱はせず user が手元で持ち込む形態 |
 | **KERNAL file I/O** | open/close: `KIO_OPEN_NAMED(fnum, dev, ch, name)` / `KIO_OPEN(fnum, dev, ch)` / `KIO_SETNAM(name)` / `KIO_CLOSE(fnum)`、channel: `KIO_CHKIN(fnum)` / `KIO_CHKOUT(fnum)` / `KIO_CLRCHN()`、1 byte: `KIO_CHRIN()` / `KIO_CHROUT(ch)` / `KIO_GETCH(fnum)` / `KIO_PUTCH(fnum, ch)`、buffer: `KIO_READ(fnum, buf, n)` / `KIO_WRITE(fnum, buf, n)`、文字列: `KIO_GETS(fnum, buf, n)` / `KIO_PUTS(fnum, str)`、status: `KIO_STATUS()` (= krnioerr 取得)。文字列は NUL terminated PETSCII で **全小文字** で書く (= SLANG リテラル `"score,s,r"` が oscar64 `-psci` 経由で PETSCII unshifted 大文字に変換され 1541 の `,S,R` token parse と整合)。SEQ ファイルの主部は起動 PRG と別名にする (= 1541 emu の同主部 PRG/SEQ 共存制約回避)。bool 系は 0/1、I/O 系はエラー時 SLANG WORD で `$FFFx` (sign extension で届く)。krnioerr / device / channel 定数は `#INCLUDE "C64_KIO.LIB"` で取得。raw address 用 (`KIO_*_ADDR`) も併設 |
 | 端末 | `WIDTH(w)` (no-op = C64 は 40 桁固定)、`LOCATE(x, y)`、`SCREEN(x, y)`、`PRMODE(m)` |
 | 数学 | `ABS / SQR / SIN / COS / TAN / LOG / EXP / ATN / RND / SRND` |
@@ -241,14 +242,23 @@ slangbuild -E c64 -I include examples/c64/SPRITE.SL  -o examples/c64/SPRITE
 slangbuild -E c64 -I include examples/c64/FMANDEL.SL -o examples/c64/FMANDEL
 slangbuild -E c64 -I include examples/c64/JOYSPR.SL  -o examples/c64/JOYSPR
 slangbuild -E c64 -I include examples/c64/SIDSFX.SL  -o examples/c64/SIDSFX
+slangbuild -E c64 -I include examples/c64/SIDBGM.SL  -o examples/c64/SIDBGM
 slangbuild -E c64 -I include examples/c64/HISCORE.SL -o examples/c64/HISCORE
 x64sc -autostart examples/c64/SPRITE.prg          # VICE (sprite/FMANDEL/JOYSPR/SIDSFX)
-# HISCORE は KERNAL file I/O で D64 が必要、autostart 不可 (= virtual drive モードで
-# 干渉する)。c1541 で空 D64 + PRG を入れて、x64sc -8 で attach + 手動 LOAD/RUN:
+# HISCORE / SIDBGM は KERNAL file I/O で D64 が必要、autostart 不可 (= virtual drive
+# モードで干渉する)。c1541 で空 D64 + PRG を入れて、x64sc -8 で attach + 手動 LOAD/RUN:
 c1541 -format "hiscore,01" d64 disks/hiscore.d64 -write examples/c64/HISCORE.prg hiscore
 x64sc -8 disks/hiscore.d64
 # BASIC 上で:
 LOAD"hiscore",8
+RUN
+# SIDBGM は HVSC 等から user が好きな .sid を手元に取得して D64 に同梱する形態
+# (= SLANG repo に tune は同梱しない、HVSC tune の copyright は user 責務):
+c1541 -format "bgm,01" d64 disks/sidbgm.d64 \
+      -write examples/c64/SIDBGM.prg sidbgm \
+      -write /path/to/your_tune.sid music
+x64sc -8 disks/sidbgm.d64
+LOAD"sidbgm",8
 RUN
 ```
 
@@ -301,9 +311,9 @@ slangbuild -E c64 myapp.SL --c-source mylib.c -o myapp
 
 ### v1 スコープと制約
 
-**動作確認済**: PRINT / INPUT / 整数算術 / FLOAT 演算 / リアルタイム key 入力 / sprite (1 個アニメ、VSYNC 同期) / joystick 入力 / KERNAL file I/O (save/load 往復) / SID 単発 SFX (= 音色 preset 切替) + ユーザー C 任意関数 (= CFUNC + `--c-source`)。`examples/FMANDEL.SL` / `examples/FURUI.SL` / `examples/STARS.SL` / `examples/c64/SPRITE.SL` / `examples/c64/FMANDEL.SL` (= 40 桁版) / `examples/c64/JOYSPR.SL` (= joystick) / `examples/c64/SIDSFX.SL` (= SID 単発 SFX) / `examples/c64/HISCORE.SL` (= KERNAL file I/O) が実機 (VICE) で動作。
+**動作確認済**: PRINT / INPUT / 整数算術 / FLOAT 演算 / リアルタイム key 入力 / sprite (1 個アニメ、VSYNC 同期) / joystick 入力 / KERNAL file I/O (save/load 往復) / SID 単発 SFX (= 音色 preset 切替) / HVSC `.sid` BGM 再生 (= disk load 経由) + ユーザー C 任意関数 (= CFUNC + `--c-source`)。`examples/FMANDEL.SL` / `examples/FURUI.SL` / `examples/STARS.SL` / `examples/c64/SPRITE.SL` / `examples/c64/FMANDEL.SL` (= 40 桁版) / `examples/c64/JOYSPR.SL` (= joystick) / `examples/c64/SIDSFX.SL` (= SID 単発 SFX) / `examples/c64/SIDBGM.SL` (= HVSC SID BGM) / `examples/c64/HISCORE.SL` (= KERNAL file I/O) が実機 (VICE) で動作。
 
-**未対応 / 今後の拡張**: sprite multiplex / VIC bitmap mode / HVSC `.sid` BGM 再生 (= v3b-B 予定) / priority SFX overlay (= v3b-C 予定、oscar64 `audio/sidfx` bridge) / CRT / overlay (`#MODULE`)。これらは bridge 関数を追加する形で順次対応予定。
+**未対応 / 今後の拡張**: sprite multiplex / VIC bitmap mode / priority SFX overlay (= v3b-C 予定、oscar64 `audio/sidfx` bridge) / CRT / overlay (`#MODULE`)。これらは bridge 関数を追加する形で順次対応予定。
 
 **Z80 固有機能**: `MACHINE` 宣言 / inline `#ASM` ブロック / `PORT IN/OUT` / `#MODULE` を含む SLANG コードは C backend では診断 error。`#IF BACKEND==1` (= OscarC) または `#IF ENV_TYPE==7` (= c64) で C backend 専用コードを gate できます (`BACKEND` は env で自動定義: 0=Z80、1=OscarC)。
 

--- a/examples/c64/SIDBGM.SL
+++ b/examples/c64/SIDBGM.SL
@@ -1,0 +1,121 @@
+// Commodore 64 HVSC SID BGM demo (oscar64 backend、env c_bindings: 経由)
+//
+// disk から PSID v2 .sid file を読み込み → header parse + payload を
+// loadAddress に memcpy → init/play address を bridge 内 static 保存 →
+// VSYNC ループで毎フレーム play 呼出、というBGM再生フローの最小 sample。
+//
+// 重要 (= memory layout の制約):
+//   SLANG コード側で `ARRAY BYTE BUF[4096]` 等を declare すると、oscar64 が
+//   生成する BSS が $0F78-$1F91 等の領域を占有し、HVSC tune (= loadAddress
+//   $1000 系が多数) の payload を memcpy する際に **SLANG runtime の global
+//   変数を破壊** する (= self-destruction)。これを回避するため、本 sample は
+//   `KIO_READ_ADDR` で $C000 (= C64 伝統的 free RAM、BASIC / KERNAL いずれも
+//   未使用) に disk 直 read し、`SID_LOAD_FROM_BUF_ADDR` で raw addr を bridge
+//   に渡す形を取る。loadAddress > $2000 系 tune だけ扱うなら通常の ARRAY BYTE
+//   経由でも動くが、$1000 系も扱えるよう本 sample は raw addr 流儀を採用。
+//
+// 用意するもの (= user 側の準備、SLANG repo には .sid 同梱しない):
+//   - HVSC (= https://www.hvsc.c64.org/) 等から PSID v2 .sid file を 1 つ
+//     手元に取得 (= 4KB 以内、playAddress != 0)
+//     ※ HVSC の tune はすべて copyright 残存 (= FAQ Q29、配布物に埋め込まず
+//        user 環境で個別に持ち込む形態)
+//   - c1541 で空の D64 image に .sid を PRG として書き込む:
+//       c1541 -format "bgm,01" d64 /tmp/sidbgm.d64 \
+//             -write examples/c64/SIDBGM.prg sidbgm \
+//             -write your_tune.sid music
+//   - VICE 起動:
+//       x64sc -8 /tmp/sidbgm.d64
+//       LOAD"sidbgm",8
+//       RUN
+//
+// 操作:
+//   起動 = song 0 で再生開始
+//   1..9 = song 切替 (= multi-song の .sid のみ意味あり)
+//
+// Build (= checkout 状態 / repo root から実行):
+//   slangbuild -E c64 -I include examples/c64/SIDBGM.SL -o examples/c64/SIDBGM
+
+#INCLUDE "C64_KIO.LIB"
+#INCLUDE "C64_SID.LIB"
+
+CONST FILE_NUM  = 2;
+CONST BUF_ADDR  = $C000;         // 伝統的 free RAM area (= 4KB)、SLANG BSS と衝突しない
+CONST BUF_SIZE  = 4096;
+
+MAIN()
+{
+    VAR OK, N, K, SONG;
+
+    // 1. disk から "music" PRG を $C000 領域に直 read (= SLANG ARRAY 経由せず、
+    //    SLANG runtime の BSS と衝突しない free area を使う)
+    OK = KIO_OPEN_NAMED(FILE_NUM, DEV_DISK, CH_READ, "music,p,r");
+    IF OK == 0 THEN
+    {
+        PRINT("OPEN FAIL ST=");
+        PRINT(KIO_STATUS());
+        PRINT(/);
+        KIO_CLOSE(FILE_NUM);
+        RETURN;
+    }
+
+    IF KIO_CHKIN(FILE_NUM) == 0 THEN
+    {
+        PRINT("CHKIN FAIL ST=");
+        PRINT(KIO_STATUS());
+        PRINT(/);
+        KIO_CLOSE(FILE_NUM);
+        RETURN;
+    }
+
+    N = KIO_READ_ADDR(FILE_NUM, BUF_ADDR, BUF_SIZE);
+    KIO_CLRCHN();
+    KIO_CLOSE(FILE_NUM);
+
+    IF N AND $8000
+    {
+        PRINT("READ ERR ST=");
+        PRINT(KIO_STATUS());
+        PRINT(/);
+        RETURN;
+    }
+
+    // 2. PSID v2 header parse + payload を loadAddress に memcpy + init/play addr 保存
+    OK = SID_LOAD_FROM_BUF_ADDR(BUF_ADDR, N);
+    IF OK == 0 THEN
+    {
+        PRINT("SID PARSE FAIL");
+        PRINT(/);
+        PRINT("(PSID V2 + PLAYADDR!=0 REQUIRED)");
+        PRINT(/);
+        RETURN;
+    }
+
+    // 3. SID 全 register 0 にして安全状態 + master volume max + player init (song 0)
+    SID_INIT_QUIET();
+    SID_VOLUME(15);
+    SONG = 0;
+    SID_PLAYER_INIT(SONG);
+
+    PRINT("PLAYING (1-9 SWITCH SONG)");
+    PRINT(/);
+
+    // 4. VSYNC loop で player の play() を毎フレーム呼出 (= 50Hz tick)
+    LOOP
+    {
+        VIC_WAIT();
+        SID_PLAYER_PLAY();
+
+        // 1..9 キーで song 切替 (= multi-song の .sid 用)
+        K = INKEY(0);
+        IF K >= 49 THEN
+        {
+            IF K <= 57 THEN
+            {
+                SONG = K - 49;        // '1'..'9' → 0..8
+                SID_INIT_QUIET();
+                SID_VOLUME(15);
+                SID_PLAYER_INIT(SONG);
+            }
+        }
+    }
+}

--- a/runtime/c64/slang_sid.c
+++ b/runtime/c64/slang_sid.c
@@ -74,3 +74,120 @@ void slang_sid_sfx(unsigned char voice, unsigned int freq,
         sid.voices[voice].ctrl = (unsigned char)(waveform | SID_CTRL_GATE);
     }
 }
+
+/* === HVSC .sid BGM 再生 (v3b-B) === */
+
+/* bridge 内 static に保存する .sid player の init / play address。
+ * slang_sid_load_from_buf 成功時にセット、SLANG_PLAYER_INIT/PLAY で参照。 */
+static unsigned int g_sid_init_addr = 0;
+static unsigned int g_sid_play_addr = 0;
+
+/* PSID v2 magic check (= "PSID" の ASCII bytes、PETSCII 変換と独立)。
+ * oscar64 `-psci` 配下では char literal 'P' 等が PETSCII 大文字 (= 0xD0 等の
+ * shifted 領域) に変換される挙動があるため、SLANG リテラル形式での比較は
+ * 使えない。バイナリ disk file の magic は ASCII で書かれているので、ここは
+ * 16 進値直書きで比較する。 */
+static unsigned char is_psid_magic(const unsigned char *p)
+{
+    /* "PSID" = 0x50 0x53 0x49 0x44 (ASCII)、buf 先頭の disk byte と直接比較。 */
+    return (unsigned char)(p[0] == 0x50 && p[1] == 0x53
+                        && p[2] == 0x49 && p[3] == 0x44);
+}
+
+unsigned int slang_sid_load_from_buf(unsigned char *buf, unsigned int len)
+{
+    /* 最低 header 0x7C + payload 先頭 (loadAddr 0 の場合) 2 byte は欲しい。 */
+    if (len < 0x7E) return 0;
+
+    /* magic: PSID v2 のみ accept、RSID は IRQ driven の通常 program 形式で
+     * v3b-B の bridge 経由再生と動作が違うため非対応。 */
+    if (!is_psid_magic(buf)) return 0;
+
+    /* version は BE WORD で 1 or 2 を許容。v3 以降は未検証なので reject。 */
+    unsigned int version = ((unsigned int)buf[0x04] << 8) | buf[0x05];
+    if (version < 1 || version > 2) return 0;
+
+    unsigned int data_offset = ((unsigned int)buf[0x06] << 8) | buf[0x07];
+    unsigned int load_addr   = ((unsigned int)buf[0x08] << 8) | buf[0x09];
+    unsigned int init_addr   = ((unsigned int)buf[0x0A] << 8) | buf[0x0B];
+    unsigned int play_addr   = ((unsigned int)buf[0x0C] << 8) | buf[0x0D];
+
+    /* playAddress = 0 は IRQ-driven (RSID 様)、v3b-B 非対応。 */
+    if (play_addr == 0) return 0;
+
+    if (data_offset >= len) return 0;
+
+    unsigned char *payload = buf + data_offset;
+    unsigned int payload_len = len - data_offset;
+
+    if (load_addr == 0) {
+        /* PSID 仕様: header loadAddress = 0 のとき、payload 先頭 2 byte (LE WORD)
+         * が実 loadAddress、残りが実 payload。 */
+        if (payload_len < 2) return 0;
+        load_addr = (unsigned int)payload[0] | ((unsigned int)payload[1] << 8);
+        payload += 2;
+        payload_len -= 2;
+    }
+
+    /* payload を load_addr に memcpy (= C64 64KB address space に直接書込)。 */
+    volatile unsigned char *dst = (volatile unsigned char *)load_addr;
+    for (unsigned int i = 0; i < payload_len; i++) {
+        dst[i] = payload[i];
+    }
+
+    g_sid_init_addr = init_addr;
+    g_sid_play_addr = play_addr;
+    return 1;
+}
+
+/* JMP indirect 用 zero page vector slot。
+ * $FB-$FE は KERNAL でも BASIC でも未使用の "free" zp として伝統的に使われる
+ * (C64 PRG 開発者向けの公式 reference でも safe 領域として案内)。oscar64 user
+ * code は zp $20-$7F を使うので competition なし。 */
+#define SLANG_SID_INIT_VEC 0x00FB
+#define SLANG_SID_PLAY_VEC 0x00FD
+
+void slang_sid_player_init(unsigned char song)
+{
+    /* oscar64 の C 関数ポインタ呼出 (= ((void(*)(byte))addr)(song)) は
+     * 内部 bytecode interpreter (bcexec) へ JSR されてしまい raw 6502 code には
+     * 飛ばないため、6502 indirect jump (JMP ($xxxx)) で実装する。
+     * .sid load 未成功時は no-op。 */
+    if (g_sid_init_addr == 0) return;
+
+    /* zp $FB/$FC に init address (LE) を書き込んでから JMP indirect。
+     * SID player init code は RTS で帰る (= 既存 stack の caller return addr へ)。 */
+    *((volatile unsigned char *)(SLANG_SID_INIT_VEC + 0)) =
+        (unsigned char)(g_sid_init_addr & 0xFF);
+    *((volatile unsigned char *)(SLANG_SID_INIT_VEC + 1)) =
+        (unsigned char)((g_sid_init_addr >> 8) & 0xFF);
+
+    __asm {
+        lda song
+        jmp ($00fb)
+    }
+}
+
+void slang_sid_player_play(void)
+{
+    if (g_sid_play_addr == 0) return;
+
+    *((volatile unsigned char *)(SLANG_SID_PLAY_VEC + 0)) =
+        (unsigned char)(g_sid_play_addr & 0xFF);
+    *((volatile unsigned char *)(SLANG_SID_PLAY_VEC + 1)) =
+        (unsigned char)((g_sid_play_addr >> 8) & 0xFF);
+
+    __asm {
+        jmp ($00fd)
+    }
+}
+
+unsigned int slang_sid_player_ready(void)
+{
+    return (g_sid_init_addr != 0 && g_sid_play_addr != 0) ? 1 : 0;
+}
+
+unsigned int slang_sid_load_from_buf_addr(unsigned int buf_addr, unsigned int len)
+{
+    return slang_sid_load_from_buf((unsigned char *)buf_addr, len);
+}

--- a/runtime/c64/slang_sid.h
+++ b/runtime/c64/slang_sid.h
@@ -77,4 +77,43 @@ void slang_sid_gate_off(unsigned char voice);
 void slang_sid_sfx(unsigned char voice, unsigned int freq,
                    unsigned char ad, unsigned char sr, unsigned char waveform);
 
+/* === HVSC .sid BGM 再生 (v3b-B) === */
+
+/* PSID v2 .sid file (buf, len) を parse して payload を loadAddress に配置、
+ * init/play address を bridge 内 static に保存する。
+ *
+ * PSID header layout (BE WORD):
+ *   0x00-0x03: magic ("PSID")  -- "RSID" は v3b-B 非対応 (= playAddr=0 の通常 program 形式)
+ *   0x06-0x07: dataOffset       -- 通常 0x007C
+ *   0x08-0x09: loadAddress      -- 0 なら payload 先頭 2 byte (LE WORD) が実 loadAddress
+ *   0x0A-0x0B: initAddress
+ *   0x0C-0x0D: playAddress      -- 0 なら IRQ-driven (RSID 様、v3b-B 非対応)
+ *
+ * 戻り値: 1 = 成功 / 0 = 失敗 (= magic 不一致、version > 2、 playAddr=0 等)。
+ * 失敗時は init/play addr が 0 のまま、後続 PLAYER_INIT/PLAY は no-op 化。
+ * 検証は slang_sid_player_ready() で個別取得可能。 */
+unsigned int slang_sid_load_from_buf(unsigned char *buf, unsigned int len);
+
+/* SID_LOAD_FROM_BUF 成功時に bridge 内に保存された init address を呼び出す
+ * (= A レジスタに song 番号を入れて JSR initAddress 相当)。.sid file 1 つで
+ * 複数 song を含む場合は song = 0..(songs-1) で切替。 */
+void slang_sid_player_init(unsigned char song);
+
+/* SID_LOAD_FROM_BUF 成功時に bridge 内に保存された play address を呼び出す
+ * (= JSR playAddress 相当)。毎フレーム (VSYNC 後) 呼ぶことで music が進行する。
+ * 通常は PAL 50Hz / NTSC 60Hz クロック前提、v3b-B は VIC_WAIT() 連動で 50Hz 想定。 */
+void slang_sid_player_play(void);
+
+/* SID_LOAD_FROM_BUF が成功して player ready 状態かを返す (1 = ready / 0 = not loaded
+ * or load 失敗)。SLANG コード側で再生開始前の状態判定に使う。 */
+unsigned int slang_sid_player_ready(void);
+
+/* SID_LOAD_FROM_BUF の raw address 版。SLANG コードで `ARRAY BYTE BUF[]` を
+ * declare すると oscar64 の BSS が $0F78-$1F91 等の領域を占有してしまい、
+ * Hoopsidasies (= loadAddress $1000 系) の payload memcpy で SLANG runtime の
+ * global 変数を破壊する。回避策として KIO_READ_ADDR で raw addr ($C000 等の
+ * SLANG runtime と衝突しない free RAM area) に disk read してから、本関数に
+ * その raw addr を渡して bridge 側で PSID parse + memcpy する。 */
+unsigned int slang_sid_load_from_buf_addr(unsigned int buf_addr, unsigned int len);
+
 #endif /* SLANG_SID_H */

--- a/runtime/env/c64.env
+++ b/runtime/env/c64.env
@@ -239,6 +239,37 @@ c_bindings:
     params: [byte, word, byte, byte, byte]
     return: void
 
+  # === HVSC .sid disk load + BGM 再生 (v3b-B) ===
+  # KIO 経由で disk から .sid file を読み込み、PSID header parse + payload を
+  # loadAddress に memcpy + init/play addr を bridge 内 static 保持して player
+  # 再生する。tune 自体は SLANG repo に同梱しない (= user が HVSC 等から手元で
+  # 取得して D64 に入れる前提、license は user 責務)。
+  # PSID v2 only (= RSID 非対応)、シングル SID のみ (= multi-SID 非対応)、
+  # PAL 50Hz 想定 (= VIC_WAIT 連動)。
+  - name: SID_LOAD_FROM_BUF
+    c_name: slang_sid_load_from_buf
+    params: [byte_ptr, word]
+    return: word
+  - name: SID_PLAYER_INIT
+    c_name: slang_sid_player_init
+    params: [byte]
+    return: void
+  - name: SID_PLAYER_PLAY
+    c_name: slang_sid_player_play
+    params: []
+    return: void
+  - name: SID_PLAYER_READY
+    c_name: slang_sid_player_ready
+    params: []
+    return: word
+  # raw address 版 (= SLANG ARRAY BYTE 経由だと oscar64 BSS が $1000 領域を
+  # 占有して HVSC tune (loadAddr $1000) と衝突するため、KIO_READ_ADDR で
+  # $C000 等の free RAM に直接 disk read してから本関数に渡す)
+  - name: SID_LOAD_FROM_BUF_ADDR
+    c_name: slang_sid_load_from_buf_addr
+    params: [word, word]
+    return: word
+
   # INPUT / GETL / GETLIN / LINPUT (SLANG Z80 backend と signature 互換)
   # ESC キーで $FFFF を返す。Z80 backend の `_CARRY` 機構は v1 未対応。
   - name: INPUT

--- a/tests/SLANGCompiler.Tests/SidBindingTests.cs
+++ b/tests/SLANGCompiler.Tests/SidBindingTests.cs
@@ -19,7 +19,8 @@ public class SidBindingTests
     {
         // 実 runtime/env/c64.env をパースする代わりに、テスト独立性のために
         // 必要 binding だけ手組み (= env file 解析テストは EnvCBindingsTests で別途網羅)。
-        // v3b-A スコープの 9 entry (= SID register direct 8 + 単発 SFX wrapper 1) を網羅。
+        // v3b-A 9 entry (= register direct 8 + 単発 SFX wrapper 1) +
+        // v3b-B 4 entry (= HVSC .sid disk load + player) = 計 13 entry を網羅。
         return new EnvironmentConfig
         {
             Name = "c64",
@@ -54,6 +55,22 @@ public class SidBindingTests
                 new() { Name = "SID_SFX", CName = "slang_sid_sfx",
                         Params = new List<CBindingType> { CBindingType.Byte, CBindingType.Word, CBindingType.Byte, CBindingType.Byte, CBindingType.Byte },
                         Return = CBindingType.Void },
+                // v3b-B: HVSC .sid disk load + BGM player
+                new() { Name = "SID_LOAD_FROM_BUF", CName = "slang_sid_load_from_buf",
+                        Params = new List<CBindingType> { CBindingType.BytePtr, CBindingType.Word },
+                        Return = CBindingType.Word },
+                new() { Name = "SID_PLAYER_INIT", CName = "slang_sid_player_init",
+                        Params = new List<CBindingType> { CBindingType.Byte },
+                        Return = CBindingType.Void },
+                new() { Name = "SID_PLAYER_PLAY", CName = "slang_sid_player_play",
+                        Params = new List<CBindingType>(),
+                        Return = CBindingType.Void },
+                new() { Name = "SID_PLAYER_READY", CName = "slang_sid_player_ready",
+                        Params = new List<CBindingType>(),
+                        Return = CBindingType.Word },
+                new() { Name = "SID_LOAD_FROM_BUF_ADDR", CName = "slang_sid_load_from_buf_addr",
+                        Params = new List<CBindingType> { CBindingType.Word, CBindingType.Word },
+                        Return = CBindingType.Word },
             },
         };
     }
@@ -79,11 +96,13 @@ public class SidBindingTests
     [Fact]
     public void SidAll_EmitsExternsAndCalls()
     {
-        // SID 9 binding を SLANG コード上で実呼出して CTranspiler が extern を
-        // 必ず emit するパスを通す。byte / word 引数の組合せ + void return を網羅。
+        // SID 14 binding (= v3b-A 9 + v3b-B 5) を SLANG コード上で実呼出して
+        // CTranspiler が extern を必ず emit するパスを通す。byte / word /
+        // byte_ptr 引数の組合せ + void / word return を網羅。
         var src = TranspileWithEnv("""
+            ARRAY BYTE BUF[16];
             MAIN() {
-                VAR I, F;
+                VAR OK, R;
                 SID_INIT_QUIET();
                 SID_VOLUME(15);
                 SID_FREQ(0, $1D44);
@@ -93,6 +112,11 @@ public class SidBindingTests
                 SID_GATE_ON(0);
                 SID_GATE_OFF(1);
                 SID_SFX(2, $22C9, $20, $A8, $80);
+                OK = SID_LOAD_FROM_BUF(BUF, 16);
+                OK = SID_LOAD_FROM_BUF_ADDR($C000, 1024);
+                SID_PLAYER_INIT(0);
+                SID_PLAYER_PLAY();
+                R = SID_PLAYER_READY();
             }
             """, MakeC64EnvWithSid(), out var diag);
 
@@ -100,7 +124,8 @@ public class SidBindingTests
             $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
 
         // bridge header (runtime/c64/slang_sid.h) の signature と env c_bindings: が
-        // drift していないことを 9 entry すべての extern 出力で確認。
+        // drift していないことを 13 entry すべての extern 出力で確認。
+        // === v3b-A: register direct + SFX wrapper (9 個) ===
         Assert.Contains("extern void slang_sid_init_quiet(void);", src);
         Assert.Contains("extern void slang_sid_volume(unsigned char);", src);
         Assert.Contains("extern void slang_sid_freq(unsigned char, unsigned int);", src);
@@ -110,17 +135,28 @@ public class SidBindingTests
         Assert.Contains("extern void slang_sid_gate_on(unsigned char);", src);
         Assert.Contains("extern void slang_sid_gate_off(unsigned char);", src);
         Assert.Contains("extern void slang_sid_sfx(unsigned char, unsigned int, unsigned char, unsigned char, unsigned char);", src);
+        // === v3b-B: HVSC .sid disk load + BGM player (5 個) ===
+        Assert.Contains("extern unsigned int slang_sid_load_from_buf(unsigned char *, unsigned int);", src);
+        Assert.Contains("extern unsigned int slang_sid_load_from_buf_addr(unsigned int, unsigned int);", src);
+        Assert.Contains("extern void slang_sid_player_init(unsigned char);", src);
+        Assert.Contains("extern void slang_sid_player_play(void);", src);
+        Assert.Contains("extern unsigned int slang_sid_player_ready(void);", src);
 
-        // 呼出が C 関数として展開される (9 個すべて)
-        Assert.Contains("slang_sid_init_quiet(", src);
-        Assert.Contains("slang_sid_volume(",     src);
-        Assert.Contains("slang_sid_freq(",       src);
-        Assert.Contains("slang_sid_pwm(",        src);
-        Assert.Contains("slang_sid_adsr(",       src);
-        Assert.Contains("slang_sid_ctrl(",       src);
-        Assert.Contains("slang_sid_gate_on(",    src);
-        Assert.Contains("slang_sid_gate_off(",   src);
-        Assert.Contains("slang_sid_sfx(",        src);
+        // 呼出が C 関数として展開される (14 個すべて)
+        Assert.Contains("slang_sid_init_quiet(",         src);
+        Assert.Contains("slang_sid_volume(",             src);
+        Assert.Contains("slang_sid_freq(",               src);
+        Assert.Contains("slang_sid_pwm(",                src);
+        Assert.Contains("slang_sid_adsr(",               src);
+        Assert.Contains("slang_sid_ctrl(",               src);
+        Assert.Contains("slang_sid_gate_on(",            src);
+        Assert.Contains("slang_sid_gate_off(",           src);
+        Assert.Contains("slang_sid_sfx(",                src);
+        Assert.Contains("slang_sid_load_from_buf(",      src);
+        Assert.Contains("slang_sid_load_from_buf_addr(", src);
+        Assert.Contains("slang_sid_player_init(",        src);
+        Assert.Contains("slang_sid_player_play(",        src);
+        Assert.Contains("slang_sid_player_ready(",       src);
     }
 
     [Fact]
@@ -141,13 +177,17 @@ public class SidBindingTests
         Assert.Contains(config.CRuntimeFiles!,
             p => Path.GetFileName(p).Equals("slang_sid.c", StringComparison.OrdinalIgnoreCase));
 
-        // c_bindings に SID_* 9 entry がすべて含まれる
+        // c_bindings に SID_* 14 entry (= v3b-A 9 + v3b-B 5) がすべて含まれる
         Assert.NotNull(config.CBindings);
         var bindingNames = config.CBindings!.Select(b => b.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
         foreach (var expected in new[]
         {
+            // v3b-A
             "SID_INIT_QUIET", "SID_VOLUME", "SID_FREQ", "SID_PWM", "SID_ADSR",
             "SID_CTRL", "SID_GATE_ON", "SID_GATE_OFF", "SID_SFX",
+            // v3b-B
+            "SID_LOAD_FROM_BUF", "SID_LOAD_FROM_BUF_ADDR",
+            "SID_PLAYER_INIT", "SID_PLAYER_PLAY", "SID_PLAYER_READY",
         })
         {
             Assert.Contains(expected, bindingNames);
@@ -174,6 +214,24 @@ public class SidBindingTests
         Assert.Equal(2, sidFreq.Params.Count);
         Assert.Equal(CBindingType.Byte, sidFreq.Params[0]);
         Assert.Equal(CBindingType.Word, sidFreq.Params[1]);
+
+        // v3b-B signature pinning
+        var sidLoadFromBuf = config.CBindings!.First(b => b.Name == "SID_LOAD_FROM_BUF");
+        Assert.Equal("slang_sid_load_from_buf", sidLoadFromBuf.CName);
+        Assert.Equal(2, sidLoadFromBuf.Params.Count);
+        Assert.Equal(CBindingType.BytePtr, sidLoadFromBuf.Params[0]);
+        Assert.Equal(CBindingType.Word, sidLoadFromBuf.Params[1]);
+        Assert.Equal(CBindingType.Word, sidLoadFromBuf.Return);
+
+        var sidPlayerPlay = config.CBindings!.First(b => b.Name == "SID_PLAYER_PLAY");
+        Assert.Equal("slang_sid_player_play", sidPlayerPlay.CName);
+        Assert.Empty(sidPlayerPlay.Params);
+        Assert.Equal(CBindingType.Void, sidPlayerPlay.Return);
+
+        var sidPlayerReady = config.CBindings!.First(b => b.Name == "SID_PLAYER_READY");
+        Assert.Equal("slang_sid_player_ready", sidPlayerReady.CName);
+        Assert.Empty(sidPlayerReady.Params);
+        Assert.Equal(CBindingType.Word, sidPlayerReady.Return);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

ロードマップ #178 配下の v3b (Issue #180) を 3 分割した 2 回目 v3b-B として、HVSC PSID v2 `.sid` file を disk から読み込んで BGM 再生する bridge と sample を追加します (実機 VICE で Hoopsidasies.sid 動作確認済)。

- `runtime/c64/slang_sid.{h,c}` に 5 関数追加: `SID_LOAD_FROM_BUF` (= `byte_ptr` 引数で PSID v2 parse + payload memcpy + init/play addr 保存) / `SID_LOAD_FROM_BUF_ADDR` (= 同等機能の `word` raw addr 引数版) / `SID_PLAYER_INIT(song)` / `SID_PLAYER_PLAY()` / `SID_PLAYER_READY()`
- `runtime/env/c64.env`: c_bindings に 5 entry 追加 (= SID 全体で 14 entry)
- 新規 `examples/c64/SIDBGM.SL`: disk から "music" PRG を `KIO_READ_ADDR` で $C000 (= C64 伝統的 free RAM) に直接 read → `SID_LOAD_FROM_BUF_ADDR` → `SID_PLAYER_INIT(0)` → VSYNC loop で `SID_PLAYER_PLAY`、1-9 キーで song 切替
- `tests/SLANGCompiler.Tests/SidBindingTests.cs`: 14 binding の extern + 呼出展開 + signature pin

## 設計判断

- **PSID v2 only** (= RSID / playAddress=0 形式は非対応)、シングル SID のみ
- **PAL 50Hz 想定** (= VIC_WAIT 連動)、NTSC では音高ずれ許容
- **任意 6502 addr への動的 jump** は zp $FB/$FC vector + `JMP ($00fb)` 6502 indirect 経由 (= oscar64 の C 関数ポインタ呼出は bytecode interpreter 経由で raw 6502 に届かないため、 player code を native として直接実行するために必要)
- **sample は `KIO_READ_ADDR` + raw addr ($C000) 流儀** で実装 (= SLANG `ARRAY BYTE` 経由だと oscar64 BSS が $1000 領域を占有し HVSC tune の loadAddress $1000 系と衝突するため)

## License 運用方針 (= v3b-A と同じ規律継続)

- bridge / sample SLANG コードはすべて SLANG 側オリジナル実装、MIT 維持
- HVSC tune は同梱しない (= HVSC FAQ Q29 で全 tune copyright 残存明示)、user が手元で個別に持ち込む形態。`.sid` の copyright / license 整合は user 責務

## Test plan

- [x] dotnet test 全 **376 tests pass** (= 既存 + SidBindingTests 2 件更新、regression なし)
- [x] smoke build (Os 最適化、SIDBGM.prg 1450 byte)
- [x] 実機 VICE で Hoopsidasies.sid (= PSID v2 / loadAddr=$1000 / playAddr=$1006) 再生確認
- [ ] 配布版 install 後 (= SLANG_HOME 設定済) で `-I include` 省略可動作 (= 別途配布版テスト)
- [ ] Codex review 反映 (= レビュー依頼後)

Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)