### PR TITLE
Support ARRAY WORD InitialCode in oscar_c backend (v3b-E first PR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - c64 backend に VIC sprite + VSYNC 同期 + joystick + KERNAL file I/O + SID 音源 (register direct + 単発 SFX + HVSC `.sid` BGM 再生 + oscar64 `audio/sidfx` priority SFX overlay) の bridge と sample 一式を追加。
 - 既存 Z80 backend の codegen / runtime の挙動は無変更 (= 言語側で `VOID` 予約語追加・`CFUNC` 構文追加が入っているため Parser には影響あり、 ただし既存 Z80 SLANG コードへの regression は確認なし)。
 - ARRAY initializer の容量超過 check / ARRAY symbol 代入 guard を SemanticAnalyzer に集約し全 backend で揃えた (Closes #190、 oscar_c の非 BYTE InitialCode emit 対応は別 PR 候補)。
+- oscar_c backend で `ARRAY WORD W[N] = { 値, %値, ... }` 初期化対応 (= CODE byte stream を 2 byte ずつ little-endian で WORD literal に grouping、 容量埋めは C implicit zero fill 任せ、 #194 配下 v3b-E first PR)。
 
 ## Version 0.24.1
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -325,18 +325,20 @@ public class CEmitter : IAstVisitor<EmitResult>
         // 決まる。pointer 化せず固定配列として emit する。
         if (isIndirect && node.InitialCode != null)
         {
-            var (initText, byteCount) = BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
+            var emit = BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
             // 多次元 unsized + InitialCode は scope 外
             if (node.Dimensions.Count != 1)
             {
                 Error("multi-dimensional ARRAY with omitted size + initializer is not supported by oscar_c backend (v3b-D scope)", node.Span);
                 return new("", null);
             }
+            // C 配列長は CElementCount (= WORD なら byte 数 /2)、 byte 数を直接使うと
+            // WORD 配列で 2 倍になる事故が起きる (Issue #194 / Codex review 指摘)。
             var declLine0 = _scope.ScopeDepth == 0
-                ? Line($"static {cType} {ident}[{byteCount}] = {initText};")
-                : Line($"{cType} {ident}[{byteCount}] = {initText};");
+                ? Line($"static {cType} {ident}[{emit.CElementCount}] = {emit.InitText};")
+                : Line($"{cType} {ident}[{emit.CElementCount}] = {emit.InitText};");
             if (_scope.ScopeDepth > 0)
-                _scope.DeclareLocal(node.Name, new ArrayType(slangType, new List<int> { byteCount }));
+                _scope.DeclareLocal(node.Name, new ArrayType(slangType, new List<int> { emit.CElementCount }));
             // 固定配列化された symbol を記録 (= VisitAssignExpr で reject 用)。
             // SLANG 仕様レベルでは PointerType だが、 oscar_c は固定配列で emit して
             // いるため代入は無効 C を生む。
@@ -382,15 +384,17 @@ public class CEmitter : IAstVisitor<EmitResult>
         }
         else if (node.InitialCode != null)
         {
-            // SLANG `ARRAY BYTE NAME[N] = { 値, %値, ... }` 形式の初期化。
+            // SLANG `ARRAY BYTE/WORD NAME[N] = { 値, %値, ... }` 形式の初期化。
             // 各要素は default BYTE (= 1 byte)、CastExpr で wrap されてれば
             // TargetSize に従う (= `%` prefix で WORD → 2 byte LE 展開)。
             // 容量超過 / 非定数 BYTE / FLOAT array トップレベル cast 等の SLANG 仕様
             // 違反は SemanticAnalyzer + ArrayInitialCodeSizer 側で先に reject 済 (Issue
-            // #190)。ここでは oscar_c emit のみ (= 非 BYTE 要素 / FLOAT prefix / 非定数
-            // は backend feature gap として defensive reject、 別 PR v3b-E で拡張予定)。
-            var (initText, _) = BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
-            init = " = " + initText;
+            // #190)。ここでは oscar_c emit のみ。 ARRAY WORD は v3b-E (Issue #194)
+            // で対応、 残 4 gap (FLOAT array / FLOAT prefix / 非定数 / multi-dim 添字
+            // 省略 / fixed-addr) は次 PR 以降。 固定配列は C array 長 = dims から計算済
+            // のためここでは InitText のみ使い、 C の implicit zero fill に容量埋めを委譲。
+            var emit = BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
+            init = " = " + emit.InitText;
         }
 
         var declLine = _scope.ScopeDepth == 0
@@ -402,31 +406,46 @@ public class CEmitter : IAstVisitor<EmitResult>
     }
 
     /// <summary>
-    /// SLANG `ARRAY BYTE NAME[N] = { 値, %値, ... }` の InitialCode を C array
-    /// init 文字列 (= `{ 0xNN, 0xNN, ... }`) と byte 総数のペアに変換する。
-    /// 各要素は default BYTE (= 1 byte)、`CastExpr(TargetSize: Word)` で wrap
-    /// されてれば WORD (= 2 byte LE)。定数評価不能 / FLOAT / 非整数の要素は
-    /// v3b-D scope 外で error。配列の要素型 (slangType) は現状 BYTE 想定
-    /// (= ARRAY BYTE 限定)、ARRAY WORD / ARRAY FLOAT の InitialCode は未対応。
-    /// <para>maxBytes != null のとき、 byte 総数が maxBytes を超えたら SLANG 仕様
-    /// 「多すぎる場合はエラー」に従って error を出す (= 添字省略 `[]` 時は null
-    /// を渡して check skip)。</para>
+    /// BuildArrayInitFromCode の戻り値。 byte 単位の入力 / emit 量 / C 要素数を分離して
+    /// caller の事故 (= unsized 経路で WORD だと C 配列長が 2 倍になる類い) を防ぐ。
     /// </summary>
-    private (string initText, int byteCount) BuildArrayInitFromCode(
+    /// <param name="InitText">C の "{0xNN, ...}" / "{0xNNNN, ...}" 文字列</param>
+    /// <param name="SourceByteCount">入力 CODE byte stream 長 (= padding 前)</param>
+    /// <param name="EmittedByteCount">実際 emit した byte 総数 (= WORD で奇数 byte の場合 +1 padding 後)</param>
+    /// <param name="CElementCount">C 配列の要素数 (BYTE: EmittedByteCount / WORD: EmittedByteCount/2)</param>
+    private sealed record ArrayInitEmitResult(
+        string InitText,
+        int SourceByteCount,
+        int EmittedByteCount,
+        int CElementCount);
+
+    /// <summary>
+    /// SLANG `ARRAY BYTE/WORD NAME[N] = { 値, %値, ... }` の InitialCode を C array
+    /// init 文字列に変換する。SLANG 仕様の「CODE byte stream」解釈に従い、 まず
+    /// byte 単位で展開してから elementType に応じて出力形を切り替える:
+    /// <list type="bullet">
+    /// <item><description>BYTE: byte stream を `{0xNN, 0xNN, ...}` で出力</description></item>
+    /// <item><description>WORD: byte stream を 2 byte ずつ grouping (= little-endian) して
+    /// `{0xNNNN, ...}` で出力、 奇数 byte なら最後を 0 padding</description></item>
+    /// </list>
+    /// 容量までの 0 fill は helper では行わず C の implicit zero fill に委譲する
+    /// (= 固定配列 `static unsigned int V[capacity] = {...};` で C が残りを 0 埋め)。
+    /// FLOAT 配列 / FLOAT prefix / 非定数 element / StringLiteral / CodeLabelRef は
+    /// Issue #194 配下の次 PR で実装、 ここでは defensive reject。
+    /// </summary>
+    private ArrayInitEmitResult BuildArrayInitFromCode(
         System.Collections.Generic.List<Expression> code,
         SlangType elementType, SourceSpan span)
     {
-        // Issue #190 移行後: 容量超過 / 非定数 BYTE 等の SLANG 仕様違反は
-        // SemanticAnalyzer + ArrayInitialCodeSizer で先 reject 済み。
-        // ここでは emit logic (= C array init 文字列生成) と、 oscar_c backend の
-        // feature gap (= ARRAY BYTE のみ対応、 FLOAT prefix 未対応) の guard のみ残す。
-        if (!(elementType is PrimitiveType { Kind: PrimitiveKind.Byte }))
+        bool isByteArray = elementType is PrimitiveType { Kind: PrimitiveKind.Byte };
+        bool isWordArray = elementType is PrimitiveType { Kind: PrimitiveKind.Word };
+        if (!isByteArray && !isWordArray)
         {
-            Error("`= { ... }` initializer is supported only for ARRAY BYTE in oscar_c backend (= 非 BYTE InitialCode の oscar_c emit 対応は別 PR / v3b-E 候補)", span);
-            return ("{0}", 0);
+            Error("`= { ... }` initializer is supported only for ARRAY BYTE / ARRAY WORD in oscar_c backend (= ARRAY FLOAT InitialCode の oscar_c emit 対応は別 PR / v3b-E 候補)", span);
+            return new ArrayInitEmitResult("{0}", 0, 0, 0);
         }
 
-        var bytes = new System.Collections.Generic.List<string>();
+        var bytes = new System.Collections.Generic.List<byte>();
         foreach (var expr in code)
         {
             var itemExpr = expr;
@@ -438,7 +457,7 @@ public class CEmitter : IAstVisitor<EmitResult>
                 {
                     // 非 FLOAT 配列の %% は SemanticAnalyzer は許可するが、 oscar_c emit
                     // は未対応 (= defensive、 SemanticAnalyzer 通過しても oscar_c で reject)
-                    Error("FLOAT (`%%`) prefix in ARRAY BYTE initializer is not supported by oscar_c backend (= 別 PR / v3b-E 候補)", expr.Span);
+                    Error("FLOAT (`%%`) prefix in ARRAY BYTE / WORD initializer is not supported by oscar_c backend (= 別 PR / v3b-E 候補)", expr.Span);
                     continue;
                 }
                 itemSize = cast.TargetSize == DataSize.Byte ? 1 : 2;
@@ -450,26 +469,46 @@ public class CEmitter : IAstVisitor<EmitResult>
             if (!constVal.HasValue)
             {
                 // defensive (= SemanticAnalyzer で同じ error が出るはず)
-                Error("ARRAY BYTE initializer element must be a compile-time constant in oscar_c backend (non-constant / string literal の oscar_c emit 対応は別 PR / v3b-E 候補)", expr.Span);
+                Error("non-FLOAT ARRAY initializer element must be a compile-time constant in oscar_c backend (non-constant / string literal / CodeLabelRef の oscar_c emit 対応は別 PR / v3b-E 候補)", expr.Span);
                 continue;
             }
 
             int v = constVal.Value;
-            if (itemSize == 1)
-            {
-                bytes.Add($"0x{(byte)(v & 0xFF):X2}");
-            }
-            else
-            {
-                // WORD: little-endian で 2 byte に展開
-                bytes.Add($"0x{(byte)(v & 0xFF):X2}");
-                bytes.Add($"0x{(byte)((v >> 8) & 0xFF):X2}");
-            }
+            bytes.Add((byte)(v & 0xFF));
+            if (itemSize == 2)
+                bytes.Add((byte)((v >> 8) & 0xFF));
+            // (itemSize == 3 = FLOAT prefix は既に上で reject 済)
         }
 
-        // 容量超過 check は SemanticAnalyzer 移行済み (= Issue #190)、 ここでは emit のみ。
+        int sourceByteCount = bytes.Count;
+        string initText;
+        int emittedByteCount;
+        int cElementCount;
+        if (isByteArray)
+        {
+            var literals = new System.Collections.Generic.List<string>(bytes.Count);
+            foreach (var b in bytes)
+                literals.Add($"0x{b:X2}");
+            initText = "{" + string.Join(", ", literals) + "}";
+            emittedByteCount = sourceByteCount;
+            cElementCount = sourceByteCount;
+        }
+        else // WORD
+        {
+            // 奇数 byte なら最後を 0 padding して 2 byte ずつ WORD literal 化
+            if ((bytes.Count & 1) != 0) bytes.Add(0);
+            var literals = new System.Collections.Generic.List<string>(bytes.Count / 2);
+            for (int i = 0; i < bytes.Count; i += 2)
+            {
+                int w = bytes[i] | (bytes[i + 1] << 8);
+                literals.Add($"0x{w:X4}");
+            }
+            initText = "{" + string.Join(", ", literals) + "}";
+            emittedByteCount = bytes.Count;
+            cElementCount = bytes.Count / 2;
+        }
 
-        return ("{" + string.Join(", ", bytes) + "}", bytes.Count);
+        return new ArrayInitEmitResult(initText, sourceByteCount, emittedByteCount, cElementCount);
     }
 
     public EmitResult VisitConstDecl(ConstDecl node)
@@ -656,12 +695,12 @@ public class CEmitter : IAstVisitor<EmitResult>
                     Error("multi-dimensional ARRAY with omitted size + initializer is not supported by oscar_c backend (v3b-D scope)", ad.Span);
                     return "";
                 }
-                var (initText0, byteCount0) = BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
-                _scope.DeclareLocal(ad.Name, new ArrayType(slangType, new List<int> { byteCount0 }));
+                var emit0 = BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
+                _scope.DeclareLocal(ad.Name, new ArrayType(slangType, new List<int> { emit0.CElementCount }));
                 // (関数内 static は _scope に ArrayType 登録済 = VisitAssignExpr の
                 //  _scope.Resolve 経由で reject されるため、 _unsizedArraysWithInit
                 //  への登録は不要。 そちらは global 由来の同名 symbol 限定。)
-                return Line($"static {cType} {ident}[{byteCount0}] = {initText0};");
+                return Line($"static {cType} {ident}[{emit0.CElementCount}] = {emit0.InitText};");
             }
 
             // 間接配列 (VAR BYTE T[];) — 関数内でもポインタとして扱う。
@@ -698,9 +737,11 @@ public class CEmitter : IAstVisitor<EmitResult>
             else if (ad.InitialCode != null)
             {
                 // 容量超過 check は SemanticAnalyzer に移行済 (Issue #190)、 ここでは
-                // emit のみ + backend feature gap reject (= 非 BYTE 要素等、 defensive)。
-                var (initText, _) = BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
-                init = " = " + initText;
+                // emit のみ。 ARRAY WORD は v3b-E (Issue #194) 対応済、 残 gap は次 PR。
+                // 容量埋めは C implicit zero fill に委譲 (= dims から決まる固定配列長
+                // を使い InitText だけ流す)。
+                var emit = BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
+                init = " = " + emit.InitText;
             }
             return Line($"static {cType} {ident}{dimsSb}{init};");
         }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -309,4 +309,141 @@ public class ArrayInitOscarCTests
         Assert.Contains("static unsigned char *V_MAIN_T;", src);
         Assert.Contains("V_MAIN_T = ", src);
     }
+
+    // === v3b-E (Issue #194) first PR: ARRAY WORD InitialCode 対応 ===
+    // SLANG 仕様の「`= { ... }` は CODE byte stream」解釈を維持しつつ
+    // C 型整合のため WORD literal に grouping して emit する。
+    // 容量までの 0 fill は helper では行わず C implicit zero fill に委譲。
+
+    [Fact]
+    public void GlobalArrayWord_AllWordValues_EmitsCArrayInit()
+    {
+        // 全 %prefix WORD 要素: 各 2 byte LE → そのまま WORD literal に grouping
+        var src = TranspileWithEnv("""
+            ARRAY WORD W[2] = { %$1234, %$5678, %$9ABC };
+            MAIN() { PRINT(W[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // ARRAY WORD W[2] は 3 要素確保 (= index 0..2)、 init 3 WORD = 6 byte で ぴったり
+        Assert.Contains("static unsigned int V_W[3] = {0x1234, 0x5678, 0x9ABC};", src);
+    }
+
+    [Fact]
+    public void GlobalArrayWord_DefaultByteItems_GroupedAsLE()
+    {
+        // default 1 byte item を 2 byte ずつ LE で grouping して WORD literal 化。
+        // byte stream [0xAB, 0xCD, 0xEF, 0xFF] → WORD[2] = {0xCDAB, 0xFFEF}
+        var src = TranspileWithEnv("""
+            ARRAY WORD W[2] = { $AB, $CD, $EF, $FF };
+            MAIN() { PRINT(W[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // 容量 3 WORD = 6 byte に対し init 4 byte = 2 WORD、 残り 1 WORD は C implicit 0 fill
+        Assert.Contains("static unsigned int V_W[3] = {0xCDAB, 0xFFEF};", src);
+    }
+
+    [Fact]
+    public void GlobalArrayWord_OddByteCount_PadsLastByteWithZero()
+    {
+        // 奇数 byte stream の場合は末尾を 0 padding して偶数化 (= WORD grouping のため)。
+        // [0x34, 0x12, 0xAB] → +1 padding → [0x34, 0x12, 0xAB, 0x00] = WORD[2] = {0x1234, 0x00AB}
+        var src = TranspileWithEnv("""
+            ARRAY WORD W[1] = { %$1234, $AB };
+            MAIN() { PRINT(W[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // ARRAY WORD W[1] は 2 要素確保、 init 2 WORD = ぴったり
+        Assert.Contains("static unsigned int V_W[2] = {0x1234, 0x00AB};", src);
+    }
+
+    [Fact]
+    public void GlobalArrayWord_Underfilled_ImplicitlyZeroFilledByC()
+    {
+        // 容量に満たない init は helper では 0 fill せず C implicit zero fill に委譲。
+        // (= 既存 BYTE UnderfilledArrayByte_InitCode_Accepted_RestZeroFilledByC と同じ流儀)
+        var src = TranspileWithEnv("""
+            ARRAY WORD W[3] = { %$0001 };
+            MAIN() { PRINT(W[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // ARRAY WORD W[3] は 4 要素確保、 init 1 WORD のみ書き残り 3 WORD は C が 0 埋め
+        Assert.Contains("static unsigned int V_W[4] = {0x0001};", src);
+    }
+
+    [Fact]
+    public void UnsizedArrayWord_InitCode_DerivesCElementCount()
+    {
+        // 添字省略 + InitialCode: C array 長は CElementCount (= byte 数 / 2)、
+        // byte 数を直接使うと WORD で 2 倍になる事故が起きる (= Codex review High 指摘)。
+        var src = TranspileWithEnv("""
+            ARRAY WORD P[] = { %$1234, %$5678 };
+            MAIN() { PRINT(P[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // byte 数 4 → CElementCount=2、 C array V_P[2]
+        Assert.Contains("static unsigned int V_P[2] = {0x1234, 0x5678};", src);
+        // 旧 byte-count 流用で V_P[4] が出ないこと (= Codex High 指摘の回帰防止)
+        Assert.DoesNotContain("V_P[4]", src);
+    }
+
+    [Fact]
+    public void UnsizedArrayWord_OddByteCount_PadsAndDerivesCElementCount()
+    {
+        // 添字省略で source byte=1 (奇数) → +1 padding → emitted byte=2、 CElementCount=1
+        var src = TranspileWithEnv("""
+            ARRAY WORD P[] = { $AB };
+            MAIN() { PRINT(P[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static unsigned int V_P[1] = {0x00AB};", src);
+    }
+
+    [Fact]
+    public void UnsizedArrayWord_AssignmentRaisesError()
+    {
+        // 添字省略 + InitialCode の ARRAY WORD も _unsizedArraysWithInit で tracking、
+        // 代入は reject (= BYTE 配列と同様の guard が WORD でも効くこと)。
+        var src = TranspileWithEnv("""
+            ARRAY WORD P[] = { %$1234 };
+            MAIN()
+            BEGIN
+                P = $3000;
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "unsized ARRAY WORD + InitialCode の代入も error 期待");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("ARRAY", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("assign", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void LocalStaticArrayWord_InitCode_EmitsCArrayInit()
+    {
+        // 関数内 static ARRAY WORD の InitialCode も同じ logic で展開
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY WORD W[2] = { %$1234, %$5678 };
+            BEGIN
+                PRINT(W[0]);
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // ARRAY WORD W[2] は 3 要素確保、 init 2 WORD で残り 1 WORD は C implicit fill
+        Assert.Contains("static unsigned int V_MAIN_W[3] = {0x1234, 0x5678};", src);
+    }
 }


### PR DESCRIPTION
## Summary

PR #189 (v3b-D) では oscar_c の `= { ... }` initializer を **ARRAY BYTE のみ**に限定して
いた。 PR #193 (#190) で容量 check / 代入 guard を SemanticAnalyzer に汎化した結果、
ARRAY WORD InitialCode は **semantic 通過するが oscar_c emit のみ未対応** となる
backend gap が残っていた (= Issue #194 で整理した 5 gap の 1 つ)。

本 PR で `ARRAY WORD W[N] = { 値, %値, ... }` の oscar_c emit を対応。 Issue #194 の
「1 PR = 1 gap」方針に従い、 first PR は **ARRAY WORD InitialCode** に限定 (= ユーザー
判断確定)。

設計の要点:
- SLANG 仕様の「`= { ... }` は CODE byte stream」解釈を維持しつつ C 型整合のため
  2 byte ずつ little-endian で **WORD literal に grouping** して `static unsigned int
  V_W[N] = {0xNNNN, ...};` 形式で出力
- 容量埋めは helper では行わず C implicit zero fill に委譲 (= 既存 BYTE underfilled
  test と同じ流儀)
- `BuildArrayInitFromCode` の戻り値を `ArrayInitEmitResult(InitText, SourceByteCount,
  EmittedByteCount, CElementCount)` record に拡張、 unsized 経路は CElementCount を
  C 配列長に使い byte 数で 2 倍化する事故を防ぐ (= Codex plan review High 指摘対応)

残 gap (= 次 PR 以降、 #194 配下):
- (2) FLOAT prefix in ARRAY BYTE/WORD (`%%1.5`)
- (1b) ARRAY FLOAT InitialCode
- (3) StringLiteral / CodeLabelRef / 非定数 element
- (4) multi-dim 添字省略
- (5) fixed addr + InitialCode

Refs #194

## Test plan

- [x] `dotnet test` 全 421/421 pass (= 既存 BYTE / semantic regression なし)
- [x] ArrayInitOscarCTests.cs に WORD 8 ケース追加し全 pass: 全 WORD literal / default byte grouping / 奇数 byte padding / underfilled implicit fill / unsized CElementCount / unsized 奇数 byte / unsized 代入 reject / 関数内 static
- [x] c64 sample 8 個 (SPRITE/FMANDEL/JOYSPR/SIDSFX/HISCORE/SIDBGM/SIDOVERLAY/SIDBGM_SFX) smoke build 成功
- [x] ARRAY WORD InitialCode minimum sample が oscar_c で `static unsigned int V_TABLE[4] = {0x1234, 0x5678, 0x9ABC, 0xDEF0};` を emit + .prg 生成成功
- [x] Z80 backend regression: `apps/FARRAY.SL` (= 既存 `ARRAY WORD WA[5] = {1,2,3,5,7,9}` 使用箇所) の asm 出力が main branch と完全一致 (= IrGenerator 無触の証拠)

🤖 Generated with [Claude Code](https://claude.com/claude-code)