### PR TITLE
Diagnose oscar_c ARRAY initializer address-ref reject as oscar64 constraint (v3b-E (3b))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - ARRAY initializer の容量超過 check / ARRAY symbol 代入 guard を SemanticAnalyzer に集約し全 backend で揃えた (Closes #190、 oscar_c の非 BYTE InitialCode emit 対応は別 PR 候補)。
 - oscar_c backend で `ARRAY WORD W[N] = { 値, %値, ... }` 初期化対応 (= CODE byte stream を 2 byte ずつ little-endian で WORD literal に grouping、 容量埋めは C implicit zero fill 任せ、 #194 配下 v3b-E first PR)。
 - oscar_c backend で `ARRAY BYTE S[N] = { "..." }` の StringLiteral 単独初期化対応 (= C string literal `static unsigned char V_S[N+1] = "...";` で emit、 oscar64 `-psci` で PETSCII 自動変換、 #194 配下 v3b-E (3a))。mixed (= StringLiteral + 数値) と ARRAY WORD への StringLiteral は scope 外で error。
+- oscar_c backend の ARRAY initializer で `%FUNC` / `%ARRAY` の address 参照 (= jump table / pointer table 用途) を **permanent backend gap** として明示 reject + workaround メッセージ (= MAIN 冒頭等で runtime 初期化に書き換え) を出すよう更新 (= oscar64 が static integer initializer で address-to-integer cast を constant initializer と認めない、 error 3008 を実機検証で確認、 #194 配下 v3b-E (3b))。Z80 backend は `DW LABEL` で linker reloc 解決可能、 backend gap として明示。
 
 ## Version 0.24.1
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -498,6 +498,20 @@ public class CEmitter : IAstVisitor<EmitResult>
             return new ArrayInitEmitResult(strInitText, strSourceBytes, strCElementCount, strCElementCount, IsCStringLiteral: true);
         }
 
+        // v3b-E (3b) 調査結果: ARRAY WORD W[] = { %FUNC, %ARRAY } 等の address reloc
+        // を oscar_c で emit する MVP を一度試したが、 oscar64 が **static integer
+        // initializer で address-to-integer cast (= `(unsigned int)F_FUNC` /
+        // `(unsigned int)V_BUF`) を constant initializer と認めない** (= error 3008
+        // Constant initializer expected) ため、 `void (*fp[])() = { foo }` 系の
+        // pointer-typed initializer なら通るが SLANG `ARRAY WORD` の C 型は unsigned int[]
+        // で意味論的に変えられない。 runtime 初期化 / 内部 `void *[]` 表現の特別扱いは
+        // (3b) MVP の範囲を超える別 issue。
+        // → **permanent backend gap**: oscar_c では `%FUNC` / `%ARRAY` の address ref
+        //   を static init に書けない、 SLANG 側で runtime 初期化 (= ARRAY 宣言後
+        //   `W[0] = %FUNC; W[1] = %ARRAY;` を main 等の冒頭で書く) で workaround。
+        // 既存 generic non-const reject (loop 内 L515 付近) で error 出るが、 message
+        // を oscar64 制約由来として明示するため下の path で個別 reject 経路を残す。
+
         var bytes = new System.Collections.Generic.List<byte>();
         foreach (var expr in code)
         {
@@ -529,8 +543,25 @@ public class CEmitter : IAstVisitor<EmitResult>
                 constVal = (int)ilit.Value;
             if (!constVal.HasValue)
             {
-                // defensive (= SemanticAnalyzer で同じ error が出るはず)
-                Error("non-FLOAT ARRAY initializer element must be a compile-time constant in oscar_c backend (non-constant / CodeLabelRef の oscar_c emit 対応は別 PR / v3b-E 候補)", expr.Span);
+                // v3b-E (3b) 調査: 非定数 IdentifierExpr (= `%FUNC` / `%ARRAY` 等の
+                //   address ref) は oscar64 が static unsigned int initializer に
+                //   address-to-integer cast (= `(unsigned int)F_FUNC`) を許容しない
+                //   (= error 3008 Constant initializer expected)、 permanent backend gap。
+                // workaround は SLANG 側で runtime 初期化 (= MAIN() の冒頭等で
+                //   `JT[0] = %FUNC; JT[1] = %ARRAY;`)、 Z80 backend は `DW LABEL` で
+                //   linker reloc 解決可能なため backend gap として明示する。
+                if (itemExpr is IdentifierExpr id)
+                {
+                    var sym = _globals?.GlobalScope.Resolve(id.Name);
+                    if (sym?.Kind == SymbolKind.Function
+                        || sym?.Kind == SymbolKind.MachineFunction
+                        || (sym?.IsArrayDecl == true && sym.IsGlobal))
+                    {
+                        Error($"ARRAY initializer の非定数 identifier `{id.Name}` の address 参照は oscar_c では未対応 (= oscar64 が static integer initializer で `(unsigned int)F_xxx` / `(unsigned int)V_xxx` を constant initializer と認めない、 error 3008)。 SLANG 側で runtime 初期化に書き換えてください (例: MAIN 冒頭で `<ARRAY 名>[i] = %{id.Name};`)。 Z80 backend は `DW LABEL` で linker reloc 解決", expr.Span);
+                        continue;
+                    }
+                }
+                Error("non-FLOAT ARRAY initializer element must be a compile-time constant in oscar_c backend (= 非定数 expression の static init は oscar64 で error 3008、 runtime 初期化に書き換え推奨)", expr.Span);
                 continue;
             }
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -557,7 +557,7 @@ public class CEmitter : IAstVisitor<EmitResult>
                         || sym?.Kind == SymbolKind.MachineFunction
                         || (sym?.IsArrayDecl == true && sym.IsGlobal))
                     {
-                        Error($"ARRAY initializer の非定数 identifier `{id.Name}` の address 参照は oscar_c では未対応 (= oscar64 が static integer initializer で `(unsigned int)F_xxx` / `(unsigned int)V_xxx` を constant initializer と認めない、 error 3008)。 SLANG 側で runtime 初期化に書き換えてください (例: MAIN 冒頭で `<ARRAY 名>[i] = %{id.Name};`)。 Z80 backend は `DW LABEL` で linker reloc 解決", expr.Span);
+                        Error($"ARRAY initializer の非定数 identifier `{id.Name}` の address 参照は oscar_c では未対応 (= oscar64 が static integer initializer で `(unsigned int)F_xxx` / `(unsigned int)V_xxx` を constant initializer と認めない、 error 3008)。 SLANG 側で runtime 初期化に書き換えてください (例: `ARRAY WORD <ARRAY 名>[N];` のように **固定サイズ宣言** にしてから MAIN 冒頭で `<ARRAY 名>[i] = %{id.Name};` で代入。 添字省略 `[]` のまま InitialCode を削ると oscar_c で pointer 宣言になるので注意)。 Z80 backend は `DW LABEL` で linker reloc 解決", expr.Span);
                         continue;
                     }
                 }

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -660,6 +660,87 @@ public class ArrayInitOscarCTests
         Assert.Contains("static unsigned char V_MSG[4] = \"hi\\r\";", src);
     }
 
+    // === v3b-E (Issue #194) (3b): ARRAY initializer 内の非定数 address 参照は
+    //   oscar_c では permanent reject ===
+    //
+    // 当初は `%FUNC` / `%ARRAY` の address ref を `(unsigned int)F_xxx` /
+    // `(unsigned int)V_xxx` で emit する MVP を試したが、 oscar64 が static integer
+    // initializer で address-to-integer cast を constant initializer と認めない
+    // (= error 3008 Constant initializer expected) ことを実機検証で確認した。
+    // `void (*fp[])(void) = { foo }` 系の pointer-typed initializer なら通るが
+    // SLANG `ARRAY WORD` の C 型は unsigned int[] で意味論的に変えられないため、
+    // permanent backend gap として明示 reject + workaround メッセージを出す。
+    // workaround: SLANG 側で runtime 初期化 (= ARRAY 宣言後 MAIN 冒頭等で
+    //   `JT[0] = %FUNC; JT[1] = %ARRAY;`)。 Z80 backend は `DW LABEL` で対応。
+
+    [Fact]
+    public void ArrayWord_FunctionRef_OscarCRejectsWithRuntimeWorkaroundHint()
+    {
+        // ARRAY WORD JT[] = { %FUNC1 } = jump table の address ref、 oscar64 制約で
+        // permanent reject、 SLANG runtime 初期化 workaround を message で誘導
+        var src = TranspileWithEnv("""
+            FUNC1() BEGIN END;
+            ARRAY WORD JT[] = { %FUNC1 };
+            MAIN() { PRINT(JT[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY WORD への function address ref は oscar_c 制約で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("FUNC1", StringComparison.Ordinal)
+              && d.Message.Contains("oscar64", StringComparison.Ordinal)
+              && d.Message.Contains("error 3008", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayWord_ArrayRef_OscarCRejectsWithRuntimeWorkaroundHint()
+    {
+        // ARRAY WORD PT[] = { %BUF1 } = pointer table の address ref、 同制約で reject
+        var src = TranspileWithEnv("""
+            ARRAY BYTE BUF1[10];
+            ARRAY WORD PT[] = { %BUF1 };
+            MAIN() { PRINT(PT[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY WORD への array address ref も同 oscar_c 制約で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("BUF1", StringComparison.Ordinal)
+              && d.Message.Contains("oscar64", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayWord_ScalarGlobalVarRef_GenericNonConstError()
+    {
+        // scalar global var への %SVAR は Function/ARRAY 判定に hit せず generic
+        // 「非定数 expression は static init で oscar64 error 3008」 message に流れる
+        var src = TranspileWithEnv("""
+            VAR WORD SVAR;
+            ARRAY WORD W[] = { %SVAR };
+            MAIN() { PRINT(W[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "scalar global var address も oscar_c で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("compile-time constant", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("oscar64", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayByte_LabelRef_GenericNonConstError()
+    {
+        // ARRAY BYTE への %FUNC ref も SLANG 仕様 (= byte stream に address) では
+        // 不可、 既存の非定数 reject path で error (= oscar64 制約 message)
+        var src = TranspileWithEnv("""
+            FUNC1() BEGIN END;
+            ARRAY BYTE B[] = { %FUNC1 };
+            MAIN() { PRINT(B[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY BYTE への label ref も oscar_c で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("FUNC1", StringComparison.Ordinal)
+              && d.Message.Contains("oscar64", StringComparison.Ordinal));
+    }
+
     [Fact]
     public void ArrayByte_StringLiteralNul_RaisesError()
     {

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -725,17 +725,20 @@ public class ArrayInitOscarCTests
     }
 
     [Fact]
-    public void ArrayByte_LabelRef_GenericNonConstError()
+    public void ArrayByte_FunctionRef_OscarCRejectsWithRuntimeWorkaroundHint()
     {
-        // ARRAY BYTE への %FUNC ref も SLANG 仕様 (= byte stream に address) では
-        // 不可、 既存の非定数 reject path で error (= oscar64 制約 message)
+        // ARRAY BYTE への %FUNC ref (= byte stream に address を 1 byte だけ詰める
+        // SLANG 構文) も oscar64 制約で reject、 既存の非定数 reject path で oscar64
+        // 制約 message に流れる。 名前を LabelRef ではなく FunctionRef にして実体
+        // (= CastExpr(Word, IdentifierExpr) で関数参照) と一致させる (Codex review Low)。
+        // 真の CodeLabelRef (`<LABEL>`) は別 SLANG 構文で別 test 対象。
         var src = TranspileWithEnv("""
             FUNC1() BEGIN END;
             ARRAY BYTE B[] = { %FUNC1 };
             MAIN() { PRINT(B[0]); }
             """, MakeC64Env(), out var diag);
 
-        Assert.True(diag.HasErrors, "ARRAY BYTE への label ref も oscar_c で reject");
+        Assert.True(diag.HasErrors, "ARRAY BYTE への function ref も oscar_c で reject");
         Assert.Contains(diag.Diagnostics,
             d => d.Message.Contains("FUNC1", StringComparison.Ordinal)
               && d.Message.Contains("oscar64", StringComparison.Ordinal));


### PR DESCRIPTION
## Summary

Issue #194 (3b) の MVP として `ARRAY WORD W[] = { %FUNC, %ARRAY }` を C で
`static unsigned int V_W[] = {(unsigned int)F_FUNC, (unsigned int)V_ARRAY};` に
emit する path を一度実装したが、 **実機検証で oscar64 が static integer initializer
で address-to-integer cast を constant initializer と認めない** (= error 3008
"Constant initializer expected") ことを確認。

ローカル oscar64 で最小 C を試した結果:
- `static unsigned int t[] = { (unsigned int)foo };` → error 3008
- `static unsigned int t[] = { (unsigned int)&foo };` → error 3008
- `static unsigned int t[] = { (unsigned int)buf };` → error 3008

一方 oscar64 でも以下は通る:
- `static void (*fp[])(void) = { foo };` (= function pointer 型 initializer)
- `static unsigned char *bp[] = { buf };` (= pointer 型 initializer)
- `static void *table[] = { (void *)0x1234, foo };` (= void* 型 initializer)

SLANG `ARRAY WORD` の C 型は `unsigned int[]` で意味論的に変えられないため、
unsigned int[] 経由で address reloc を入れる方法は oscar64 では使えない。
runtime 初期化 / 内部 `void *[]` 表現の特別扱いは (3b) MVP の範囲を超える別 issue
(= 「address table 特別表現」、 ARRAY WORD と区別する型システム拡張要)。

本 PR では **permanent backend gap** として diagnose、 SLANG ユーザーに runtime
初期化への書き換えを促す具体的 workaround message を出す。 Z80 backend は
`DW LABEL` で linker reloc 解決可能、 backend gap として明示。

実装:
- `BuildArrayInitFromCode` の非定数 IdentifierExpr reject path で `_globals` 経由
  symbol resolve、 Function / MachineFunction / ARRAY global は専用 oscar64 制約説明
  message、 それ以外 (scalar / local var) は generic non-const reject
- CHANGELOG に backend gap 明示

残 gap (= 次 PR 以降、 #194 配下):
- (2) FLOAT prefix in ARRAY BYTE/WORD (`%%1.5`)
- (1b) ARRAY FLOAT InitialCode
- (4)(5) multi-dim 添字省略 / fixed addr + InitialCode

Refs #194

## Test plan

- [x] `dotnet test` 全 439/439 pass
- [x] ArrayInitOscarCTests に 4 ケース追加: ARRAY WORD への function ref / array ref / scalar global var ref / ARRAY BYTE への label ref、 全 reject + workaround message 確認
- [x] c64 sample 8 個 (SPRITE/FMANDEL/JOYSPR/SIDSFX/HISCORE/SIDBGM/SIDOVERLAY/SIDBGM_SFX) smoke build 成功 (= 既存 BYTE/WORD/StringLiteral path に影響なし)
- [x] 実機検証: `dotnet $SLANGC -E c64 -I include /tmp/jt.SL` (= `ARRAY WORD JT[] = { %F1 };`) → reject + oscar64 制約説明 + workaround message

🤖 Generated with [Claude Code](https://claude.com/claude-code)