### PR TITLE
Remove dead fixed-addr + InitialCode guard in oscar_c CEmitter (v3b-E (5))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - oscar_c backend で `ARRAY WORD W[N] = { 値, %値, ... }` 初期化対応 (= CODE byte stream を 2 byte ずつ little-endian で WORD literal に grouping、 容量埋めは C implicit zero fill 任せ、 #194 配下 v3b-E first PR)。
 - oscar_c backend で `ARRAY BYTE S[N] = { "..." }` の StringLiteral 単独初期化対応 (= C string literal `static unsigned char V_S[N+1] = "...";` で emit、 oscar64 `-psci` で PETSCII 自動変換、 #194 配下 v3b-E (3a))。mixed (= StringLiteral + 数値) と ARRAY WORD への StringLiteral は scope 外で error。
 - oscar_c backend の ARRAY initializer で `%FUNC` / `%ARRAY` の address 参照 (= jump table / pointer table 用途) を **permanent backend gap** として明示 reject + workaround メッセージ (= MAIN 冒頭等で runtime 初期化に書き換え) を出すよう更新 (= oscar64 が static integer initializer で address-to-integer cast を constant initializer と認めない、 error 3008 を実機検証で確認、 #194 配下 v3b-E (3b))。Z80 backend は `DW LABEL` で linker reloc 解決可能、 backend gap として明示。
+- oscar_c CEmitter の `ARRAY ...:address = { ... }` (= fixed addr + InitialCode) 防衛 error を削除 (= SLANG parser が文法レベルで reject するため到達不能、 #194 配下 v3b-E (5))。 parser reject を pin する test を追加。
 
 ## Version 0.24.1
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -300,13 +300,11 @@ public class CEmitter : IAstVisitor<EmitResult>
         // 1 つでも null = 間接配列 (= ポインタ)、宣言は static T *A_name;
         bool isIndirect = node.Dimensions.Any(d => d == null);
 
-        // ARRAY x:address + InitialCode は不整合 (固定 addr に初期値併用は SLANG では
-        // 意味曖昧)、 oscar_c backend では明示 error にして silently drop を防ぐ。
-        if (node.Address != null && node.InitialCode != null)
-        {
-            Error("`ARRAY ...:address = { ... }` (fixed address with initializer) is not supported by oscar_c backend", node.Span);
-            return new("", null);
-        }
+        // (v3b-E (5) 調査結果: `ARRAY ...:address = { ... }` (fixed addr + InitialCode)
+        //  は SLANG parser 自体が文法 reject する (= "Expected expression, got LBrace '{'"、
+        //  `:address` の後に `;` か別の syntax が来るのが文法)、 CEmitter には到達しない
+        //  ため defensive guard は dead code として削除。 ArrayInitOscarCTests に
+        //  parser reject を pin する test を追加。)
 
         // ARRAY x:address → static T *A_x = (T*)addr;
         if (node.Address != null)

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -660,6 +660,25 @@ public class ArrayInitOscarCTests
         Assert.Contains("static unsigned char V_MSG[4] = \"hi\\r\";", src);
     }
 
+    [Fact]
+    public void ArrayWithFixedAddressAndInitCode_ParserRejects()
+    {
+        // SLANG 文法レベルで `ARRAY x:address = { ... }` は parse error
+        // (= `:address` の後に LBrace は来ない)。 つまり CEmitter の Address +
+        // InitialCode 分岐は到達不能 = dead code。 v3b-E (5) で defensive guard を
+        // 削除した際の回帰防止 (= 将来 parser に `:address = { ... }` 受理が入っても
+        // この test が落ちて気付ける)。
+        var src = TranspileWithEnv("""
+            ARRAY BYTE A:$3000 = { 1, 2, 3 };
+            MAIN() { PRINT(A[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "`ARRAY ...:address = { ... }` は SLANG parser で reject される文法");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("Expected expression", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("LBrace", StringComparison.OrdinalIgnoreCase));
+    }
+
     // === v3b-E (Issue #194) (3b): ARRAY initializer 内の非定数 address 参照は
     //   oscar_c では permanent reject ===
     //


### PR DESCRIPTION
## Summary

Issue #194 配下 (5) の調査結果: SLANG parser が `ARRAY x:address = { ... }` syntax
を文法レベルで reject する (= `"Expected expression, got LBrace '{'"`、 `:address`
の後に LBrace は来ない文法) ため、 CEmitter の defensive guard
(`if (node.Address != null && node.InitialCode != null)`) は dead code。
c64 / lsx (Z80) どちらでも同じ parse error が出ることを実機で確認。

変更:
- CEmitter から該当 guard を削除、 dead code 化していた経緯と SLANG parser が
  reject する事実を comment で残す
- ArrayInitOscarCTests に `ArrayWithFixedAddressAndInitCode_ParserRejects` を
  追加して parser reject を pin (= 将来 parser に `:address = { ... }` 受理が
  入った場合に test が落ちて気付ける)

残 gap (= 次 PR 以降、 #194 配下 3 件):
- (2) FLOAT prefix in ARRAY BYTE/WORD (`%%1.5`)
- (1b) ARRAY FLOAT InitialCode
- (4) multi-dim 添字省略

Refs #194

## Test plan

- [x] `dotnet test` 全 440/440 pass
- [x] c64 sample 8 個 smoke build 成功 (= dead code 削除で regression なし)
- [x] 実機: `ARRAY BYTE A:$3000 = { 1, 2, 3 };` は c64 / lsx 共に parse error で reject

🤖 Generated with [Claude Code](https://claude.com/claude-code)