### PR TITLE
Support StringLiteral in ARRAY BYTE InitialCode for oscar_c backend (v3b-E (3a))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - 既存 Z80 backend の codegen / runtime の挙動は無変更 (= 言語側で `VOID` 予約語追加・`CFUNC` 構文追加が入っているため Parser には影響あり、 ただし既存 Z80 SLANG コードへの regression は確認なし)。
 - ARRAY initializer の容量超過 check / ARRAY symbol 代入 guard を SemanticAnalyzer に集約し全 backend で揃えた (Closes #190、 oscar_c の非 BYTE InitialCode emit 対応は別 PR 候補)。
 - oscar_c backend で `ARRAY WORD W[N] = { 値, %値, ... }` 初期化対応 (= CODE byte stream を 2 byte ずつ little-endian で WORD literal に grouping、 容量埋めは C implicit zero fill 任せ、 #194 配下 v3b-E first PR)。
+- oscar_c backend で `ARRAY BYTE S[N] = { "..." }` の StringLiteral 単独初期化対応 (= C string literal `static unsigned char V_S[N+1] = "...";` で emit、 oscar64 `-psci` で PETSCII 自動変換、 #194 配下 v3b-E (3a))。mixed (= StringLiteral + 数値) と ARRAY WORD への StringLiteral は scope 外で error。
 
 ## Version 0.24.1
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -445,6 +445,27 @@ public class CEmitter : IAstVisitor<EmitResult>
             return new ArrayInitEmitResult("{0}", 0, 0, 0);
         }
 
+        // 単独 StringLiteral path (= `ARRAY BYTE S[] = {"hello"}` / `ARRAY BYTE S[N] = {"hi"}`)
+        // は C string literal をそのまま emit して oscar64 -psci で PETSCII 化に任せる
+        // (= hex literal 列で出すと -psci 変換 が効かない、 PETSCII 自動変換は string
+        //  literal のみ対象)。 BYTE 配列限定 (WORD/FLOAT は意味曖昧 = scope 外)、 mixed
+        //  (= StringLiteral + 他要素) も loop 側で reject。
+        if (code.Count == 1 && code[0] is StringLiteral slit)
+        {
+            if (!isByteArray)
+            {
+                Error("StringLiteral element is supported only for ARRAY BYTE in oscar_c backend (= ARRAY WORD への StringLiteral は意味曖昧、 scope 外)", span);
+                return new ArrayInitEmitResult("\"\"", 0, 0, 0);
+            }
+            // SLANG 仕様 byte stream 長は SJIS bytes (= ArrayInitialCodeSizer の容量
+            // check と整合)。 C 配列は NUL 含めて確保 (= C string literal 規約)。
+            var sjisBytes = StringEncoder.ToShiftJisBytes(slit.Value, _diagnostics);
+            int strSourceBytes = sjisBytes.Length;
+            int strCElementCount = slit.Value.Length + 1; // C source の char 数 + NUL
+            string strInitText = CStringEncoder.Encode(slit.Value);
+            return new ArrayInitEmitResult(strInitText, strSourceBytes, strCElementCount, strCElementCount);
+        }
+
         var bytes = new System.Collections.Generic.List<byte>();
         foreach (var expr in code)
         {
@@ -463,13 +484,21 @@ public class CEmitter : IAstVisitor<EmitResult>
                 itemSize = cast.TargetSize == DataSize.Byte ? 1 : 2;
             }
 
+            // StringLiteral が mixed で来た (= 単独 short-circuit に入らなかった) は
+            // 別 PR scope。 単独 path だけ先に対応済 (= v3b-E (3a) first PR)。
+            if (itemExpr is StringLiteral)
+            {
+                Error("StringLiteral mixed with other items in ARRAY initializer is not supported by oscar_c backend (= 別 PR / v3b-E 候補、 単独 StringLiteral 要素なら対応済)", expr.Span);
+                continue;
+            }
+
             var constVal = _constEval.Evaluate(itemExpr);
             if (itemExpr is IntegerLiteral ilit)
                 constVal = (int)ilit.Value;
             if (!constVal.HasValue)
             {
                 // defensive (= SemanticAnalyzer で同じ error が出るはず)
-                Error("non-FLOAT ARRAY initializer element must be a compile-time constant in oscar_c backend (non-constant / string literal / CodeLabelRef の oscar_c emit 対応は別 PR / v3b-E 候補)", expr.Span);
+                Error("non-FLOAT ARRAY initializer element must be a compile-time constant in oscar_c backend (non-constant / CodeLabelRef の oscar_c emit 対応は別 PR / v3b-E 候補)", expr.Span);
                 continue;
             }
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -466,19 +466,25 @@ public class CEmitter : IAstVisitor<EmitResult>
                 Error("StringLiteral element is supported only for ARRAY BYTE in oscar_c backend (= ARRAY WORD への StringLiteral は意味曖昧、 scope 外)", span);
                 return new ArrayInitEmitResult("\"\"", 0, 0, 0);
             }
-            // 非 ASCII / 表示不可制御文字は v3b-E (3a) scope 外 で reject:
+            // 非 ASCII / 表示不可制御文字 / NUL は v3b-E (3a) scope 外 で reject:
             //   1. SLANG raw .Length と SJIS byte 数が一致しないと C 配列長 (= raw.Length + 1)
             //      が SJIS byte 数より小さくなる (= "あ" U+3042 は SJIS 2 byte / .Length=1)
             //   2. CStringEncoder の `\xNN` escape は C 仕様で後続 hex digit を食う
-            //      (例 "\x01A" → 0x1A) ため制御文字 + 続く hex char の組合せが壊れる
-            // 安全策として ASCII printable (0x20-0x7E) + 既定 escape (\n \r \t \0) のみ許可。
+            //      (例 "\x01A" → C `\x01A` = 0x1A) ため制御文字 + 続く hex char が壊れる
+            //   3. NUL (= U+0000) は CStringEncoder が `\0` (C octal escape の短縮形) で
+            //      出すため、直後が 0..7 だと C 側で octal escape として連結 (例 SLANG
+            //      `"\x007"` → C `"\07"` = [0x07] と誤解釈) → これも reject
+            // SLANG lexer 解釈に注意: `"\n"` 経由は CR (0x0D)、 `"\xNN"` 経由は raw byte、
+            // SLANG `"\r"` `"\t"` `"\0"` 自体は別の char (0x1C / 't' / '0') になるため
+            // ここの check は **char 値ベース** で判定する (= SLANG escape 構文ベースではない)。
+            // 安全策として **ASCII printable (0x20-0x7E) + CR (0x0D、 SLANG `\n` 経由) のみ** 許可。
             foreach (var ch in slit.Value)
             {
                 bool isAsciiPrintable = ch >= 0x20 && ch <= 0x7E;
-                bool isWhitelistedEscape = ch == '\n' || ch == '\r' || ch == '\t' || ch == '\0';
-                if (!isAsciiPrintable && !isWhitelistedEscape)
+                bool isAllowedNewline = ch == '\r'; // SLANG `\n` (lexer で CR=0x0D 解釈)
+                if (!isAsciiPrintable && !isAllowedNewline)
                 {
-                    Error("StringLiteral with non-ASCII / non-printable character is not supported in oscar_c ARRAY BYTE initializer (v3b-E (3a) scope は ASCII printable 0x20-0x7E + 既定 escape `\\n` `\\r` `\\t` `\\0` のみ、 高位 byte / その他制御文字は別 PR / v3b-E (3a-ext) 候補)", slit.Span);
+                    Error("StringLiteral with non-ASCII / non-printable / NUL character is not supported in oscar_c ARRAY BYTE initializer (v3b-E (3a) scope は ASCII printable 0x20-0x7E + 改行 CR (0x0D、 SLANG `\\n` 経由) のみ、 NUL / 高位 byte / その他制御文字は別 PR / v3b-E (3a-ext) 候補)", slit.Span);
                     return new ArrayInitEmitResult("\"\"", 0, 0, 0, IsCStringLiteral: true);
                 }
             }

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -394,6 +394,14 @@ public class CEmitter : IAstVisitor<EmitResult>
             // 省略 / fixed-addr) は次 PR 以降。 固定配列は C array 長 = dims から計算済
             // のためここでは InitText のみ使い、 C の implicit zero fill に容量埋めを委譲。
             var emit = BuildArrayInitFromCode(node.InitialCode, slangType, node.Span);
+            // StringLiteral 単独 path は C string literal が NUL を含んで初期化するため、
+            // 固定配列の容量 (= dims から決まる N+1 byte) が NUL 含む長さに満たないと
+            // C 上は valid (= NUL 落ち) だが SLANG 期待の終端保証が壊れる。
+            // semantic は SJIS K byte 単位で容量比較するため検知できないので backend で reject。
+            if (emit.IsCStringLiteral && emit.CElementCount > totalSize)
+            {
+                Error($"固定長 ARRAY BYTE NAME[N] = {{\"...\"}} で C string literal の NUL 終端が容量に入りません (= 容量 {totalSize} byte < NUL 含 {emit.CElementCount} byte)。容量を 1 byte 大きく、もしくは StringLiteral を短くしてください", node.Span);
+            }
             init = " = " + emit.InitText;
         }
 
@@ -417,7 +425,8 @@ public class CEmitter : IAstVisitor<EmitResult>
         string InitText,
         int SourceByteCount,
         int EmittedByteCount,
-        int CElementCount);
+        int CElementCount,
+        bool IsCStringLiteral = false);
 
     /// <summary>
     /// SLANG `ARRAY BYTE/WORD NAME[N] = { 値, %値, ... }` の InitialCode を C array
@@ -457,13 +466,30 @@ public class CEmitter : IAstVisitor<EmitResult>
                 Error("StringLiteral element is supported only for ARRAY BYTE in oscar_c backend (= ARRAY WORD への StringLiteral は意味曖昧、 scope 外)", span);
                 return new ArrayInitEmitResult("\"\"", 0, 0, 0);
             }
+            // 非 ASCII / 表示不可制御文字は v3b-E (3a) scope 外 で reject:
+            //   1. SLANG raw .Length と SJIS byte 数が一致しないと C 配列長 (= raw.Length + 1)
+            //      が SJIS byte 数より小さくなる (= "あ" U+3042 は SJIS 2 byte / .Length=1)
+            //   2. CStringEncoder の `\xNN` escape は C 仕様で後続 hex digit を食う
+            //      (例 "\x01A" → 0x1A) ため制御文字 + 続く hex char の組合せが壊れる
+            // 安全策として ASCII printable (0x20-0x7E) + 既定 escape (\n \r \t \0) のみ許可。
+            foreach (var ch in slit.Value)
+            {
+                bool isAsciiPrintable = ch >= 0x20 && ch <= 0x7E;
+                bool isWhitelistedEscape = ch == '\n' || ch == '\r' || ch == '\t' || ch == '\0';
+                if (!isAsciiPrintable && !isWhitelistedEscape)
+                {
+                    Error("StringLiteral with non-ASCII / non-printable character is not supported in oscar_c ARRAY BYTE initializer (v3b-E (3a) scope は ASCII printable 0x20-0x7E + 既定 escape `\\n` `\\r` `\\t` `\\0` のみ、 高位 byte / その他制御文字は別 PR / v3b-E (3a-ext) 候補)", slit.Span);
+                    return new ArrayInitEmitResult("\"\"", 0, 0, 0, IsCStringLiteral: true);
+                }
+            }
             // SLANG 仕様 byte stream 長は SJIS bytes (= ArrayInitialCodeSizer の容量
-            // check と整合)。 C 配列は NUL 含めて確保 (= C string literal 規約)。
+            // check と整合、 ASCII printable 限定なら SJIS == .Length)。 C 配列は NUL
+            // 含めて確保 (= C string literal 規約)。
             var sjisBytes = StringEncoder.ToShiftJisBytes(slit.Value, _diagnostics);
             int strSourceBytes = sjisBytes.Length;
             int strCElementCount = slit.Value.Length + 1; // C source の char 数 + NUL
             string strInitText = CStringEncoder.Encode(slit.Value);
-            return new ArrayInitEmitResult(strInitText, strSourceBytes, strCElementCount, strCElementCount);
+            return new ArrayInitEmitResult(strInitText, strSourceBytes, strCElementCount, strCElementCount, IsCStringLiteral: true);
         }
 
         var bytes = new System.Collections.Generic.List<byte>();
@@ -770,6 +796,13 @@ public class CEmitter : IAstVisitor<EmitResult>
                 // 容量埋めは C implicit zero fill に委譲 (= dims から決まる固定配列長
                 // を使い InitText だけ流す)。
                 var emit = BuildArrayInitFromCode(ad.InitialCode, slangType, ad.Span);
+                // StringLiteral 単独 path は C string literal が NUL を含むため、固定
+                // 配列の容量が NUL 含む長さに満たないと NUL 終端保証が壊れる (= global
+                // 経路と同じ理由)。
+                if (emit.IsCStringLiteral && emit.CElementCount > totalSize)
+                {
+                    Error($"関数内 static ARRAY BYTE NAME[N] = {{\"...\"}} で C string literal の NUL 終端が容量に入りません (= 容量 {totalSize} byte < NUL 含 {emit.CElementCount} byte)。容量を 1 byte 大きく、もしくは StringLiteral を短くしてください", ad.Span);
+                }
                 init = " = " + emit.InitText;
             }
             return Line($"static {cType} {ident}{dimsSb}{init};");

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -573,4 +573,90 @@ public class ArrayInitOscarCTests
         // SLANG `a"b\c` の 5 char + NUL = 6 byte、 C 出力で `"` `\` を escape
         Assert.Contains("static unsigned char V_MSG[6] = \"a\\\"b\\\\c\";", src);
     }
+
+    [Fact]
+    public void FixedArrayByte_StringLiteralExactSjisCapacity_RaisesNulFitError()
+    {
+        // ARRAY BYTE MSG[4] (= 容量 5 byte) に "hello" (SJIS 5 byte) は semantic では
+        // ぴったり pass するが、 C string literal は NUL 含めて 6 byte 必要 →
+        // NUL 終端が容量に入らず backend error (= Codex review Medium 指摘 (1) 対応、
+        // C 上は NUL 落ちで compile 通るが SLANG 期待の終端保証が壊れる)
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[4] = { "hello" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "固定長で NUL 終端が容量に入らない StringLiteral は backend reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("NUL", StringComparison.Ordinal)
+              && d.Message.Contains("容量", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LocalStaticArrayByte_StringLiteralExactSjisCapacity_RaisesNulFitError()
+    {
+        // 関数内 static 経路も同じ NUL 終端 check が効くこと
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY BYTE MSG[4] = { "world" };
+            BEGIN
+                PRINT(MSG[0]);
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "関数内 static でも NUL 終端 check");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("NUL", StringComparison.Ordinal)
+              && d.Message.Contains("容量", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayByte_StringLiteralNonAscii_RaisesError()
+    {
+        // 高位 byte (= "あ" 等) は SJIS bytes と char 数が一致せず、 C 配列長 / 内容が
+        // 壊れる + CStringEncoder の `\xNN` escape が後続 hex digit を食う問題もある
+        // (= Codex review Medium 指摘 (2) 対応)。 ASCII printable 限定スコープで reject。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "あ" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "非 ASCII char は v3b-E (3a) scope 外");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("non-ASCII", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("ASCII printable", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ArrayByte_StringLiteralControlChar_RaisesError()
+    {
+        // 制御文字 + 後続 hex digit (= "\x01A") は C `\xNN` escape が後続を食って
+        // 0x1A になる仕様の罠 (= Codex review Low 指摘 (3) 対応)。 制御文字も reject。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "\x01A" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "0x01 等の表示不可制御文字は v3b-E (3a) scope 外");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("non-printable", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("ASCII printable", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ArrayByte_StringLiteralAllowedEscapes_Accepted()
+    {
+        // 既定 escape (= `\n` `\r` `\t` `\0`) は scope 内で許可、 通過すること。
+        // SLANG parser は `\n` (改行) を CR (0x0D) として解釈する仕様 (= microcomputer
+        // 文化、 既存 SLANG 動作)、 そのため C 出力では `\r` escape になる。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "hi\n" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // SLANG `"hi\n"` (= 3 char with 改行=CR) + NUL = 4 byte、 C 出力で `\r`
+        Assert.Contains("static unsigned char V_MSG[4] = \"hi\\r\";", src);
+    }
 }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -446,4 +446,131 @@ public class ArrayInitOscarCTests
         // ARRAY WORD W[2] は 3 要素確保、 init 2 WORD で残り 1 WORD は C implicit fill
         Assert.Contains("static unsigned int V_MAIN_W[3] = {0x1234, 0x5678};", src);
     }
+
+    // === v3b-E (Issue #194) (3a): StringLiteral 単独 in ARRAY BYTE 対応 ===
+    // oscar64 -psci で C string literal の PETSCII 自動変換を活かすため、
+    // SLANG 仕様の SJIS byte 列 (= Z80 既存挙動) ではなく C string literal を
+    // そのまま emit する (= 意図的 backend gap)。 mixed / WORD / FLOAT は scope 外。
+
+    [Fact]
+    public void UnsizedArrayByte_StringLiteralSingle_EmitsCStringWithNul()
+    {
+        // 添字省略 + 単独 StringLiteral: C 配列長 = SJIS bytes + NUL 1 byte
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "hello" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // hex literal 列ではなく C string literal で emit (= oscar64 -psci で PETSCII 化)
+        Assert.Contains("static unsigned char V_MSG[6] = \"hello\";", src);
+    }
+
+    [Fact]
+    public void FixedArrayByte_StringLiteralExactCapacity_EmitsCString()
+    {
+        // ARRAY BYTE M[5] は 6 要素確保 = "hello" (5 char) + NUL でぴったり
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[5] = { "hello" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static unsigned char V_MSG[6] = \"hello\";", src);
+    }
+
+    [Fact]
+    public void FixedArrayByte_StringLiteralUnderfilled_ImplicitZeroFillByC()
+    {
+        // ARRAY BYTE M[9] は 10 要素確保、 "hi" (2 char) + NUL = 3 byte 書き、
+        // 残り 7 byte は C implicit zero fill (= 既存 underfilled BYTE test と整合)
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[9] = { "hi" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static unsigned char V_MSG[10] = \"hi\";", src);
+    }
+
+    [Fact]
+    public void FixedArrayByte_StringLiteralOverflow_SemanticErrorByCapacity()
+    {
+        // ARRAY BYTE M[1] は 2 要素確保、 "hello" SJIS 5 byte は超過 → semantic error
+        // (= helper の StringLiteral path 自体は通すが ArrayInitialCodeSizer で先 reject)
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[1] = { "hello" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "StringLiteral 容量超過は SLANG semantic で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("capacity", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("多すぎ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayByte_StringLiteralMixedWithOther_RaisesError()
+    {
+        // mixed (= "hi" + 数値要素) は v3b-E first PR scope 外として error
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "hi", 0 };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "StringLiteral と数値の mixed は scope 外 error");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("StringLiteral", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("mixed", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void ArrayWord_StringLiteralSingle_RaisesError()
+    {
+        // WORD 配列への StringLiteral は意味曖昧 = scope 外 error
+        var src = TranspileWithEnv("""
+            ARRAY WORD W[] = { "hi" };
+            MAIN() { PRINT(W[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY WORD への StringLiteral は scope 外 error");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("StringLiteral", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("ARRAY BYTE", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void LocalStaticArrayByte_StringLiteralSingle_EmitsCString()
+    {
+        // 関数内 static + 添字省略 + StringLiteral
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY BYTE MSG[] = { "world" };
+            BEGIN
+                PRINT(MSG[0]);
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static unsigned char V_MAIN_MSG[6] = \"world\";", src);
+    }
+
+    [Fact]
+    public void ArrayByte_StringLiteral_EscapesQuoteAndBackslash()
+    {
+        // C string literal 出力で `"` `\` 等が escape されること (= CStringEncoder 経由)
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "a\"b\\c" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // SLANG `a"b\c` の 5 char + NUL = 6 byte、 C 出力で `"` `\` を escape
+        Assert.Contains("static unsigned char V_MSG[6] = \"a\\\"b\\\\c\";", src);
+    }
 }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -644,11 +644,11 @@ public class ArrayInitOscarCTests
     }
 
     [Fact]
-    public void ArrayByte_StringLiteralAllowedEscapes_Accepted()
+    public void ArrayByte_StringLiteralAllowedNewline_Accepted()
     {
-        // 既定 escape (= `\n` `\r` `\t` `\0`) は scope 内で許可、 通過すること。
-        // SLANG parser は `\n` (改行) を CR (0x0D) として解釈する仕様 (= microcomputer
-        // 文化、 既存 SLANG 動作)、 そのため C 出力では `\r` escape になる。
+        // SLANG `\n` (lexer 解釈で CR=0x0D) は scope 内で許可、 通過すること。
+        // SLANG `\r` `\t` `\0` は SLANG lexer 仕様では別 char (= 0x1C / 't' / '0')
+        // になり、 `\r` のみ ASCII printable 外で reject 対象 (= scope 外)。
         var src = TranspileWithEnv("""
             ARRAY BYTE MSG[] = { "hi\n" };
             MAIN() { PRINT(MSG[0]); }
@@ -658,5 +658,23 @@ public class ArrayInitOscarCTests
             $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
         // SLANG `"hi\n"` (= 3 char with 改行=CR) + NUL = 4 byte、 C 出力で `\r`
         Assert.Contains("static unsigned char V_MSG[4] = \"hi\\r\";", src);
+    }
+
+    [Fact]
+    public void ArrayByte_StringLiteralNul_RaisesError()
+    {
+        // NUL (= `\x00`) は CStringEncoder が `\0` C octal escape 短縮形で出すため、
+        // 直後が 0..7 だと C 側で octal escape として連結し ARRAY 内容が壊れる
+        // (= Codex review round 2 Medium 指摘: SLANG `"\x007"` → C `"\07"` = [0x07]
+        //  と誤解釈、 期待 [0x00, '7', 0x00] にならない)。 安全策で NUL も scope 外 reject。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE MSG[] = { "\x007" };
+            MAIN() { PRINT(MSG[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "NUL 含む StringLiteral は v3b-E (3a) scope 外");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("NUL", StringComparison.Ordinal)
+              || d.Message.Contains("non-printable", StringComparison.OrdinalIgnoreCase));
     }
 }


### PR DESCRIPTION
## Summary

SLANG `ARRAY BYTE S[N] = { "hello" }` の oscar_c emit を対応 (= Issue #194 配下の
5 gap のうち (3a) StringLiteral)。 ユーザー判断で **単独 StringLiteral + ARRAY BYTE
限定**、 mixed (= StringLiteral + 数値) と ARRAY WORD への StringLiteral は scope 外
reject。

設計のポイント:
- C string literal をそのまま emit (= `static unsigned char V_S[N+1] = "hello";`)、
  hex literal 列にせず oscar64 `-psci` で **PETSCII 自動変換** させる。 oscar_c では
  PETSCII 化が肝で hex literal だと変換が効かない (= `runtime/c64/slang_runtime.c`
  の `hex_digits[]` 既存実例と同じ方針)
- 容量計算: `SourceByteCount` = SJIS bytes (= SLANG 仕様 byte stream 長、
  `ArrayInitialCodeSizer` と整合)、 `CElementCount` = char len + 1 (= NUL 含む C 規約)
- unsized 経路: C array 長 = `CElementCount` (= NUL 含む)
- 固定経路: C array 長 = SLANG `[N]` = N+1 (= 既存 dims 通り)、 init は C string
  literal で残り byte は C implicit zero fill
- mixed: loop 内で StringLiteral 出会ったら error
- ARRAY WORD への StringLiteral: short-circuit 内で reject (= 意味曖昧)

残 gap (= 次 PR 以降、 Issue #194 配下):
- (2) FLOAT prefix in ARRAY BYTE/WORD (`%%1.5`)
- (1b) ARRAY FLOAT InitialCode
- (3b) CodeLabelRef / 非定数 element / StringLiteral mixed
- (4)(5) multi-dim 添字省略 / fixed addr + InitialCode

Refs #194

## Test plan

- [x] `dotnet test` 全 429/429 pass
- [x] ArrayInitOscarCTests.cs に 8 ケース追加し全 pass: unsized NUL 含み / 固定ぴったり / 固定 underfill C implicit fill / 容量超過 semantic error / mixed reject / WORD reject / 関数内 static / escape (`\\` `\"`) 通過
- [x] c64 sample 8 個 (SPRITE/FMANDEL/JOYSPR/SIDSFX/HISCORE/SIDBGM/SIDOVERLAY/SIDBGM_SFX) smoke build 成功
- [x] `ARRAY BYTE MSG[] = {"hello"}` → `static unsigned char V_MSG[6] = "hello";` 期待通り
- [x] `ARRAY BYTE MSG[9] = {"hi"}` → `static unsigned char V_MSG[10] = "hi";` (= 残り 7 byte は C implicit zero fill)
- [x] Z80 backend: `ARRAY BYTE [...] = {"..."}` 形式の使用箇所が examples/include/runtime/apps 配下になし (= Z80 regression risk なし、 IrGenerator 無触)

🤖 Generated with [Claude Code](https://claude.com/claude-code)