### PR TITLE
Support ARRAY FLOAT InitialCode + diagnose %% FLOAT prefix in oscar_c (v3b-E (1b)+(2))

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - oscar_c backend で `ARRAY BYTE S[N] = { "..." }` の StringLiteral 単独初期化対応 (= C string literal `static unsigned char V_S[N+1] = "...";` で emit、 oscar64 `-psci` で PETSCII 自動変換、 #194 配下 v3b-E (3a))。mixed (= StringLiteral + 数値) と ARRAY WORD への StringLiteral は scope 外で error。
 - oscar_c backend の ARRAY initializer で `%FUNC` / `%ARRAY` の address 参照 (= jump table / pointer table 用途) を **permanent backend gap** として明示 reject + workaround メッセージ (= MAIN 冒頭等で runtime 初期化に書き換え) を出すよう更新 (= oscar64 が static integer initializer で address-to-integer cast を constant initializer と認めない、 error 3008 を実機検証で確認、 #194 配下 v3b-E (3b))。Z80 backend は `DW LABEL` で linker reloc 解決可能、 backend gap として明示。
 - oscar_c CEmitter の `ARRAY ...:address = { ... }` (= fixed addr + InitialCode) 防衛 error を削除 (= SLANG parser が文法レベルで reject するため到達不能、 #194 配下 v3b-E (5))。 parser reject を pin する test を追加。
+- oscar_c backend で `ARRAY FLOAT FA[N] = { 1.0, 2.0, ... }` 初期化対応 (= oscar64 native float32 で `static float V_FA[N+1] = {1.0, 2.0};` emit、 整数 element は自動的に float promote、 容量未満は C implicit zero fill、 #194 配下 v3b-E (1b))。非定数 element は oscar64 制約で reject + runtime 初期化 hint message。 `ARRAY BYTE/WORD` 内の `%%` FLOAT prefix は SLANG parser 文法上未対応 + oscar_c は f24 byte stream 表現を持たないため意味的にも対応不能、 ARRAY FLOAT を使う旨を CEmitter defensive guard で diagnose (= #194 配下 v3b-E (2))。
 
 ## Version 0.24.1
 

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -446,10 +446,55 @@ public class CEmitter : IAstVisitor<EmitResult>
     {
         bool isByteArray = elementType is PrimitiveType { Kind: PrimitiveKind.Byte };
         bool isWordArray = elementType is PrimitiveType { Kind: PrimitiveKind.Word };
-        if (!isByteArray && !isWordArray)
+        bool isFloatArray = elementType is PrimitiveType { Kind: PrimitiveKind.Float };
+        if (!isByteArray && !isWordArray && !isFloatArray)
         {
-            Error("`= { ... }` initializer is supported only for ARRAY BYTE / ARRAY WORD in oscar_c backend (= ARRAY FLOAT InitialCode の oscar_c emit 対応は別 PR / v3b-E 候補)", span);
+            Error("`= { ... }` initializer is supported only for ARRAY BYTE / WORD / FLOAT in oscar_c backend", span);
             return new ArrayInitEmitResult("{0}", 0, 0, 0);
+        }
+
+        // v3b-E (1b): ARRAY FLOAT FA[N] = { 1.0, 2.0, ... } 専用 path
+        // oscar64 native float32 を使い `static float V_FA[N+1] = {1.0, 2.0};` で emit。
+        // SLANG semantic は f24 (3 byte/elem) 基準で容量計算するが、 oscar_c では
+        // float32 (4 byte/elem) 基準で C 配列確保 = element 数ベースで偶然整合する
+        // (= 容量 N+1 elements 以内に init element が収まれば semantic / C 両方 pass)。
+        // ユーザー指示: oscar 側 float のみ考慮、 SLANG f24 byte stream layout は無視。
+        if (isFloatArray)
+        {
+            var floatLiterals = new System.Collections.Generic.List<string>(code.Count);
+            bool sawFloatError = false;
+            foreach (var expr in code)
+            {
+                // トップレベル CastExpr は ArrayInitialCodeSizer で先 reject 済 = defensive
+                if (expr is CastExpr)
+                {
+                    Error("Cast expression not allowed in FLOAT array initializer (= ArrayInitialCodeSizer で先 reject 済、 defensive)", expr.Span);
+                    sawFloatError = true;
+                    continue;
+                }
+                // ConstEvaluator.EvaluateFloat で値解決 (= FloatLiteral / IntegerLiteral
+                // promote / 定数式 1.0 + 2.0 等を C float literal に展開)
+                var fv = _constEval.EvaluateFloat(expr);
+                if (fv.HasValue)
+                {
+                    // oscar64 は float の `f` suffix を受け付けない (= 既存 VisitFloatLiteral
+                    // と同じ規約)、 `.0` を含む形に補完して float literal を確定させる
+                    string lit = fv.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
+                    if (!lit.Contains('.') && !lit.Contains('e') && !lit.Contains('E')) lit += ".0";
+                    floatLiterals.Add(lit);
+                    continue;
+                }
+                // 非定数 (= 識別子参照等) は oscar64 static initializer 制約で reject
+                // (= 既存 (3b) 知見、 error 3008 Constant initializer expected と同じ理由)
+                Error("ARRAY FLOAT initializer element must be a compile-time constant in oscar_c backend (= 非定数 expression の static init は oscar64 で error 3008、 MAIN 冒頭等で runtime 初期化に書き換え推奨)", expr.Span);
+                sawFloatError = true;
+            }
+            if (sawFloatError) return new ArrayInitEmitResult("{0}", 0, 0, 0);
+            string fInitText = "{" + string.Join(", ", floatLiterals) + "}";
+            // SourceByteCount = SLANG semantic 基準 (= f24 3 byte/elem)、
+            // EmittedByteCount = oscar64 float32 基準 (= 4 byte/elem)、
+            // CElementCount = element 数 (= caller の C 配列長算出 / NUL fit check に使う)
+            return new ArrayInitEmitResult(fInitText, code.Count * 3, code.Count * 4, code.Count);
         }
 
         // 単独 StringLiteral path (= `ARRAY BYTE S[] = {"hello"}` / `ARRAY BYTE S[N] = {"hi"}`)
@@ -520,9 +565,11 @@ public class CEmitter : IAstVisitor<EmitResult>
                 itemExpr = cast.Operand;
                 if (cast.TargetSize == DataSize.Float)
                 {
-                    // 非 FLOAT 配列の %% は SemanticAnalyzer は許可するが、 oscar_c emit
-                    // は未対応 (= defensive、 SemanticAnalyzer 通過しても oscar_c で reject)
-                    Error("FLOAT (`%%`) prefix in ARRAY BYTE / WORD initializer is not supported by oscar_c backend (= 別 PR / v3b-E 候補)", expr.Span);
+                    // FLOAT prefix (= `%%1.5`) は SLANG 仕様で f24 (= 3 byte) を byte
+                    // stream に流す機能だが、 oscar_c は oscar64 native float32 mapped で
+                    // f24 byte 表現を持たないため意味的に **permanent backend gap**。
+                    // ユーザーが float 値を ARRAY に詰めたい場合は ARRAY FLOAT を使う。
+                    Error("FLOAT prefix (`%%`) in ARRAY BYTE / WORD initializer is not supported by oscar_c backend (= oscar64 は f24 byte stream 表現を持たない、 ARRAY FLOAT FA[N] = { 1.0, ... } を使ってください、 #194 配下 v3b-E (2) permanent backend gap)", expr.Span);
                     continue;
                 }
                 itemSize = cast.TargetSize == DataSize.Byte ? 1 : 2;

--- a/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
+++ b/src/SLANGCompiler.Core/CodeGen/C/CEmitter.cs
@@ -473,15 +473,13 @@ public class CEmitter : IAstVisitor<EmitResult>
                     continue;
                 }
                 // ConstEvaluator.EvaluateFloat で値解決 (= FloatLiteral / IntegerLiteral
-                // promote / 定数式 1.0 + 2.0 等を C float literal に展開)
+                // promote / 定数式 1.0 + 2.0 等を C float literal に展開)。
+                // oscar64 は exponent notation (= `1E-05`) を float literal として
+                // 受理しないため、 共通 helper で固定小数点 + `.0` 補完に整形する。
                 var fv = _constEval.EvaluateFloat(expr);
                 if (fv.HasValue)
                 {
-                    // oscar64 は float の `f` suffix を受け付けない (= 既存 VisitFloatLiteral
-                    // と同じ規約)、 `.0` を含む形に補完して float literal を確定させる
-                    string lit = fv.Value.ToString("R", System.Globalization.CultureInfo.InvariantCulture);
-                    if (!lit.Contains('.') && !lit.Contains('e') && !lit.Contains('E')) lit += ".0";
-                    floatLiterals.Add(lit);
+                    floatLiterals.Add(FormatFloatForOscar64Literal(fv.Value));
                     continue;
                 }
                 // 非定数 (= 識別子参照等) は oscar64 static initializer 制約で reject
@@ -1359,11 +1357,36 @@ public class CEmitter : IAstVisitor<EmitResult>
 
     public EmitResult VisitFloatLiteral(FloatLiteral node)
     {
-        // oscar64 は float リテラルの `f` suffix を受け付けない (ANSI C と差異)。
-        // 整数表記 (`1`) は int になるため、必ず `.` を含める形にする。
-        var s = node.Value.ToString("R", CultureInfo.InvariantCulture);
-        if (!s.Contains('.') && !s.Contains('e') && !s.Contains('E')) s += ".0";
-        return new(s, SlangType.Float);
+        return new(FormatFloatForOscar64Literal(node.Value), SlangType.Float);
+    }
+
+    /// <summary>
+    /// double 値を oscar64 が受理する C float literal 形式に整形する。 oscar64 は
+    /// (1) `f` suffix 不可 (= ANSI C と差異)、 (2) **exponent notation (`1E-05` 等)
+    /// を float literal として受理しない** (= Codex review #199 で実機確認) ため、
+    /// `R` (短い round-trip) を優先しつつ、 exponent が含まれた場合のみ F17 で
+    /// 固定小数点 fallback して trailing zeros を除去する (= `0.00001` の精度悪化
+    /// を避けつつ `3.14` の精度誤差表記 (`3.14000000000000012`) も避ける)。 整数値
+    /// (`1`) は `.0` 補完で float literal 確定。
+    /// </summary>
+    internal static string FormatFloatForOscar64Literal(double v)
+    {
+        string s = v.ToString("R", CultureInfo.InvariantCulture);
+        // exponent (= 1E-05 / 1e+30) が出たら F17 で固定小数点 fallback
+        if (s.IndexOfAny(new[] { 'e', 'E' }) >= 0)
+        {
+            s = v.ToString("F17", CultureInfo.InvariantCulture);
+            if (s.Contains('.'))
+            {
+                s = s.TrimEnd('0');
+                if (s.EndsWith('.')) s += '0';
+            }
+        }
+        else if (!s.Contains('.'))
+        {
+            s += ".0";
+        }
+        return s;
     }
 
     public EmitResult VisitStringLiteral(StringLiteral node)

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -764,6 +764,27 @@ public class ArrayInitOscarCTests
     }
 
     [Fact]
+    public void ArrayFloat_SmallValue_EmitsFixedPointNotation()
+    {
+        // .NET の R format は `0.00001` 等で exponent (= `1E-05`) に逃げるが、
+        // oscar64 は exponent notation を float literal として受理しない
+        // (= Codex review #199 High 指摘で実機確認、 parse error)。 共通 formatter
+        // が exponent を検知して F17 trimEnd fallback で固定小数点表記にすること
+        // を pin。
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[] = { 0.00001 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        // exponent notation `1E-05` 等は含まれず、 固定小数点 `0.00001` で emit
+        Assert.Contains("static float V_FA[1] = {0.00001};", src);
+        Assert.DoesNotContain("E-", src);
+        Assert.DoesNotContain("e-", src);
+    }
+
+    [Fact]
     public void LocalStaticArrayFloat_InitCode_EmitsCArrayInit()
     {
         // 関数内 static ARRAY FLOAT の InitialCode も同じ logic で展開

--- a/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
+++ b/tests/SLANGCompiler.Tests/ArrayInitOscarCTests.cs
@@ -117,19 +117,8 @@ public class ArrayInitOscarCTests
         Assert.Contains("static unsigned char V_MAIN_LOCAL[3] = {0xCD, 0xAB, 0xEF};", src);
     }
 
-    [Fact]
-    public void ArrayFloat_InitCode_StillRejected()
-    {
-        // v3b-D scope: ARRAY BYTE 限定。ARRAY FLOAT の InitialCode は明示 error
-        var src = TranspileWithEnv("""
-            ARRAY FLOAT FA[2] = { 1.0, 2.0, 3.0 };
-            MAIN() { PRINT(FA[0]); }
-            """, MakeC64Env(), out var diag);
-
-        Assert.True(diag.HasErrors, "ARRAY FLOAT init は v3b-D scope 外として error 期待");
-        Assert.Contains(diag.Diagnostics,
-            d => d.Message.Contains("ARRAY BYTE", StringComparison.OrdinalIgnoreCase));
-    }
+    // (v3b-D 時代の `ArrayFloat_InitCode_StillRejected` は v3b-E (1b) で ARRAY FLOAT
+    //  InitialCode 対応により撤回、 後続の `GlobalArrayFloat_*` test 群で置換)
 
     [Fact]
     public void UnsizedArrayByte_InitCode_DerivesSizeFromInit()
@@ -658,6 +647,160 @@ public class ArrayInitOscarCTests
             $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
         // SLANG `"hi\n"` (= 3 char with 改行=CR) + NUL = 4 byte、 C 出力で `\r`
         Assert.Contains("static unsigned char V_MSG[4] = \"hi\\r\";", src);
+    }
+
+    // === v3b-E (Issue #194) (1b): ARRAY FLOAT InitialCode の oscar_c 対応 ===
+    // oscar64 native float32 mapped、 各 element を C float literal で emit する。
+    // SLANG semantic は f24 (3 byte/elem) 基準で容量計算するが、 oscar_c は
+    // element 数ベースで C 配列確保 (= float32 で 4 byte/elem)、 容量整合は
+    // element 数ベースで偶然 OK。 user 指示: oscar 側 float のみ考慮、 f24 layout 無視。
+
+    [Fact]
+    public void GlobalArrayFloat_AllFloatLiterals_EmitsCArrayInit()
+    {
+        // ARRAY FLOAT FA[2] = 3 要素確保、 init 3 element でぴったり
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[2] = { 1.0, 2.5, 3.14 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static float V_FA[3] = {1, 2.5, 3.14};", src.Replace("1.0", "1"));
+        // 念のため形のみ pin (= 1.0 / 1 どちらの表現でも OK、 oscar64 で float に promote)
+        Assert.Contains("static float V_FA[3] =", src);
+    }
+
+    [Fact]
+    public void GlobalArrayFloat_IntegerPromotion_EmitsAsFloatLiteral()
+    {
+        // IntegerLiteral element (= `42`) は ConstEvaluator.EvaluateFloat で
+        // double 化、 `.0` 補完で float literal `42.0` として emit
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[2] = { 42, 1.5 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static float V_FA[3] = {42.0, 1.5};", src);
+    }
+
+    [Fact]
+    public void GlobalArrayFloat_Underfilled_ImplicitZeroFillByC()
+    {
+        // ARRAY FLOAT FA[3] = 4 要素確保、 init 1 element、 残り 3 element は C
+        // implicit 0 fill (= 既存 BYTE/WORD/String と同じ流儀)
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[3] = { 1.0 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static float V_FA[4] = {1.0};", src);
+    }
+
+    [Fact]
+    public void UnsizedArrayFloat_InitCode_DerivesCElementCount()
+    {
+        // 添字省略 + InitialCode = init element 数で C 配列長確定
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[] = { 1.0, 2.0 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static float V_FA[2] = {1.0, 2.0};", src);
+    }
+
+    [Fact]
+    public void ArrayFloat_Overflow_SemanticRejectsWithCapacity()
+    {
+        // ARRAY FLOAT FA[1] = 2 elem = 6 byte 容量、 init 3 elem = 9 byte は超過、
+        // ArrayInitialCodeSizer で semantic reject (= byte 単位 6 vs 9 比較)
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[1] = { 1.0, 2.0, 3.0 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY FLOAT 容量超過は semantic で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("capacity", StringComparison.OrdinalIgnoreCase)
+              || d.Message.Contains("多すぎ", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayFloat_TopLevelCastExpr_SemanticRejects()
+    {
+        // ARRAY FLOAT 内の `%expr` (= トップレベル CastExpr) は SLANG 仕様で禁止、
+        // ArrayInitialCodeSizer.CalculateFloatArrayBytes で先 reject
+        var src = TranspileWithEnv("""
+            ARRAY FLOAT FA[2] = { %1.0 };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "FLOAT 配列内のトップレベル CastExpr は semantic 違反");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("Cast expression not allowed in FLOAT array", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ArrayFloat_NonConstantElement_OscarCRejectsWithRuntimeWorkaroundHint()
+    {
+        // 非定数 element (= VAR FLOAT 参照) は oscar64 static initializer 制約で reject、
+        // (3b) と同じ「runtime 初期化に書き換え」 hint message
+        var src = TranspileWithEnv("""
+            VAR FLOAT FV;
+            ARRAY FLOAT FA[2] = { FV };
+            MAIN() { PRINT(FA[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY FLOAT で非定数 element は oscar_c で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("compile-time constant", StringComparison.OrdinalIgnoreCase)
+              && d.Message.Contains("oscar64", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void LocalStaticArrayFloat_InitCode_EmitsCArrayInit()
+    {
+        // 関数内 static ARRAY FLOAT の InitialCode も同じ logic で展開
+        var src = TranspileWithEnv("""
+            MAIN()
+                ARRAY FLOAT FA[2] = { 1.0, 2.0 };
+            BEGIN
+                PRINT(FA[0]);
+            END;
+            """, MakeC64Env(), out var diag);
+
+        Assert.False(diag.HasErrors,
+            $"errors: {string.Join("; ", diag.Diagnostics.Select(d => d.Message))}");
+        Assert.Contains("static float V_MAIN_FA[3] = {1.0, 2.0};", src);
+    }
+
+    // === v3b-E (Issue #194) (2): FLOAT prefix in ARRAY BYTE/WORD は parser でも reject ===
+    // SLANG `%%` (= FLOAT cast prefix) は parser で非 FLOAT 配列の InitialCode 内では
+    // 受理されない (= ArrayInitSemanticTests のコメント L85 で言及済)、 CEmitter の
+    // FLOAT prefix reject guard は dead code として保険のみ。 oscar_c は oscar64 native
+    // float32 mapped で f24 byte stream 表現を持たないため意味的にも対応不能、
+    // ARRAY FLOAT を使う workaround を CEmitter message で促す (= 到達した場合の保険)。
+
+    [Fact]
+    public void ArrayBytePrefixDoublePercent_ParserRejects()
+    {
+        // ARRAY BYTE A[] = { %%1.5 } の `%%` は parser 文法上 ARRAY initializer 内では
+        // 受理されない (= future syntax)。 parser reject を pin、 将来 parser に
+        // `%%` InitialCode 受理が入った場合に test が落ちて気付ける
+        var src = TranspileWithEnv("""
+            ARRAY BYTE A[5] = { %%1.5 };
+            MAIN() { PRINT(A[0]); }
+            """, MakeC64Env(), out var diag);
+
+        Assert.True(diag.HasErrors, "ARRAY BYTE 内の `%%` は parser で reject");
+        Assert.Contains(diag.Diagnostics,
+            d => d.Message.Contains("Expected", StringComparison.OrdinalIgnoreCase));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Issue #194 配下 (1b) + (2) を 1 PR で対応。 ユーザー指示「**oscar 側 float のみ
考慮、 SLANG f24 byte stream layout は無視**」に基づき oscar64 native float32 で
ARRAY FLOAT InitialCode を emit する。

### (1b) ARRAY FLOAT InitialCode

`ARRAY FLOAT FA[N] = { 1.0, 2.0, ... }` を oscar_c で
`static float V_FA[N+1] = {1.0, 2.0};` の形で emit。

- SLANG semantic は f24 (3 byte/elem) 基準で容量計算するが、 oscar_c では
  element 数ベースで C 配列確保 (= float32 / 4 byte/elem)、 element 数整合は
  semantic / C 両方で偶然成立する (= byte 単位 reject と C 仕様 element 単位
  reject が同じ範囲を覆う)
- IntegerLiteral element は自動的に float promote (`42` → `42.0`)
- 容量未満は C implicit zero fill (= 既存 BYTE/WORD/String と同じ流儀)
- 非定数 element は oscar64 static initializer 制約で reject + runtime 初期化
  workaround hint (= 既存 (3b) 同パターン)
- トップレベル CastExpr は ArrayInitialCodeSizer で先 semantic reject + helper
  内 defensive guard

### (2) FLOAT prefix in ARRAY BYTE/WORD

`ARRAY BYTE A[] = { %%1.5 }` の `%%` FLOAT prefix:
- SLANG parser が ARRAY initializer 内の `%%` を文法レベルで受理しない
  (= 既存 `ArrayInitSemanticTests` L85 のコメントで言及)
- oscar_c は oscar64 native float32 mapped で f24 byte stream 表現を持たない、
  仮に parser が将来受理しても意味的に対応不能 = **permanent backend gap**
- CEmitter defensive guard の error message を「f24 byte stream 表現を持たない、
  ARRAY FLOAT FA[N] = { 1.0, ... } を使ってください」 に diagnose 改善
- parser reject を pin する test を追加 (= 将来 parser 拡張時に気付ける)

## 既存 test 撤回

`ArrayFloat_InitCode_StillRejected` (v3b-D scope = ARRAY BYTE 限定で
ARRAY FLOAT InitialCode を error 期待) は (1b) 対応で挙動が変わるため撤回。
後続の `GlobalArrayFloat_*` test 群で置換。

## 残 gap (= 次 PR 以降、 #194 配下)

- (4) multi-dim 添字省略 (= `ARRAY BYTE A[][3] = {...}`)

Refs #194

## Test plan

- [x] `dotnet test` 全 448/448 pass
- [x] ArrayInitOscarCTests に 9 ケース追加: ARRAY FLOAT 全 element / int promote / underfill / unsized / 容量超過 semantic reject / CastExpr semantic reject / 非定数 oscar64 制約 reject / 関数内 static / `%%` parser reject pin
- [x] c64 sample 8 個 smoke build 成功
- [x] 実機検証 (oscar64 build): ARRAY FLOAT 各 case 全て .prg 生成成功
- [x] Z80 backend regression: `apps/FARRINIT.SL` / `apps/FARRAY.SL` の asm 出力が main branch と完全一致 (= IrGenerator 無触)

🤖 Generated with [Claude Code](https://claude.com/claude-code)