### PR TITLE
Support ARRAY BYTE initializer in oscar_c backend (v3b-D, #180 配下)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 
 - `src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs` の `VisitArrayDecl` / `EmitStaticDecl` で `ARRAY BYTE NAME[N] = { 値, %値, ... }` 初期化を C array init (`= { 0xNN, ... }`) に展開。default は 1 byte、`%` prefix (= `CastExpr(TargetSize: Word)`) で LE 2 byte。`ConstEvaluator` で式評価するため CONST 参照や `OR` 式も対応
 - v3b-D scope: ARRAY BYTE のみ (= ARRAY WORD / ARRAY FLOAT / `%%` FLOAT 要素 / StringLiteral / 非定数式 は引き続き error)
-- 新規 `tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs` (11 ケース): BYTE 列のみ / `%WORD` prefix 混在 / CONST OR 式 / 関数内 static / ARRAY FLOAT reject / unsized + InitialCode (= 固定配列化) / 容量超過 error / 不足は 0 fill / ARRAY 宣言 symbol への代入 reject (固定サイズ + unsized) / VAR ポインタ代入 regression なし
+- 新規 `tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs` (14 ケース): BYTE 列のみ / `%WORD` prefix 混在 / CONST OR 式 / 関数内 static / ARRAY FLOAT reject / unsized + InitialCode (= 固定配列化) / 容量超過 error / 不足は 0 fill / ARRAY 宣言 symbol への代入 reject (global 固定サイズ + global unsized + 関数内 static 固定サイズ + 関数内 static unsized) / VAR ポインタ代入 regression なし (global + 関数内 static)
 
 これにより v3b-C で `audio/sidfx.h` の `SIDFX` struct (= WORD 2 個 + BYTE 8 個程度の 14 byte 構造) を SLANG コード上で自然に書ける流儀が用意できる。
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,14 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 - `examples/c64/SIDSFX.SL` (= v3b-A) joystick で sprite 移動 + fire ボタンで voice 0 SFX 発射 + 1/2/3 キーで音色 preset 切替 (= laser/boom/noise の 3 種類)
 - `examples/c64/SIDBGM.SL` (= v3b-B) disk から PSID v2 `.sid` file を KIO 経由で読み込み → header parse + payload 配置 → VSYNC loop で player 駆動して BGM 再生 (= HVSC tune を user 持込で動作確認)
 
+### v3b-D — ARRAY BYTE initializer の oscar_c backend 対応 (#180 配下)
+
+- `src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs` の `VisitArrayDecl` / `EmitStaticDecl` で `ARRAY BYTE NAME[N] = { 値, %値, ... }` 初期化を C array init (`= { 0xNN, ... }`) に展開。default は 1 byte、`%` prefix (= `CastExpr(TargetSize: Word)`) で LE 2 byte。`ConstEvaluator` で式評価するため CONST 参照や `OR` 式も対応
+- v3b-D scope: ARRAY BYTE のみ (= ARRAY WORD / ARRAY FLOAT / `%%` FLOAT 要素 / StringLiteral / 非定数式 は引き続き error)
+- 新規 `tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs`: 全 BYTE / WORD prefix 混在 / CONST OR 式 / 関数内 static / scope 外 (ARRAY FLOAT) reject の 5 ケース
+
+これにより v3b-C で `audio/sidfx.h` の `SIDFX` struct (= WORD 2 個 + BYTE 8 個程度の 14 byte 構造) を SLANG コード上で自然に書ける流儀が用意できる。
+
 ### v3b-B — HVSC .sid disk load + BGM 再生 (#180 配下)
 
 - `runtime/c64/slang_sid.{h,c}` に 5 関数追加: `slang_sid_load_from_buf` (= PSID

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,7 @@ Z80 専用だった SLANG コンパイラに **Commodore 64 (6502)** 対応を�
 
 - `src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs` の `VisitArrayDecl` / `EmitStaticDecl` で `ARRAY BYTE NAME[N] = { 値, %値, ... }` 初期化を C array init (`= { 0xNN, ... }`) に展開。default は 1 byte、`%` prefix (= `CastExpr(TargetSize: Word)`) で LE 2 byte。`ConstEvaluator` で式評価するため CONST 参照や `OR` 式も対応
 - v3b-D scope: ARRAY BYTE のみ (= ARRAY WORD / ARRAY FLOAT / `%%` FLOAT 要素 / StringLiteral / 非定数式 は引き続き error)
-- 新規 `tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs`: 全 BYTE / WORD prefix 混在 / CONST OR 式 / 関数内 static / scope 外 (ARRAY FLOAT) reject の 5 ケース
+- 新規 `tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs` (11 ケース): BYTE 列のみ / `%WORD` prefix 混在 / CONST OR 式 / 関数内 static / ARRAY FLOAT reject / unsized + InitialCode (= 固定配列化) / 容量超過 error / 不足は 0 fill / ARRAY 宣言 symbol への代入 reject (固定サイズ + unsized) / VAR ポインタ代入 regression なし
 
 これにより v3b-C で `audio/sidfx.h` の `SIDFX` struct (= WORD 2 個 + BYTE 8 個程度の 14 byte 構造) を SLANG コード上で自然に書ける流儀が用意できる。
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -1318,10 +1318,23 @@ public class CEmitter : IAstVisitor<EmitResult>
         // C コードを emit してしまうため、 ここで明示 error にして silently drop を
         // 防ぐ (= SemanticAnalyzer の check 不足を backend 側で補う)。
         // `VAR BYTE T[];` (= IsArrayDecl=false、 ポインタ的) は引き続き通る。
+        //
+        // 関数内 static ARRAY (= MAIN ARRAY BYTE A[2]; のような local) は global
+        // SymbolTable に登録されないので、 _scope (= CScopeTracker) で ArrayType
+        // として declare されているかも併せて check する。
         if (node.Target is IdentifierExpr tid)
         {
             var sym = _globals?.GlobalScope.Resolve(tid.Name);
-            if (sym != null && sym.IsArrayDecl)
+            bool isArraySymbol = sym != null && sym.IsArrayDecl;
+            if (!isArraySymbol)
+            {
+                // global 未登録 (= 関数内 static or local) を _scope で ArrayType 確認。
+                // PointerType (= VAR BYTE T[]) は配列実体ではないので reject 対象外。
+                var localType = _scope.Resolve(tid.Name);
+                if (localType is ArrayType)
+                    isArraySymbol = true;
+            }
+            if (isArraySymbol)
             {
                 Error($"cannot assign to ARRAY symbol `{tid.Name}`; ARRAY 宣言は配列実体で再代入不可 (`VAR BYTE T[];` のポインタ宣言ならOK)", node.Span);
                 return new("/* invalid ARRAY assignment */0", SlangType.Word);

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -294,6 +294,14 @@ public class CEmitter : IAstVisitor<EmitResult>
         // 1 つでも null = 間接配列 (= ポインタ)、宣言は static T *A_name;
         bool isIndirect = node.Dimensions.Any(d => d == null);
 
+        // ARRAY x:address + InitialCode は不整合 (固定 addr に初期値併用は SLANG では
+        // 意味曖昧)、 oscar_c backend では明示 error にして silently drop を防ぐ。
+        if (node.Address != null && node.InitialCode != null)
+        {
+            Error("`ARRAY ...:address = { ... }` (fixed address with initializer) is not supported by oscar_c backend", node.Span);
+            return new("", null);
+        }
+
         // ARRAY x:address → static T *A_x = (T*)addr;
         if (node.Address != null)
         {
@@ -304,6 +312,26 @@ public class CEmitter : IAstVisitor<EmitResult>
             if (_scope.ScopeDepth > 0)
                 _scope.DeclareLocal(node.Name, new PointerType(slangType));
             return new(line, null);
+        }
+
+        // isIndirect (= 添字省略 `ARRAY BYTE A[]`) + InitialCode は SLANG 仕様で
+        // 「添字省略時は要素数チェックなし」= 初期値 byte 列の長さで実配列サイズが
+        // 決まる。pointer 化せず固定配列として emit する。
+        if (isIndirect && node.InitialCode != null)
+        {
+            var (initText, byteCount) = BuildArrayInitFromCode(node.InitialCode, slangType, null, node.Span);
+            // 多次元 unsized + InitialCode は scope 外
+            if (node.Dimensions.Count != 1)
+            {
+                Error("multi-dimensional ARRAY with omitted size + initializer is not supported by oscar_c backend (v3b-D scope)", node.Span);
+                return new("", null);
+            }
+            var declLine0 = _scope.ScopeDepth == 0
+                ? Line($"static {cType} {ident}[{byteCount}] = {initText};")
+                : Line($"{cType} {ident}[{byteCount}] = {initText};");
+            if (_scope.ScopeDepth > 0)
+                _scope.DeclareLocal(node.Name, new ArrayType(slangType, new List<int> { byteCount }));
+            return new(declLine0, null);
         }
 
         if (isIndirect)
@@ -321,6 +349,7 @@ public class CEmitter : IAstVisitor<EmitResult>
         // SemanticAnalyzer.cs:194 / IrGenerator.cs:397/404 と同じく `+1` する。
         var dimsSb = new StringBuilder();
         var dimList = new List<int>();
+        int totalSize = 1;
         foreach (var dim in node.Dimensions)
         {
             // null は isIndirect で先に処理済み
@@ -333,6 +362,7 @@ public class CEmitter : IAstVisitor<EmitResult>
             int allocSize = evaluated.Value + 1;
             dimsSb.Append('[').Append(allocSize).Append(']');
             dimList.Add(allocSize);
+            totalSize *= allocSize;
         }
 
         string init = "";
@@ -346,8 +376,11 @@ public class CEmitter : IAstVisitor<EmitResult>
             // 各要素は default BYTE (= 1 byte)、CastExpr で wrap されてれば
             // TargetSize に従う (= `%` prefix で WORD → 2 byte LE 展開)。
             // ConstEvaluator で定数評価して C の hex literal 列に展開する。
+            // 容量超過 (= initializer byte 数 > 配列要素数 N+1) は SLANG 仕様で
+            // error、足りない場合は C array init の挙動で残り 0 fill。
             // FLOAT 要素 / StringLiteral / 非定数式は v3b-D scope 外で error。
-            init = " = " + BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
+            var (initText, _) = BuildArrayInitFromCode(node.InitialCode, slangType, totalSize, node.Span);
+            init = " = " + initText;
         }
 
         var declLine = _scope.ScopeDepth == 0
@@ -360,19 +393,23 @@ public class CEmitter : IAstVisitor<EmitResult>
 
     /// <summary>
     /// SLANG `ARRAY BYTE NAME[N] = { 値, %値, ... }` の InitialCode を C array
-    /// init 文字列 (= `{ 0xNN, 0xNN, ... }`) に変換する。各要素は default BYTE
-    /// (= 1 byte)、`CastExpr(TargetSize: Word)` で wrap されてれば WORD (= 2 byte
-    /// LE)。定数評価不能 / FLOAT / 非整数の要素は v3b-D scope 外で error。
-    /// 配列の要素型 (slangType) は現状 BYTE 想定 (= ARRAY BYTE 限定)、ARRAY WORD
-    /// / ARRAY FLOAT の InitialCode は未対応。
+    /// init 文字列 (= `{ 0xNN, 0xNN, ... }`) と byte 総数のペアに変換する。
+    /// 各要素は default BYTE (= 1 byte)、`CastExpr(TargetSize: Word)` で wrap
+    /// されてれば WORD (= 2 byte LE)。定数評価不能 / FLOAT / 非整数の要素は
+    /// v3b-D scope 外で error。配列の要素型 (slangType) は現状 BYTE 想定
+    /// (= ARRAY BYTE 限定)、ARRAY WORD / ARRAY FLOAT の InitialCode は未対応。
+    /// <para>maxBytes != null のとき、 byte 総数が maxBytes を超えたら SLANG 仕様
+    /// 「多すぎる場合はエラー」に従って error を出す (= 添字省略 `[]` 時は null
+    /// を渡して check skip)。</para>
     /// </summary>
-    private string BuildArrayInitFromCode(System.Collections.Generic.List<Expression> code,
-                                           SlangType elementType, SourceSpan span)
+    private (string initText, int byteCount) BuildArrayInitFromCode(
+        System.Collections.Generic.List<Expression> code,
+        SlangType elementType, int? maxBytes, SourceSpan span)
     {
         if (!(elementType is PrimitiveType { Kind: PrimitiveKind.Byte }))
         {
             Error("`= { ... }` initializer is supported only for ARRAY BYTE in oscar_c backend (v3b-D)", span);
-            return "{0}";
+            return ("{0}", 0);
         }
 
         var bytes = new System.Collections.Generic.List<string>();
@@ -413,7 +450,12 @@ public class CEmitter : IAstVisitor<EmitResult>
             }
         }
 
-        return "{" + string.Join(", ", bytes) + "}";
+        if (maxBytes.HasValue && bytes.Count > maxBytes.Value)
+        {
+            Error($"ARRAY BYTE initializer has {bytes.Count} bytes but array capacity is {maxBytes.Value} (= dimension N+1); SLANG 仕様で「多すぎる場合はエラー」", span);
+        }
+
+        return ("{" + string.Join(", ", bytes) + "}", bytes.Count);
     }
 
     public EmitResult VisitConstDecl(ConstDecl node)
@@ -589,12 +631,27 @@ public class CEmitter : IAstVisitor<EmitResult>
             var slangType = TypeOfDataSize(ad.Size);
             var cType = CTypeMapper.MapDeclType(slangType);
             var ident = StaticVarIdent(_currentFuncName!, ad.Name);
+            bool isIndirect = ad.Dimensions.Any(d => d == null);
+
+            // 添字省略 (= ARRAY BYTE A[]) + InitialCode は SLANG 仕様で
+            // 「添字省略時は要素数チェックなし」、 初期値 byte 列長で配列サイズを決定。
+            if (isIndirect && ad.InitialCode != null)
+            {
+                if (ad.Dimensions.Count != 1)
+                {
+                    Error("multi-dimensional ARRAY with omitted size + initializer is not supported by oscar_c backend (v3b-D scope)", ad.Span);
+                    return "";
+                }
+                var (initText0, byteCount0) = BuildArrayInitFromCode(ad.InitialCode, slangType, null, ad.Span);
+                _scope.DeclareLocal(ad.Name, new ArrayType(slangType, new List<int> { byteCount0 }));
+                return Line($"static {cType} {ident}[{byteCount0}] = {initText0};");
+            }
 
             // 間接配列 (VAR BYTE T[];) — 関数内でもポインタとして扱う。
             // INDTEST.SL の TEST1 で T = ADR; とアドレスを後から代入するパターン。
             // local 間接配列は本来 static にする必要はないが、SLANG の static decl
             // (BEGIN 前) に書かれている場合は static にする。
-            if (ad.Dimensions.Any(d => d == null))
+            if (isIndirect)
             {
                 _scope.DeclareLocal(ad.Name, new PointerType(slangType));
                 return Line($"static {cType} *{ident};");
@@ -603,6 +660,7 @@ public class CEmitter : IAstVisitor<EmitResult>
             // 固定サイズ配列。SLANG 仕様: `ARRAY A[N]` は要素数 N+1 (index 0..N 有効)。
             var dimsSb = new StringBuilder();
             var dimList = new List<int>();
+            int totalSize = 1;
             foreach (var dim in ad.Dimensions)
             {
                 var evaluated = _constEval.Evaluate(dim!);
@@ -614,13 +672,18 @@ public class CEmitter : IAstVisitor<EmitResult>
                 int allocSize = evaluated.Value + 1;
                 dimsSb.Append('[').Append(allocSize).Append(']');
                 dimList.Add(allocSize);
+                totalSize *= allocSize;
             }
             _scope.DeclareLocal(ad.Name, new ArrayType(slangType, dimList));
             string init = "";
             if (ad.InitialValue != null)
                 init = " = " + Expr(ad.InitialValue);
             else if (ad.InitialCode != null)
-                init = " = " + BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
+            {
+                // 容量超過 check 込み (= maxBytes=totalSize)。
+                var (initText, _) = BuildArrayInitFromCode(ad.InitialCode, slangType, totalSize, ad.Span);
+                init = " = " + initText;
+            }
             return Line($"static {cType} {ident}{dimsSb}{init};");
         }
         if (decl is ConstDecl cd)

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -294,12 +294,6 @@ public class CEmitter : IAstVisitor<EmitResult>
         // 1 つでも null = 間接配列 (= ポインタ)、宣言は static T *A_name;
         bool isIndirect = node.Dimensions.Any(d => d == null);
 
-        if (node.InitialCode != null)
-        {
-            Error("`= { code... }` initializer is not supported by oscar_c backend (uses Z80-specific MACHINE code)", node.Span);
-            return new("", null);
-        }
-
         // ARRAY x:address → static T *A_x = (T*)addr;
         if (node.Address != null)
         {
@@ -346,6 +340,15 @@ public class CEmitter : IAstVisitor<EmitResult>
         {
             init = " = " + Expr(node.InitialValue);
         }
+        else if (node.InitialCode != null)
+        {
+            // SLANG `ARRAY BYTE NAME[N] = { 値, %値, ... }` 形式の初期化。
+            // 各要素は default BYTE (= 1 byte)、CastExpr で wrap されてれば
+            // TargetSize に従う (= `%` prefix で WORD → 2 byte LE 展開)。
+            // ConstEvaluator で定数評価して C の hex literal 列に展開する。
+            // FLOAT 要素 / StringLiteral / 非定数式は v3b-D scope 外で error。
+            init = " = " + BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
+        }
 
         var declLine = _scope.ScopeDepth == 0
             ? Line($"static {cType} {ident}{dimsSb}{init};")
@@ -353,6 +356,64 @@ public class CEmitter : IAstVisitor<EmitResult>
         if (_scope.ScopeDepth > 0)
             _scope.DeclareLocal(node.Name, new ArrayType(slangType, dimList));
         return new(declLine, null);
+    }
+
+    /// <summary>
+    /// SLANG `ARRAY BYTE NAME[N] = { 値, %値, ... }` の InitialCode を C array
+    /// init 文字列 (= `{ 0xNN, 0xNN, ... }`) に変換する。各要素は default BYTE
+    /// (= 1 byte)、`CastExpr(TargetSize: Word)` で wrap されてれば WORD (= 2 byte
+    /// LE)。定数評価不能 / FLOAT / 非整数の要素は v3b-D scope 外で error。
+    /// 配列の要素型 (slangType) は現状 BYTE 想定 (= ARRAY BYTE 限定)、ARRAY WORD
+    /// / ARRAY FLOAT の InitialCode は未対応。
+    /// </summary>
+    private string BuildArrayInitFromCode(System.Collections.Generic.List<Expression> code,
+                                           SlangType elementType, SourceSpan span)
+    {
+        if (!(elementType is PrimitiveType { Kind: PrimitiveKind.Byte }))
+        {
+            Error("`= { ... }` initializer is supported only for ARRAY BYTE in oscar_c backend (v3b-D)", span);
+            return "{0}";
+        }
+
+        var bytes = new System.Collections.Generic.List<string>();
+        foreach (var expr in code)
+        {
+            var itemExpr = expr;
+            int itemSize = 1; // default BYTE
+            if (itemExpr is CastExpr cast)
+            {
+                itemExpr = cast.Operand;
+                if (cast.TargetSize == DataSize.Float)
+                {
+                    Error("FLOAT (`%%`) prefix in ARRAY BYTE initializer is not supported by oscar_c backend (v3b-D scope)", expr.Span);
+                    continue;
+                }
+                itemSize = cast.TargetSize == DataSize.Byte ? 1 : 2;
+            }
+
+            var constVal = _constEval.Evaluate(itemExpr);
+            if (itemExpr is IntegerLiteral ilit)
+                constVal = (int)ilit.Value;
+            if (!constVal.HasValue)
+            {
+                Error("ARRAY BYTE initializer element must be a compile-time constant in oscar_c backend (non-constant / string literal は v3b-D scope 外)", expr.Span);
+                continue;
+            }
+
+            int v = constVal.Value;
+            if (itemSize == 1)
+            {
+                bytes.Add($"0x{(byte)(v & 0xFF):X2}");
+            }
+            else
+            {
+                // WORD: little-endian で 2 byte に展開
+                bytes.Add($"0x{(byte)(v & 0xFF):X2}");
+                bytes.Add($"0x{(byte)((v >> 8) & 0xFF):X2}");
+            }
+        }
+
+        return "{" + string.Join(", ", bytes) + "}";
     }
 
     public EmitResult VisitConstDecl(ConstDecl node)
@@ -555,7 +616,11 @@ public class CEmitter : IAstVisitor<EmitResult>
                 dimList.Add(allocSize);
             }
             _scope.DeclareLocal(ad.Name, new ArrayType(slangType, dimList));
-            string init = ad.InitialValue != null ? " = " + Expr(ad.InitialValue) : "";
+            string init = "";
+            if (ad.InitialValue != null)
+                init = " = " + Expr(ad.InitialValue);
+            else if (ad.InitialCode != null)
+                init = " = " + BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
             return Line($"static {cType} {ident}{dimsSb}{init};");
         }
         if (decl is ConstDecl cd)

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -1312,6 +1312,21 @@ public class CEmitter : IAstVisitor<EmitResult>
 
     public EmitResult VisitAssignExpr(AssignExpr node)
     {
+        // SLANG `ARRAY ...` 宣言で確保された symbol への直接代入 (= `A = $3000;`) は
+        // SLANG 仕様で意味曖昧 (= 配列実体の置換は不可、ポインタ代入は `VAR x[];` の
+        // 役割)。oscar_c backend では `static unsigned char V_A[N]` に代入する無効な
+        // C コードを emit してしまうため、 ここで明示 error にして silently drop を
+        // 防ぐ (= SemanticAnalyzer の check 不足を backend 側で補う)。
+        // `VAR BYTE T[];` (= IsArrayDecl=false、 ポインタ的) は引き続き通る。
+        if (node.Target is IdentifierExpr tid)
+        {
+            var sym = _globals?.GlobalScope.Resolve(tid.Name);
+            if (sym != null && sym.IsArrayDecl)
+            {
+                Error($"cannot assign to ARRAY symbol `{tid.Name}`; ARRAY 宣言は配列実体で再代入不可 (`VAR BYTE T[];` のポインタ宣言ならOK)", node.Span);
+                return new("/* invalid ARRAY assignment */0", SlangType.Word);
+            }
+        }
         var target = ExprFull(node.Target);
         var value = ExprFull(node.Value);
         var targetType = target.Type ?? SlangType.Word;

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -189,4 +189,66 @@ public class ArrayInitOscarCTests
     // 既に reject する (= `:address = { ... }` の組合せは文法上 parse error)、
     // CEmitter の Address + InitialCode 分岐は文法的に到達不能。 念のため
     // CEmitter 側にも防御 error を残しているが、 unit test の必要なし。
+
+    [Fact]
+    public void AssignmentToArrayDecl_RaisesError()
+    {
+        // SLANG `ARRAY ...` 宣言の symbol への直接代入 (= `A = $3000;`) は
+        // 配列実体の置換が SLANG 仕様で意味曖昧。oscar_c backend では C 側で
+        // `static unsigned char V_A[N] = ...` という無効 C を出してしまうため、
+        // VisitAssignExpr で IsArrayDecl を check して error にする。
+        // Codex review Medium 指摘 (= unsized + InitialCode で代入が通ってしまう
+        // 件) の修正、固定サイズ ARRAY も同じ理由で reject する。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE A[10];
+            MAIN()
+            BEGIN
+                A = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY 宣言 symbol への代入は error 期待");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("ARRAY", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("assign", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AssignmentToUnsizedArrayWithInitCode_RaisesError()
+    {
+        // 添字省略 + InitialCode の ARRAY も IsArrayDecl=true で reject される
+        // (= Codex review Medium の主指摘ケース、static unsigned char V_A[3] に
+        // V_A = ... の無効 C を出さないこと)。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE A[] = { 1, 2, 3 };
+            MAIN()
+            BEGIN
+                A = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "unsized + InitialCode の ARRAY 代入も error 期待");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("ARRAY", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("assign", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AssignmentToVarPointer_StillWorks()
+    {
+        // VAR BYTE T[]; (= IsArrayDecl=false、ポインタ宣言) への代入は SLANG 仕様で
+        // OK。oscar_c backend でも従来通り通る (= regression なし)。
+        var src = TranspileWithEnv("""
+            VAR BYTE T[];
+            MAIN()
+            BEGIN
+                T = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static unsigned char *V_T;", src);
+        Assert.Contains("V_T = ", src);
+    }
 }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -130,4 +130,63 @@ public class ArrayInitOscarCTests
         Assert.Contains(diag.Diagnostics,
             d => d.Message.Contains("ARRAY BYTE", StringComparison.OrdinalIgnoreCase));
     }
+
+    [Fact]
+    public void UnsizedArrayByte_InitCode_DerivesSizeFromInit()
+    {
+        // SLANG 仕様: 添字省略 `ARRAY BYTE A[]={...}` は初期値 byte 列長で配列サイズ決定
+        // (= 「添字省略時はチェックしない」)。pointer 化せず固定配列として emit。
+        // Codex review High 指摘 (= 旧実装で initializer silently dropped されてた) の回帰防止。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE UNSIZED[] = { %$1234, $56 };
+            MAIN() { PRINT(UNSIZED[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // %$1234 (= 2 byte LE) + $56 (= 1 byte) = 3 byte、ポインタ宣言ではなく固定配列
+        Assert.Contains("static unsigned char V_UNSIZED[3] = {0x34, 0x12, 0x56};", src);
+        // 旧実装で silently dropped されていた pointer 宣言は出ないこと
+        Assert.DoesNotContain("static unsigned char *V_UNSIZED;", src);
+    }
+
+    [Fact]
+    public void OverflowArrayByte_InitCode_RaisesError()
+    {
+        // SLANG 仕様: 「初期値が多すぎる場合はエラー」。
+        // ARRAY BYTE A[1] は 2 要素確保 (= index 0..1)、 init 4 byte は超過 → error。
+        // Codex review Medium 指摘 (= 旧実装で容量超過 check なしに無効 C 出力) の回帰防止。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE OVER[1] = { 1, 2, 3, 4 };
+            MAIN() { PRINT(OVER[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "容量超過 ARRAY BYTE init は SLANG 仕様で error");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("multi", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("capacity", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("多すぎ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void UnderfilledArrayByte_InitCode_Accepted_RestZeroFilledByC()
+    {
+        // SLANG 仕様: 「初期値が足りない場合は0で埋められる」。
+        // ARRAY BYTE A[4] は 5 要素確保、init 2 byte は足りないが error にはならず、
+        // C array init の挙動で残り 3 byte は 0 で埋まる (= oscar64 も同様)。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE UNDER[4] = { 1, 2 };
+            MAIN() { PRINT(UNDER[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // 配列宣言は 5 要素、 init は 2 byte だけ書く (= C コンパイラが残り 0 で fill)
+        Assert.Contains("static unsigned char V_UNDER[5] = {0x01, 0x02};", src);
+    }
+
+    // 注: `ARRAY ...:address = { ... }` (fixed addr + initializer) は SLANG parser が
+    // 既に reject する (= `:address = { ... }` の組合せは文法上 parse error)、
+    // CEmitter の Address + InitialCode 分岐は文法的に到達不能。 念のため
+    // CEmitter 側にも防御 error を残しているが、 unit test の必要なし。
 }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -251,4 +251,62 @@ public class ArrayInitOscarCTests
         Assert.Contains("static unsigned char *V_T;", src);
         Assert.Contains("V_T = ", src);
     }
+
+    [Fact]
+    public void AssignmentToFunctionStaticArrayDecl_RaisesError()
+    {
+        // 関数内 static ARRAY (= MAIN() ARRAY BYTE A[2]; BEGIN ... END;) の symbol
+        // も IsArrayDecl=true で reject。global SymbolTable には登録されないので
+        // _scope (= CScopeTracker) で ArrayType 判別する必要あり (= Codex review 2nd
+        // round Medium 指摘の核心: _globals だけ見てた漏れの fix)。
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY BYTE A[2];
+            BEGIN
+                A = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "関数内 static ARRAY 代入は error 期待");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("ARRAY", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("assign", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AssignmentToFunctionStaticUnsizedArrayInit_RaisesError()
+    {
+        // 関数内 static + unsized + InitialCode の組合せも reject (= 同 Codex 指摘)。
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY BYTE A[] = { 1, 2, 3 };
+            BEGIN
+                A = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "関数内 static unsized + InitialCode の ARRAY 代入は error 期待");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("ARRAY", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("assign", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void AssignmentToFunctionStaticVarPointer_StillWorks()
+    {
+        // 関数内 static VAR BYTE T[]; (= IsArrayDecl=false、 PointerType) は引き続き
+        // 通る (= regression なし)。
+        var src = TranspileWithEnv("""
+            MAIN()
+                VAR BYTE T[];
+            BEGIN
+                T = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static unsigned char *V_MAIN_T;", src);
+        Assert.Contains("V_MAIN_T = ", src);
+    }
 }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -1,0 +1,133 @@
+using SLANGCompiler;
+using SLANGCompiler.CodeGen.C;
+using SLANGCompiler.Lexer;
+using SLANGCompiler.Parser;
+using SLANGCompiler.Runtime;
+using SLANGCompiler.Semantics;
+using Xunit;
+
+namespace SLANGCompiler.Tests;
+
+/// <summary>
+/// v3b-D oscar_c backend での `ARRAY BYTE NAME[N] = { 値, %値, ... }` 初期化
+/// 展開を golden 化する。BYTE/WORD 混在 (= `%` prefix で WORD) を LE byte 列に
+/// 展開する。 FLOAT / ARRAY WORD / ARRAY FLOAT / 非定数 / StringLiteral は scope
+/// 外で error になることも確認。
+/// </summary>
+public class ArrayInitOscarCTests
+{
+    private static EnvironmentConfig MakeC64Env()
+    {
+        return new EnvironmentConfig
+        {
+            Name = "c64",
+            Backend = BackendKind.OscarC,
+            OutputFormat = "c_source",
+            CBindings = new List<CBindingDef>(),
+        };
+    }
+
+    private static string TranspileWithEnv(string source, EnvironmentConfig env, out DiagnosticBag diag)
+    {
+        diag = new DiagnosticBag();
+        var lexer = new Lexer.Lexer(source, "<test>");
+        var tokens = lexer.Tokenize();
+        var preproc = new Preprocessor(diag, new List<string>());
+        preproc.DefineConst("BACKEND", 1);
+        preproc.DefineConst("ENV_TYPE", 7);
+        tokens = preproc.Process(tokens, ".");
+        var parser = new Parser.Parser(tokens, diag);
+        var ast = parser.ParseCompilationUnit();
+        var analyzer = new SemanticAnalyzer(diag);
+        analyzer.Analyze(ast);
+        if (diag.HasErrors) return "";
+        var transpiler = new CTranspiler(analyzer.Symbols, env, diag);
+        return transpiler.Transpile(ast);
+    }
+
+    [Fact]
+    public void GlobalArrayByte_AllByteValues_EmitsCArrayInit()
+    {
+        // 全 BYTE 要素の ARRAY BYTE init = 各値が 1 byte の hex literal で出る
+        var src = TranspileWithEnv("""
+            ARRAY BYTE DATA[3] = { 1, 2, 3, 4 };
+            MAIN() { PRINT(DATA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+
+        // ARRAY BYTE A[3] は SLANG 仕様で 4 要素確保 (= index 0..3)
+        Assert.Contains("static unsigned char V_DATA[4] = {0x01, 0x02, 0x03, 0x04};", src);
+    }
+
+    [Fact]
+    public void GlobalArrayByte_WordPrefixMix_ExpandsAsLittleEndian()
+    {
+        // `%` prefix の WORD を LE 2 byte に展開、BYTE 要素と混在可能
+        // SIDFX struct のような C struct を SLANG ARRAY BYTE で書ける流儀の検証
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MIXED[5] = { %$1234, $56, %$7890, $AB };
+            MAIN() { PRINT(MIXED[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+
+        // %$1234 → 0x34, 0x12 (LE) / $56 / %$7890 → 0x90, 0x78 (LE) / $AB の 6 byte
+        // ARRAY BYTE A[5] は 6 要素確保 + 6 byte 初期値 = ぴったり
+        Assert.Contains("static unsigned char V_MIXED[6] = {0x34, 0x12, 0x56, 0x90, 0x78, 0xAB};", src);
+    }
+
+    [Fact]
+    public void GlobalArrayByte_ConstReference_EvaluatesAtCompileTime()
+    {
+        // ARRAY init 内に CONST 参照 + OR 式があっても ConstEvaluator が静的に評価
+        var src = TranspileWithEnv("""
+            CONST FLAG_A = $01;
+            CONST FLAG_B = $80;
+            ARRAY BYTE FLAGS[2] = { FLAG_A, FLAG_B, FLAG_A OR FLAG_B };
+            MAIN() { PRINT(FLAGS[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+
+        // FLAG_A=$01, FLAG_B=$80, OR=$81 → 0x01, 0x80, 0x81 (3 byte)
+        // ARRAY BYTE A[2] は 3 要素確保
+        Assert.Contains("static unsigned char V_FLAGS[3] = {0x01, 0x80, 0x81};", src);
+    }
+
+    [Fact]
+    public void LocalStaticArrayByte_InitCode_EmitsCArrayInit()
+    {
+        // 関数内 static (BEGIN 前) ARRAY BYTE 宣言の InitialCode も同様に展開
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY BYTE LOCAL[2] = { %$ABCD, $EF };
+            BEGIN
+                PRINT(LOCAL[0]);
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+
+        // %$ABCD → 0xCD, 0xAB / $EF の 3 byte、ARRAY BYTE A[2] = 3 要素確保
+        Assert.Contains("static unsigned char V_MAIN_LOCAL[3] = {0xCD, 0xAB, 0xEF};", src);
+    }
+
+    [Fact]
+    public void ArrayFloat_InitCode_StillRejected()
+    {
+        // v3b-D scope: ARRAY BYTE 限定。ARRAY FLOAT の InitialCode は明示 error
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[2] = { 1.0, 2.0, 3.0 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY FLOAT init は v3b-D scope 外として error 期待");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("ARRAY BYTE", StringComparison.OrdinalIgnoreCase));
+    }
+}


### PR DESCRIPTION
## Summary

ロードマップ #178 配下の v3b に **v3b-D (= v3b-C 着手前の前提条件)** を挿入。oscar_c backend で `ARRAY BYTE NAME[N] = { 値, %値, ... }` 初期化を C array init として展開できるようにします。これで v3b-C で oscar64 `SIDFX` struct (= 14 byte の WORD 2 個 + BYTE 8 個) を SLANG コード上で自然に書けるようになります。

## 動機

v3b-C 設計検討中に判明 — 既存 oscar_c backend は SLANG `ARRAY BYTE NAME[] = { ... }` initializer を **即 error** で reject (= "uses Z80-specific MACHINE code") していて、SIDFX struct のような C 構造体相当のデータを SLANG コードから渡せませんでした。v3b-D で oscar_c backend に Z80 backend 同等の初期化 emit を追加し、v3b-C 着手の前提条件を満たします。

## スコープ (= 最小)

- **ARRAY BYTE 限定** (= ARRAY WORD / ARRAY FLOAT は引き続き未対応)
- 要素 default は 1 byte、`%` prefix (= `CastExpr(TargetSize: Word)`) で **LE 2 byte 展開**
- 既存 `ConstEvaluator` で式評価 (= CONST 参照、`OR` / `+` / `<<` 等の bitwise/算術 式対応)
- `%%` FLOAT 要素 / StringLiteral 初期化 / 非定数式は **scope 外** (= 引き続き error)
- 添字省略 `ARRAY BYTE A[] = { ... }` は SLANG 仕様「添字省略時はチェックしない」に従って byte 列長で配列サイズ決定
- 容量超過 `ARRAY BYTE A[N] = { ... 多すぎ ... }` は SLANG 仕様「多すぎる場合はエラー」に従って error
- 不足 `ARRAY BYTE A[N] = { ... 少ない ... }` は SLANG 仕様「足りない場合は 0 で埋められる」のとおり C 側で残り 0 fill
- ARRAY 宣言 symbol への代入 (= `ARRAY BYTE A[10]; A = $3000;`) は意味曖昧 (= 配列実体の置換は SLANG 仕様で不可) で oscar_c 側で error。global / 関数内 static (= `MAIN() ARRAY BYTE A[2]; BEGIN A=$3000; END;`) 両方塞ぐ。`VAR BYTE T[];` (= IsArrayDecl=false、 ポインタ宣言) は引き続き OK

## 実装

`src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs` の 3 箇所:
- `VisitArrayDecl` (= global ARRAY 宣言)
- `EmitStaticDecl` の ArrayDecl 経路 (= 関数内 static、BEGIN 前 ARRAY 宣言)
- `VisitAssignExpr` (= ARRAY 宣言 symbol への代入を `_globals` + `_scope` の両方確認で検出して error)

ARRAY init 展開は `BuildArrayInitFromCode` helper (= maxBytes 引数で容量超過 check) を経由して global / function-local static で共有。

## 動作例

```slang
ARRAY BYTE MIXED[5] = { %$1234, $56, %$7890, $AB };
```
↓
```c
static unsigned char V_MIXED[6] = {0x34, 0x12, 0x56, 0x90, 0x78, 0xAB};
```

(= `%$1234` を LE `0x34, 0x12` に / `$56` BYTE / `%$7890` を LE `0x90, 0x78` に / `$AB` BYTE)

## Test plan

- [x] **390 tests pass** (= 既存 376 + 新規 ArrayInitOscarCTests 14: BYTE 列のみ / `%WORD` 混在 / CONST OR 式 / 関数内 static / ARRAY FLOAT reject / unsized + InitialCode 固定配列化 / 容量超過 error / 不足 0 fill / ARRAY 宣言 symbol 代入 reject (global 固定サイズ + global unsized + 関数内 static 固定サイズ + 関数内 static unsized) / VAR ポインタ代入 regression なし (global + 関数内 static))
- [x] c64 backend 全 sample (SPRITE/FMANDEL/JOYSPR/SIDSFX/HISCORE/SIDBGM) smoke build regression なし
- [x] Codex review 反映 (= 3 round 全 fix 済)

## 別 PR / 別 issue 化予定

Codex review 検証で **Z80 backend (= IrGenerator) も同じ仕様未準拠** と判明 (= 容量超過 check 未実装、 固定サイズ ARRAY への代入も silently emit)。本 PR scope は oscar_c に限定し、**「全 backend 共通 ARRAY initializer capacity check + assignment guard」横展開タスク** として別 issue 化予定。

Refs #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)