### PR TITLE
Add x1native runtime (OS 非依存 X1 hardware 直、 Phase A for tape output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - oscar_c CEmitter の `ARRAY ...:address = { ... }` (= fixed addr + InitialCode) 防衛 error を削除 (= SLANG parser が文法レベルで reject するため到達不能、 #194 配下 v3b-E (5))。 parser reject を pin する test を追加。
 - oscar_c backend で `ARRAY FLOAT FA[N] = { 1.0, 2.0, ... }` 初期化対応 (= oscar64 native float32 で `static float V_FA[N+1] = {1.0, 2.0};` emit、 整数 element は自動的に float promote、 容量未満は C implicit zero fill、 #194 配下 v3b-E (1b))。非定数 element は oscar64 制約で reject + runtime 初期化 hint message。 `ARRAY BYTE/WORD` 内の `%%` FLOAT prefix は SLANG parser 文法上未対応 + oscar_c は f24 byte stream 表現を持たないため意味的にも対応不能、 ARRAY FLOAT を使う旨を CEmitter defensive guard で diagnose (= #194 配下 v3b-E (2))。
 - oscar_c backend で `ARRAY BYTE/WORD A[][M] = { ... }` (= multi-dim 第 1 次元省略) の InitialCode 対応 (= C99 auto dim 推論 `static T V_A[][M+1] = {flat init};` で emit、 第 1 次元は C compiler が init 量から推定、 #194 配下 v3b-E (4))。ARRAY FLOAT multi-dim および第 2 次元以降の `[]` 省略は scope 外で error (= C99 仕様で第 1 次元のみ省略可)。これで #194 配下 v3b-E は完了。
+- X1 環境に **OS 非依存の `x1native` env** を新設 (= Phase A、 将来 .tap / .wav テープ出力対応のための土台)。 既存 `x1.env` / `sosx1.env` (= LSX-Dodgers / S-OS 依存) は完全無触、 新規 `libx1native_base/input/print.asm` 3 ファイルで SLANGINIT / sGETKY (X1 sub CPU $1900 polling) / sPRINT (text VRAM $3000 直書き) を native 実装、 `libx1_base.asm` (VSYNC) のみ既存 reuse。 file I/O は linker undefined symbol で reject (= 必要なら lsx / sosx1 env を使う)、 D88 boot / graphics / PSG / PCG は Phase A scope 外。 出典: LSX-Dodgers (MIT) / X1_compatible_rom (CC0) を参考実装、 各 asm header に attribution。 詳細は [docs/X1.md](docs/X1.md) 参照。
 
 ## Version 0.24.1
 

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -1,0 +1,105 @@
+# SLANG X1 環境ガイド
+
+SLANG compiler の X1 (= シャープ X1 / X1turbo 系) 向け環境一覧と、 OS 非依存
+`x1native` env の使い方。
+
+## 環境一覧
+
+| env | OS | 用途 |
+|---|---|---|
+| `x1` | LSX-Dodgers (= 主に X1 上の disk OS) | D88 disk image で配布、 LSX 上で実行 |
+| `lsx` | LSX-Dodgers (= 汎用 LSX) | LSX 系 一般 |
+| `sosx1` | S-OS for X1 / X1turbo | S-OS 系 disk |
+| `x1native` (**新規 Phase A**) | **OS なし** (= X1 hardware 直) | tape boot / monitor load 想定 |
+
+## `x1native` env — OS 非依存 runtime
+
+LSX / S-OS が動いてない素の X1 上で boot して動く binary を生成する env。
+目標: X1 tape (.tap / .wav) で配布 = Phase B で対応予定 (= 本ガイドは Phase A 完成時点)。
+
+### scope (Phase A)
+
+- **対応**: PRINT (文字列 + 改行 + 数値) / INKEY (= 0: no-wait, 1: wait 1 回, else: ループ wait) / VSYNC
+- **未対応 (= Phase A scope 外)**:
+  - WIDTH / SCREEN / LOCATE / PRMODE (= 後続段階で native 実装予定)
+  - file I/O API (FOPEN / FCLOSE / FREAD / FWRITE / FSEEK) = **linker undefined symbol** で reject、 必要なら `lsx` or `sosx1` env を使う
+  - D88 disk image boot (= 既存 `DiskImageBuilder` は OS 上で動く binary を template に追加する流儀、 OS なしには loader 設計が別途必要)
+  - graphics / PSG / PCG / SGL / magic chars (= `libx1_psg.asm` 等が OS_TYPE==0 で LSX 固定 addr 使用、 後続 Phase で native branch 追加)
+
+### env 設定
+
+`runtime/env/x1native.env`:
+```yaml
+env_type: 1           # X1 hardware (= 既存 x1.env と同じ identity)
+os_type: 4            # 新規割当、 X1 native / no OS
+defines:
+  X1NATIVE: 1         # SLANG `#IF X1NATIVE` 条件分岐用
+default_org: "$1000"  # X1 tape boot 慣習 (= Phase B で tap header load addr と整合)
+output: bin           # Phase A = flat binary のみ
+libraries:
+  - runtime.yml
+  - libfloat.yml
+  - libx1native_base.yml   # SLANGINIT / STOP / sWORK (新規)
+  - libx1native_input.yml  # sGETKY 等 (新規、 X1 sub CPU $1900 polling)
+  - libx1native_print.yml  # sPRINT 等 (新規、 X1 text VRAM $3000 直書き)
+  - libx1_base.yml         # VSYNC reuse (既存、 LSX 非依存)
+  - libcompress.yml
+  - libsoroban.yml
+```
+
+### sample
+
+`examples/X1NATIVE_HELLO.SL`:
+```sl
+MAIN()
+BEGIN
+    PRINT("HELLO, X1 NATIVE!");
+    PRINT(/);
+    PRINT("PRESS ANY KEY...");
+    PRINT(/);
+    INKEY(0);
+END;
+```
+
+build:
+```sh
+SLANGC=src/SLANGCompiler.CLI/bin/Debug/net8.0/slangc.dll
+dotnet $SLANGC -E x1native -o HELLO.asm examples/X1NATIVE_HELLO.SL
+# AILZ80ASM 等で HELLO.asm → HELLO.bin
+```
+
+### 動作確認 (= Phase A は emulator memory load)
+
+1. `HELLO.bin` を X1 emulator (xmil / X-millenium 等) の monitor / memory load 機能で `$1000` に流し込む
+2. PC = `$1000` にセットして実行
+3. 期待: `HELLO, X1 NATIVE!` 表示 + キー入力で停止解除
+
+D88 boot による実用的な配布は **Phase B (= tap / wav 出力対応)** で対応予定。
+
+### 検証 (= LSX 切り離し confirm)
+
+生成 asm 内に LSX 痕跡が含まれていないことを確認:
+```sh
+# comment / attribution 行を除外してから check
+grep -v '^\s*;' HELLO.asm | grep -E "CALL.*\\\$0005|\(\\\$0001\)|\\\$EE8C|\\\$EE8E|\\\$EE92"
+# 何も出ないこと (= LSX BDOS call / LSX work area / LSX 固定 addr 不在)
+```
+
+### ライセンス / 出典
+
+x1native runtime asm は以下を出典明示で参考実装:
+- **LSX-Dodgers** (MIT、 Gaku 1995): SLANGINIT 構造 / sWORK pattern / 上位 routine 構造
+- **X1_compatible_rom** (CC0、 Meister 2020-、 https://github.com/meister68k/X1_compatible_rom): KBHIT / WAIT_80C49_WR / READ_80C49 / VRAM layout / TXTCUR 定数
+
+各 asm file の header に attribution comment あり。
+
+## 既存 env (= LSX / S-OS) との比較
+
+既存 `x1.env` (LSX-Dodgers) / `sosx1.env` (S-OS X1) は **完全に無触**、 既存 SLANG
+コード regression なし。 必要に応じて使い分け:
+
+| 要件 | 推奨 env |
+|---|---|
+| LSX-Dodgers disk 上で配布 / disk file I/O 使う | `x1` |
+| S-OS for X1 disk 上で配布 | `sosx1` |
+| **OS なしで起動 / tape boot 用 / 単体 binary** | `x1native` (Phase A) |

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -58,13 +58,16 @@ libraries:
 
 `examples/X1NATIVE_HELLO.SL`:
 ```sl
+VAR K;
+
 MAIN()
 BEGIN
     PRINT("HELLO, X1 NATIVE!");
     PRINT(/);
     PRINT("PRESS ANY KEY...");
     PRINT(/);
-    INKEY(0);
+    K = INKEY(1);   // 1 = wait until any key (0 = no-wait, n>=2 = loop wait)
+    PRINT("KEY:", K, /);
 END;
 ```
 

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -19,12 +19,19 @@ LSX / S-OS が動いてない素の X1 上で boot して動く binary を生成
 
 ### scope (Phase A)
 
-- **対応**: PRINT (文字列 + 改行 + 数値) / INKEY (= 0: no-wait, 1: wait 1 回, else: ループ wait) / VSYNC
+- **対応**:
+  - **SLANGINIT 初期化**: DI + SP set + __WORK__ clear + **8255 init (port B 入力 mode)** + **text/attribute VRAM clear ($3000-$37FF を space + $2000-$27FF を白)** + cursor 初期化 + MAIN call + inline HALT loop
+  - PRINT: 文字列 + 改行 + 数値、 native sPRINT (= port-mapped text VRAM 書込 + attribute 白で書込)
+  - INKEY (= 0: no-wait, 1: wait 1 回, else: ループ wait)
+  - VSYNC (= 既存 libx1_base.asm reuse)
 - **未対応 (= Phase A scope 外)**:
-  - WIDTH / SCREEN / LOCATE / PRMODE (= 後続段階で native 実装予定)
+  - **PRINT scroll**: 25 行目到達で **最終行に固定上書き** (= port-mapped VRAM の LDIR 不可、 1920 cell × IN+OUT loop 後続 PR で実装)
+  - **CRTC 初期化**: emulator boot ROM / IPL が **WIDTH 80 mode で初期化済** の前提 (= X1_compatible_rom INIT_CRTC は WIDTH 40、 WIDTH 80 パラメタ別途必要、 後続 PR)
+  - WIDTH / SCREEN / LOCATE / PRMODE (= S-OS BIOS 依存、 後続段階で native 実装予定)
   - file I/O API (FOPEN / FCLOSE / FREAD / FWRITE / FSEEK) = **linker undefined symbol** で reject、 必要なら `lsx` or `sosx1` env を使う
   - D88 disk image boot (= 既存 `DiskImageBuilder` は OS 上で動く binary を template に追加する流儀、 OS なしには loader 設計が別途必要)
   - graphics / PSG / PCG / SGL / magic chars (= `libx1_psg.asm` 等が OS_TYPE==0 で LSX 固定 addr 使用、 後続 Phase で native branch 追加)
+  - **unit test の runtime asm 内容検証**: 現状 env YAML pin の 5 件のみ、 「実 SLANG → asm 生成 + 内容 grep」 は CodeGenerator + RuntimeManager setup の複雑性で別 PR (= integration test として slangc CLI spawn ベース予定)。 現状は本 docs の manual verification 手順で代替。
 
 ### env 設定
 

--- a/examples/X1NATIVE_HELLO.SL
+++ b/examples/X1NATIVE_HELLO.SL
@@ -1,0 +1,13 @@
+// X1 native runtime (= OS 非依存) の動作確認 sample
+// build: slangbuild -E x1native -I include examples/X1NATIVE_HELLO.SL -o HELLO
+// 実行: X1 emulator (xmil 等) の monitor で .bin を $1000 に load → PC=$1000 jump
+// 期待: "HELLO, X1 NATIVE!" 表示 + キー入力で停止解除
+
+MAIN()
+BEGIN
+    PRINT("HELLO, X1 NATIVE!");
+    PRINT(/);
+    PRINT("PRESS ANY KEY...");
+    PRINT(/);
+    INKEY(0);
+END;

--- a/examples/X1NATIVE_HELLO.SL
+++ b/examples/X1NATIVE_HELLO.SL
@@ -2,6 +2,7 @@
 // build: slangbuild -E x1native -I include examples/X1NATIVE_HELLO.SL -o HELLO
 // 実行: X1 emulator (xmil 等) の monitor で .bin を $1000 に load → PC=$1000 jump
 // 期待: "HELLO, X1 NATIVE!" 表示 + キー入力で停止解除
+VAR K;
 
 MAIN()
 BEGIN
@@ -9,5 +10,6 @@ BEGIN
     PRINT(/);
     PRINT("PRESS ANY KEY...");
     PRINT(/);
-    INKEY(1);   // 1 = wait until any key (0 = no-wait, n>=2 = loop wait)
+    K = INKEY(1);   // 1 = wait until any key (0 = no-wait, n>=2 = loop wait)
+    PRINT("KEY:", K, /);
 END;

--- a/examples/X1NATIVE_HELLO.SL
+++ b/examples/X1NATIVE_HELLO.SL
@@ -9,5 +9,5 @@ BEGIN
     PRINT(/);
     PRINT("PRESS ANY KEY...");
     PRINT(/);
-    INKEY(0);
+    INKEY(1);   // 1 = wait until any key (0 = no-wait, n>=2 = loop wait)
 END;

--- a/runtime/env/x1native.env
+++ b/runtime/env/x1native.env
@@ -1,0 +1,15 @@
+env_type: 1
+os_type: 4
+defines:
+  X1NATIVE: 1
+default_org:	"$1000"
+output: bin
+libraries:
+  - runtime.yml
+  - libfloat.yml
+  - libx1native_base.yml
+  - libx1native_input.yml
+  - libx1native_print.yml
+  - libx1_base.yml
+  - libcompress.yml
+  - libsoroban.yml

--- a/runtime/libx1native_base.asm
+++ b/runtime/libx1native_base.asm
@@ -1,0 +1,70 @@
+; libx1native_base.asm
+; SLANG x1native runtime — OS 非依存 X1 hardware 直接 access
+;
+; Adapted from:
+;   - liblsx_base.asm (SLANG-compiler, MIT) — SLANGINIT 構造、 __WORK__ clear pattern
+;   - libsosx1_base.asm (SLANG-compiler, MIT) — SEARCHCTC / X1turbo 割り込みパッチ (将来追加用、 本 file 未実装)
+;   - libx1_base.asm (SLANG-compiler, MIT) — VSYNC / SETUPCTC は別 lib (libx1_base) でそのまま reuse
+;   - X1_compatible_rom (Meister, CC0 1.0 Universal、 https://github.com/meister68k/X1_compatible_rom)
+;     参考: X1 memory layout 定数 (text VRAM=$3000, attribute VRAM=$2000, TXTCUR=$FF80)
+;
+; Phase A scope:
+;   - SLANGINIT: SP set + __WORK__ clear + cursor init + IY + MAIN call → STOP
+;   - STOP: DI + HALT loop
+;   - CRTC / VRAM clear / SEARCHCTC は本 file scope 外 (= emulator boot ROM の画面
+;     初期化を信頼、 native binary は load + PC jump で起動)。 後続 Phase で追加。
+
+; @name SLANGINIT
+; @resident local
+; @calls sWORK
+DI
+; SP は default_org ($1000) 直前に置く。 emulator load 時に boot ROM 経由 SP が
+; 既に有効でも、 安全のため明示設定 (= スタック overflow しても user code に
+; 喰い込まない範囲)。
+LD SP, $0FFE
+
+; WORK ZERO CLEAR
+XOR A
+LD HL, __WORK__
+LD DE, __WORK__+1
+LD BC, __WORKEND__-__WORK__-1
+LD (HL), A
+LDIR
+
+<<CALLINITIALIZER>>
+
+; cursor 初期値 (= __WORK__ 内 sXYADR を 0,0 に)。 __WORK__ clear で既に 0 だが
+; 明示的に書く。 LSX 同期 ($FF80 = TXTCUR) は意図的に行わない (= native は独立)。
+XOR A
+LD (sXYADR), A
+LD (sXYADR+1), A
+
+LD IY, __IYWORK
+
+CALL MAIN
+
+; MAIN return 後の暴走防止 (= OS なしで戻り先がないため inline HALT loop)。
+; STOP() を SLANG コードから明示的に呼出された場合は別 routine (@resident shared) を使う。
+DI
+.slang_halt:
+HALT
+JR .slang_halt
+
+
+; @name STOP
+; @resident shared
+; @param_count 0
+; SLANG コード `STOP()` 明示呼出時の停止。 OS なしで戻り先なし、 DI + HALT loop。
+; LSX BDOS exit `JP 0` の代替。
+DI
+.stop_halt:
+HALT
+JR .stop_halt
+
+
+; @name sWORK
+; @resident shared
+; @param_count 0
+; @works sXYADR:2,sKBFAD:128,sKBFAD0:1,sKBFAD1:1,sKBFADX:81,sPRBF:80,sSUBPS:2,sSUBBF:256,_CTCVEC:2,_CTC:2
+; LSX 同名 work area を踏襲 (= sPRINT / sGETL 等の互換性確保)。 LSX 固定 addr
+; ($EE8C / $EE8E / $EE92 等) は使わない、 全て __WORK__ 内 BSS。

--- a/runtime/libx1native_base.asm
+++ b/runtime/libx1native_base.asm
@@ -33,11 +33,40 @@ LDIR
 
 <<CALLINITIALIZER>>
 
+; --- X1 hardware 初期化 (= X1_compatible_rom IPLBOT 参考、 CC0) ---
+; INIT_8255: port B のみ入力 mode (= 8255 CWR $1A03 に $82)
+LD BC, $1A03
+LD A, $82
+OUT (C), A
+
+; CLR_VRAM_ALL: text VRAM $3000-$37FF を space + attribute $2000-$27FF を白で fill
+; (= X1_compatible_rom CLR_VRAM_ALL + CLR_VRAM、 256 byte × 8 block = $800 byte loop)
+LD A, 8           ; HIGH(TXTSIZ=$800) = 8 block (= 256 byte × 8)
+LD HL, $2007      ; H = $20 (space) / L = $07 (white attribute) = TEXT_STD
+LD BC, $3000      ; BC = IOTEXT (text VRAM base port)
+.clrv_text:
+OUT (C), H        ; text: space を 256 byte
+INC C
+JR NZ, .clrv_text
+RES 4, B          ; bit 4 clear: text ($30) → attribute ($20)
+.clrv_attr:
+OUT (C), L        ; attribute: white を 256 byte
+INC C
+JR NZ, .clrv_attr
+SET 4, B          ; bit 4 set: attribute ($20) → text ($30)
+INC B             ; 次 256 byte block ($3000 → $3100 → ... → $3700)
+DEC A
+JR NZ, .clrv_text
+
 ; cursor 初期値 (= __WORK__ 内 sXYADR を 0,0 に)。 __WORK__ clear で既に 0 だが
 ; 明示的に書く。 LSX 同期 ($FF80 = TXTCUR) は意図的に行わない (= native は独立)。
 XOR A
 LD (sXYADR), A
 LD (sXYADR+1), A
+
+; CRTC 初期化は本 file scope 外 (= IPL / emulator boot ROM が WIDTH 80 mode で
+;  設定済の前提、 X1_compatible_rom は WIDTH 40 / 80 別パラメタ table 必要)。
+;  WIDTH 切替が必要なら後続 PR で別 routine 追加。
 
 LD IY, __IYWORK
 

--- a/runtime/libx1native_input.asm
+++ b/runtime/libx1native_input.asm
@@ -1,0 +1,116 @@
+; libx1native_input.asm
+; SLANG x1native runtime — keyboard input (OS 非依存)
+;
+; X1 keyboard input は sub CPU (= 80C49 @ port $1900) 経由:
+;   1. 8255 port B ($1A01) の bit40h (write 可能 flag) 待ち
+;   2. $1900 に command 0xE6 (= keyboard 入力) 送信
+;   3. 再度 write 可能待ち
+;   4. 8255B bit20h (read 可能 flag) 待ち → $1900 から function key (= 1 byte 読み捨て)
+;   5. 同様 → $1900 から ASCII (= 本命 1 byte)
+;
+; Adapted from:
+;   - liblsx_input.asm (SLANG-compiler, MIT) — INKEY / LINPUT / GETL / GETLIN 構造
+;   - X1_compatible_rom (Meister, CC0) — KBHIT / WAIT_80C49_WR / READ_80C49 シーケンス
+;     (https://github.com/meister68k/X1_compatible_rom L1164-1232)
+;
+; Phase A scope: sGETKY / sFLGET / sINKEY / INKEY のみ。 LINPUT / GETL / GETLIN /
+; INPUT は LSX 既存 path (= sGETL = BDOS 経路) に依存するため、 sample で使わなければ
+; dead code 除去で問題なし。 完全対応は後続段階。
+
+; --- I/O ports ---
+; IO8255B  EQU $1A01   ; 8255 port B (status flag for 80C49 sub CPU)
+; IO80C49  EQU $1900   ; sub CPU 80C49 data port
+; (EQU は asm 内で局所使用、 LSX 同名 symbol との衝突回避のため inline 即値で書く)
+
+
+; @name sGETKY
+; @resident shared
+; @param_count 0
+; X1 keyboard 1 byte 取得 (= no wait、 押されてなければ A=0)
+; X1_compatible_rom KBHIT 相当
+PUSH BC
+EI
+; WAIT_80C49_WR: 8255B bit40h が 0 になるまで wait (= sub CPU 書込み可能)
+LD BC, $1A01
+.gk_w1:
+IN A, (C)
+AND $40
+JR NZ, .gk_w1
+; command 送信
+LD BC, $1900
+LD A, $E6
+OUT (C), A
+; 再度 wait
+LD BC, $1A01
+.gk_w2:
+IN A, (C)
+AND $40
+JR NZ, .gk_w2
+DI
+; READ_80C49 ×1: function key (読み捨て)
+LD BC, $1A01
+.gk_r1:
+IN A, (C)
+AND $20
+JR NZ, .gk_r1
+LD BC, $1900
+IN A, (C)        ; function key (使わない)
+; READ_80C49 ×2: ASCII (本命)
+LD BC, $1A01
+.gk_r2:
+IN A, (C)
+AND $20
+JR NZ, .gk_r2
+LD BC, $1900
+IN A, (C)
+POP BC
+OR A             ; flag 更新
+RET
+
+
+; @name sFLGET
+; @resident shared
+; @param_count 0
+; @calls sGETKY
+; キーが押されるまで wait (= LSX BDOS DIRIN 相当)
+.fl_loop:
+CALL sGETKY
+OR A
+JR Z, .fl_loop
+RET
+
+
+; @name sINKEY
+; @resident shared
+; @param_count 0
+; @calls sGETKY
+; LSX 既存と同 semantic: sGETKY ループで wait
+.ik_loop:
+CALL sGETKY
+OR A
+JR Z, .ik_loop
+RET
+
+
+; @name INKEY
+; @resident shared
+; @param_count 1
+; @calls sGETKY,sFLGET,sINKEY
+; SLANG `INKEY(n)`: n=0 → sGETKY (no wait), n=1 → sFLGET (wait once),
+; その他 → sINKEY (loop wait)
+; liblsx_input.asm INKEY と同 logic
+LD A,L
+CP 1
+JR NC,.inkey1
+CALL sGETKY
+JR .inkey_end
+.inkey1
+JR NZ,.inkey2
+CALL sFLGET
+JR .inkey_end
+.inkey2
+CALL sINKEY
+.inkey_end
+LD L,A
+LD H,0
+RET

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -87,6 +87,11 @@ LD B, A
 DB $ED, $71   ; OUT (C), 0 = kanji area に 0 (= ANK 文字、 Z80 未定義命令)
 RES 3, B      ; bit 3 clear ($38→$30、 text region)
 OUT (C), E    ; OUT text (= 文字コード)
+; attribute も白で書込 (= IPL_PUTCHAR と同戦略、 boot ROM 初期値依存を回避)。
+; bit 4 clear で $30→$20 (attribute region)、 $07 = 白
+RES 4, B
+LD A, $07
+OUT (C), A
 ; cursor X 進行
 LD HL, sXYADR
 INC (HL)
@@ -161,10 +166,15 @@ JR .pstr1
 ; @name PCHR
 ; @resident shared
 ; @calls PRT
+; 既存 libx1_print.asm L243-251 と同じく、 H / L が 0 なら sPRINT skip
+; (= NUL 文字を VRAM に書かない、 cursor 進めない、 Codex review Medium 指摘修正)
 LD A, H
-CALL PRT
+OR A
+CALL NZ, PRT
 LD A, L
-JR PRT
+OR A
+JR NZ, PRT
+RET
 
 
 ; @name PRT

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -1,102 +1,109 @@
 ; libx1native_print.asm
-; SLANG x1native runtime — text print (OS 非依存、 X1 text VRAM 直書き)
+; SLANG x1native runtime — text print (OS 非依存、 X1 port-mapped text VRAM 書込)
+;
+; **重要**: X1 の text VRAM は **port-mapped I/O** (= `OUT (C), A`、 BC = VRAM addr)、
+; 単純な `LD (HL), A` では書けない (= main RAM に書いてしまう)。 既存 libx1_print.asm
+; PRT (LSX 上で動作実績あり) と X1_compatible_rom IPL_PUTCHAR の sequence を採用:
+;   1. BC に VRAM addr (= $0000-$07CF が text 領域内 offset)
+;   2. LD A,B; OR $38; LD B,A   ← 上位 nibble に $38 = text VRAM region 選択
+;   3. DB $ED,$71  (OUT (C),0 = Z80 未定義命令)  ← kanji = 0 (= ANK 文字指定)
+;   4. RES 3, B    ← bit 3 clear ($38→$30) で text 領域に切替
+;   5. OUT (C), A  ← text VRAM 書込 (= 文字コード)
+;   6. attribute は触らず (= boot ROM 初期色のまま、 IPL_PUTCHAR と同様の MVP 戦略)
 ;
 ; Strategy: sPRINT (= 1 char emit) のみ native 実装、 上位 routine (PRT / PSTR /
-; PCRONE / PCR / PCR1 / PCHR / PHEX / PRT / P10 / PMSG / PMSX / MPRNT / PSIGN) は
-; libsos_print.asm から copy 流用 (= 全部 PRT 経由、 PRT は sPRINT を JP)。
-; WIDTH / PRMODE / SCREEN / LOCATE は S-OS BIOS 依存のため本 file scope 外
-; (= MVP sample で使わない、 必要なら後続段階で native 実装)。
+; PCRONE / 等) は libsos_print.asm から copy 流用 (= 全部 PRT 経由、 PRT = JP sPRINT)。
+; WIDTH / PRMODE / SCREEN / LOCATE は scope 外 (= MVP sample で使わない)。
 ;
-; Text VRAM layout (= X1):
-;   $3000-$37FF : text VRAM (80 col × 25 row = 2000 byte)
-;   $2000-$27FF : attribute VRAM (boot ROM 初期値そのまま、 本 file は text のみ書込)
+; X1 text VRAM layout:
+;   port-mapped、 BC = $30xx (text) / $20xx (attribute) / $10xx (kanji)
+;   80 col × 25 row = 2000 byte (= offset $0000-$07CF)
 ;
-; Cursor: sXYADR (L=X 0-79, H=Y 0-24)、 LSX 同名 work area を __WORK__ 内で保持
+; Cursor: sXYADR (L=X 0-79, H=Y 0-24)、 LSX 同名 work area を __WORK__ 内で保持。
+; scroll は port-mapped VRAM だと LDIR 不可 (= 1920 cell × IN+OUT loop) で重い、
+; MVP は Y=25 到達で stop (= 最終行に居続け、 後続 char は同じ位置を上書き)。
 ;
 ; Adapted from:
+;   - libx1_print.asm (SLANG-compiler, MIT) — PRT 内 VRAM port-mapped OUT sequence
 ;   - libsos_print.asm (SLANG-compiler, MIT) — PRT 系上位 routine
-;   - X1_compatible_rom (Meister, CC0) — IPL_PUTCHAR / IPLPRN_1 周辺 (VRAM 書込 pattern)
-;     (https://github.com/meister68k/X1_compatible_rom L1247-1340)
+;   - X1_compatible_rom (Meister, CC0) — IPL_PUTCHAR 実装 (BIT_ATTR_TEXT 反転)
+;     (https://github.com/meister68k/X1_compatible_rom L1262-1280)
 
 
 ; @name sPRINT
 ; @resident shared
 ; @param_count 0
 ; @calls sWORK
-; X1 native: A = char code を text VRAM に書き込み + cursor 進行
-; - $0D (CR): 行頭に戻す → 次行
-; - $0A (LF): 無視 (CR と LF は LSX 流儀で CR=改行、 LF は noop)
-; - $08 (BS): 後退 (本 MVP は未対応、 通常文字扱い)
-; - 他: VRAM 書込 + cursor X 進行、 X=80 で自動改行、 Y=25 で scroll up
+; A = char code
+; - $0D (CR): X=0, Y++ (= sp_do_cr)
+; - $0A (LF): no-op
+; - 他: text VRAM port-mapped 書込 + cursor X 進行、 X=80 で auto CR
+PUSH AF
 PUSH BC
 PUSH DE
 PUSH HL
-LD (sp_char_buf), A   ; char を退避 (= POP DE で E が破壊されるため、 別途保存)
 LD E, A
 CP $0D
 JR Z, .sp_cr
 CP $0A
 JR Z, .sp_end
-; 通常文字
-LD HL, (sXYADR)   ; L=X, H=Y
+; 通常文字: X=80 なら auto CR
+LD HL, (sXYADR)
 LD A, L
 CP 80
 JR C, .sp_putc
-; 行末超え: auto CR
 PUSH DE
 CALL sp_do_cr
 POP DE
 LD HL, (sXYADR)
 .sp_putc:
-; VRAM addr = $3000 + Y*80 + X
-PUSH HL
+; HL = Y*80 + X を計算 (= text 領域内 offset 0-$07CF)
+PUSH DE
 LD A, H
+LD D, 0
+LD E, A       ; DE = Y (= 0-24)
 LD H, 0
-LD D, H
-LD B, A           ; B = Y count
-OR A
-JR Z, .sp_no_y
+LD L, 0       ; HL = 0
 LD BC, 80
-LD H, 0
-LD L, 0
+OR A
+JR Z, .sp_no_y_loop
 .sp_y_loop:
-ADD HL, BC
+ADD HL, BC    ; HL += 80
 DEC A
 JR NZ, .sp_y_loop
-JR .sp_addy
-.sp_no_y:
-LD H, 0
-LD L, 0
-.sp_addy:
-POP DE            ; D=元Y, E=元X
-LD A, E
+.sp_no_y_loop:
+POP DE        ; DE 復元 (E=char、 D=?)
+; HL += X (= sXYADR low byte)
+LD A, (sXYADR)
 LD B, 0
 LD C, A
-ADD HL, BC        ; HL = Y*80 + X
-LD BC, $3000
-ADD HL, BC        ; HL = $3000 + Y*80 + X
-LD A, (sp_char_buf)
-LD (HL), A
+ADD HL, BC    ; HL = Y*80 + X (= 0-$07CF)
+; port-mapped OUT (libx1_print.asm PRT sequence)
+LD B, H
+LD C, L
+LD A, B
+OR $38        ; text VRAM region (= bit set $30-$37 範囲)
+LD B, A
+DB $ED, $71   ; OUT (C), 0 = kanji area に 0 (= ANK 文字、 Z80 未定義命令)
+RES 3, B      ; bit 3 clear ($38→$30、 text region)
+OUT (C), E    ; OUT text (= 文字コード)
 ; cursor X 進行
 LD HL, sXYADR
 INC (HL)
 JR .sp_end
 .sp_cr:
 CALL sp_do_cr
-JR .sp_end
 .sp_end:
 POP HL
 POP DE
 POP BC
+POP AF
 RET
 
-; --- internal helpers (= label private to file) ---
-sp_char_buf: DB 0   ; char 一時保存用 (= sPRINT 内の POP DE で E が破壊されるため必要)
 
-; CR 処理: X=0, Y++、 Y=25 なら scroll up
+; CR 処理: X=0, Y++、 Y=25 到達で stop (= MVP、 scroll は port-mapped 重いので後回し)
 sp_do_cr:
-PUSH BC
-PUSH DE
+PUSH AF
 PUSH HL
 XOR A
 LD (sXYADR), A     ; X = 0
@@ -104,27 +111,13 @@ LD HL, sXYADR+1
 INC (HL)           ; Y++
 LD A, (HL)
 CP 25
-JR C, .sp_cr_done
-; Y=25: scroll up = text VRAM を 80 byte 上に移動、 最終行 clear
-LD HL, $3000+80    ; src = 2 行目
-LD DE, $3000       ; dst = 1 行目
-LD BC, 80*24       ; 24 行分
-LDIR
-; 最終行 clear (= space で埋める、 $20)
-LD HL, $3000+80*24
-LD A, $20
-LD B, 80
-.sp_clr_last:
-LD (HL), A
-INC HL
-DJNZ .sp_clr_last
-; Y を 24 に戻す
+JR C, .spcr_done
+; Y=25 到達: 最終行に固定 (= scroll なし、 上書きされ続ける、 後続 PR で port-mapped scroll 実装)
 LD A, 24
 LD (sXYADR+1), A
-.sp_cr_done:
+.spcr_done:
 POP HL
-POP DE
-POP BC
+POP AF
 RET
 
 

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -44,7 +44,7 @@ CP 80
 JR C, .sp_putc
 ; 行末超え: auto CR
 PUSH DE
-CALL .sp_do_cr
+CALL sp_do_cr
 POP DE
 LD HL, (sXYADR)
 .sp_putc:
@@ -82,7 +82,7 @@ LD HL, sXYADR
 INC (HL)
 JR .sp_end
 .sp_cr:
-CALL .sp_do_cr
+CALL sp_do_cr
 JR .sp_end
 .sp_end:
 POP HL
@@ -94,7 +94,7 @@ RET
 sp_char_buf: DB 0   ; char 一時保存用 (= sPRINT 内の POP DE で E が破壊されるため必要)
 
 ; CR 処理: X=0, Y++、 Y=25 なら scroll up
-.sp_do_cr:
+sp_do_cr:
 PUSH BC
 PUSH DE
 PUSH HL

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -1,0 +1,317 @@
+; libx1native_print.asm
+; SLANG x1native runtime — text print (OS 非依存、 X1 text VRAM 直書き)
+;
+; Strategy: sPRINT (= 1 char emit) のみ native 実装、 上位 routine (PRT / PSTR /
+; PCRONE / PCR / PCR1 / PCHR / PHEX / PRT / P10 / PMSG / PMSX / MPRNT / PSIGN) は
+; libsos_print.asm から copy 流用 (= 全部 PRT 経由、 PRT は sPRINT を JP)。
+; WIDTH / PRMODE / SCREEN / LOCATE は S-OS BIOS 依存のため本 file scope 外
+; (= MVP sample で使わない、 必要なら後続段階で native 実装)。
+;
+; Text VRAM layout (= X1):
+;   $3000-$37FF : text VRAM (80 col × 25 row = 2000 byte)
+;   $2000-$27FF : attribute VRAM (boot ROM 初期値そのまま、 本 file は text のみ書込)
+;
+; Cursor: sXYADR (L=X 0-79, H=Y 0-24)、 LSX 同名 work area を __WORK__ 内で保持
+;
+; Adapted from:
+;   - libsos_print.asm (SLANG-compiler, MIT) — PRT 系上位 routine
+;   - X1_compatible_rom (Meister, CC0) — IPL_PUTCHAR / IPLPRN_1 周辺 (VRAM 書込 pattern)
+;     (https://github.com/meister68k/X1_compatible_rom L1247-1340)
+
+
+; @name sPRINT
+; @resident shared
+; @param_count 0
+; @calls sWORK
+; X1 native: A = char code を text VRAM に書き込み + cursor 進行
+; - $0D (CR): 行頭に戻す → 次行
+; - $0A (LF): 無視 (CR と LF は LSX 流儀で CR=改行、 LF は noop)
+; - $08 (BS): 後退 (本 MVP は未対応、 通常文字扱い)
+; - 他: VRAM 書込 + cursor X 進行、 X=80 で自動改行、 Y=25 で scroll up
+PUSH BC
+PUSH DE
+PUSH HL
+LD (sp_char_buf), A   ; char を退避 (= POP DE で E が破壊されるため、 別途保存)
+LD E, A
+CP $0D
+JR Z, .sp_cr
+CP $0A
+JR Z, .sp_end
+; 通常文字
+LD HL, (sXYADR)   ; L=X, H=Y
+LD A, L
+CP 80
+JR C, .sp_putc
+; 行末超え: auto CR
+PUSH DE
+CALL .sp_do_cr
+POP DE
+LD HL, (sXYADR)
+.sp_putc:
+; VRAM addr = $3000 + Y*80 + X
+PUSH HL
+LD A, H
+LD H, 0
+LD D, H
+LD B, A           ; B = Y count
+OR A
+JR Z, .sp_no_y
+LD BC, 80
+LD H, 0
+LD L, 0
+.sp_y_loop:
+ADD HL, BC
+DEC A
+JR NZ, .sp_y_loop
+JR .sp_addy
+.sp_no_y:
+LD H, 0
+LD L, 0
+.sp_addy:
+POP DE            ; D=元Y, E=元X
+LD A, E
+LD B, 0
+LD C, A
+ADD HL, BC        ; HL = Y*80 + X
+LD BC, $3000
+ADD HL, BC        ; HL = $3000 + Y*80 + X
+LD A, (sp_char_buf)
+LD (HL), A
+; cursor X 進行
+LD HL, sXYADR
+INC (HL)
+JR .sp_end
+.sp_cr:
+CALL .sp_do_cr
+JR .sp_end
+.sp_end:
+POP HL
+POP DE
+POP BC
+RET
+
+; --- internal helpers (= label private to file) ---
+sp_char_buf: DB 0   ; char 一時保存用 (= sPRINT 内の POP DE で E が破壊されるため必要)
+
+; CR 処理: X=0, Y++、 Y=25 なら scroll up
+.sp_do_cr:
+PUSH BC
+PUSH DE
+PUSH HL
+XOR A
+LD (sXYADR), A     ; X = 0
+LD HL, sXYADR+1
+INC (HL)           ; Y++
+LD A, (HL)
+CP 25
+JR C, .sp_cr_done
+; Y=25: scroll up = text VRAM を 80 byte 上に移動、 最終行 clear
+LD HL, $3000+80    ; src = 2 行目
+LD DE, $3000       ; dst = 1 行目
+LD BC, 80*24       ; 24 行分
+LDIR
+; 最終行 clear (= space で埋める、 $20)
+LD HL, $3000+80*24
+LD A, $20
+LD B, 80
+.sp_clr_last:
+LD (HL), A
+INC HL
+DJNZ .sp_clr_last
+; Y を 24 に戻す
+LD A, 24
+LD (sXYADR+1), A
+.sp_cr_done:
+POP HL
+POP DE
+POP BC
+RET
+
+
+; --- 以下 libsos_print.asm からの copy (= PRT 経由で sPRINT を呼ぶ流儀) ---
+
+; @name PCRONE
+; @resident shared
+; @param_count 0
+; @calls PCR
+LD HL,1
+
+
+; @name PCR
+; @resident shared
+; @param_count 1
+; @calls PCR1
+LD E,$0D
+
+
+; @name PCR1
+; @resident shared
+; @param_count 1
+; @calls PSTR
+EX DE,HL
+
+
+; @name PSTR
+; @resident shared
+; @param_count 2
+; @calls PRT
+.pstr1
+LD A,D
+OR E
+RET Z
+LD A,L
+CALL PRT
+DEC DE
+JR .pstr1
+
+
+; @name PCHR
+; @resident shared
+; @calls PRT
+LD A, H
+CALL PRT
+LD A, L
+JR PRT
+
+
+; @name PRT
+; @resident shared
+; @param_count 1
+; @calls sPRINT
+JP sPRINT
+
+
+; @name PHEX4
+; @resident shared
+; @param_count 1
+; @calls PHEX2
+LD A,H
+CALL PHEX
+
+
+; @name PHEX2
+; @resident shared
+; @param_count 1
+; @calls PHEX
+LD A,L
+
+
+; @name PHEX
+; @resident shared
+; @param_count 1
+; @calls SASC,PRT
+PUSH AF
+RRCA
+RRCA
+RRCA
+RRCA
+CALL SASC
+CALL PRT
+
+POP AF
+CALL SASC
+
+
+; @name PMSG
+; @resident shared
+; @calls PMSX1
+LD B, $0D
+JR PMSX1
+
+
+; @name PMSX
+; @resident shared
+; @calls PMSX1
+LD B, 00
+
+
+; @name PMSX1
+; @resident shared
+; @calls PRT,PMSG
+LD A, (HL)
+CP B
+RET Z
+CALL PRT
+INC HL
+JR PMSX1
+
+
+; @name MPRNT
+; @resident shared
+; @calls PRT
+EX (SP),HL
+.mprnt2
+LD A, (HL)
+INC HL
+OR A
+JR Z, .mprnt1
+CALL PRT
+JR .mprnt2
+.mprnt1
+EX (SP),HL
+RET
+
+
+; @name PSIGN
+; @resident shared
+; @param_count 1
+; @calls PRT,NEGHL,P10
+BIT 7, H
+JR Z,.psign1
+LD A, $2D
+CALL PRT
+CALL NEGHL
+.psign1
+
+
+; @name P10
+; @resident shared
+; @param_count 1
+; @function_type Machine
+; @calls P10to5,P10toN
+LD DE, -1
+JR P10toN
+
+
+; @name P10to5
+; @resident shared
+; @param_count 1
+; @function_type Machine
+; @calls P10toN
+LD DE, 0005
+
+
+; @name P10toN
+; @resident shared
+; @param_count 2
+; @function_type Machine
+; @calls PRT,VTOS,PMSX
+PUSH DE
+LD DE, WORK10
+CALL VTOS
+EX DE, HL
+POP DE
+LD A, E
+CP $05
+JR NC, .p10ton1
+LD A, $05
+SUB E
+.p10ton2
+INC HL
+DEC A
+JR NZ, .p10ton2
+JR PMSX
+.p10ton1
+LD A, E
+CP $FF
+JR NZ, PMSX
+.p10ton4
+LD A, (HL)
+CP $20
+JR NZ, PMSX
+INC HL
+JR .p10ton4
+
+WORK10:
+DB  "12345",0
+DS  4

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -83,4 +83,11 @@ public class X1NativeEnvTests
         var config = EnvironmentLoader.Load(EnvFilePath());
         Assert.Null(config.OutputFormat);
     }
+
+    // 注: 「実 SLANG → asm 生成 + 内容 grep」 系 test (= MinimumPrint_BuildsSuccessfully /
+    // NoLsxBdosCall / HasNativeVramOut 等、 Codex review Medium 指摘) は本 PR scope 外。
+    // 理由: CodeGenerator が RuntimeManager + env runtime asm 解決 path を必要とし、
+    // unit test 内での setup が複雑。 別 PR で integration test として slangc CLI
+    // spawn ベースで追加予定。 現状は docs/X1.md の manual verification 手順
+    // (= grep / AILZ80ASM / emulator memory load) で代替。
 }

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -1,0 +1,86 @@
+using SLANGCompiler.Runtime;
+using Xunit;
+
+namespace SLANGCompiler.Tests;
+
+/// <summary>
+/// x1native env (= OS 非依存 X1 hardware 直接 access、 Phase A) の env load 系
+/// テスト。 asm 生成 + LSX 痕跡 grep verify は実 slangc CLI 経由なので manual
+/// verification script (= docs/X1.md) に任せ、 ここでは env file の YAML
+/// deserialize 基本属性のみ pin する。
+/// </summary>
+public class X1NativeEnvTests
+{
+    private static string EnvFilePath()
+    {
+        // tests/SLANGCompiler.Tests/bin/Debug/net8.0/ から runtime/env/ に到達
+        var baseDir = AppContext.BaseDirectory;
+        // 7 階層上が repo root (= bin/Debug/net8.0/SLANGCompiler.Tests/) → adjust
+        var dir = new DirectoryInfo(baseDir);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "runtime", "env", "x1native.env")))
+        {
+            dir = dir.Parent;
+        }
+        Assert.NotNull(dir);
+        return Path.Combine(dir!.FullName, "runtime", "env", "x1native.env");
+    }
+
+    [Fact]
+    public void X1NativeEnv_LoadsSuccessfully()
+    {
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.NotNull(config);
+        Assert.Equal("x1native", config.Name);
+        // env_type=1 (= X1 hardware identity 維持、 既存 x1.env と同じ)
+        Assert.Equal(1, config.EnvType);
+        // os_type=4 (= 新規割当、 X1 native / no OS)
+        Assert.Equal(4, config.OsType);
+    }
+
+    [Fact]
+    public void X1NativeEnv_HasX1NativeDefine()
+    {
+        // SLANG `#IF X1NATIVE` 条件分岐用 define
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.NotNull(config.Defines);
+        Assert.True(config.Defines!.ContainsKey("X1NATIVE"),
+            "x1native env should define `X1NATIVE: 1` for conditional compilation");
+        Assert.Equal(1, config.Defines["X1NATIVE"]);
+    }
+
+    [Fact]
+    public void X1NativeEnv_LibrariesIncludeNativeAsm()
+    {
+        // libraries 列に native asm 3 つ + libx1_base reuse が含まれる、
+        // LSX 系 (liblsx_*) は含まれない (= LSX 切り離しの構造保証)
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.Contains("libx1native_base.asm", config.Libraries);
+        Assert.Contains("libx1native_input.asm", config.Libraries);
+        Assert.Contains("libx1native_print.asm", config.Libraries);
+        Assert.Contains("libx1_base.asm", config.Libraries);  // VSYNC reuse
+        Assert.DoesNotContain("liblsx_base.asm", config.Libraries);
+        Assert.DoesNotContain("liblsx_input.asm", config.Libraries);
+        Assert.DoesNotContain("liblsx_print.asm", config.Libraries);
+        Assert.DoesNotContain("liblsx_file.asm", config.Libraries);
+    }
+
+    [Fact]
+    public void X1NativeEnv_DefaultOrgIsX1TapeBootAddress()
+    {
+        // X1 tape boot 慣習の load address $1000 (= Phase B で tap header と整合)
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        // env file が "$1000" 文字列で書かれてる場合、 parser が int に変換するか
+        // 文字列のままかは EnvironmentLoader 仕様依存、 ここでは property type に合わせる
+        Assert.Equal(0x1000, config.DefaultOrg);
+    }
+
+    [Fact]
+    public void X1NativeEnv_OutputIsBinDefault()
+    {
+        // Phase A = flat binary のみ (= D88 boot は scope 外、 tap は Phase B)。
+        // env file の `output: bin` は EnvironmentLoader で null 正規化 (= bin が
+        // default)、 OutputFormat = null で「 cmt / c_source ではない」 を pin。
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.Null(config.OutputFormat);
+    }
+}


### PR DESCRIPTION
## Summary

X1 環境に **OS 非依存の `x1native` env** を新設 (= 将来 .tap / .wav テープ出力対応の
ための土台、 Phase A)。

### 背景

SLANG コンパイラの X1 環境系は LSX-Dodgers / S-OS X1 上で動く binary しか生成
できなかった。 テープ起動 (= .tap) 用には OS なしで X1 hardware を直接叩く binary
が必要、 まず runtime / env 整備を Phase A として実施。

Phase B (= tap/wav 出力 + tapcnv 統合) は別 PR / 別 plan。

### 設計の要点 (Codex review 3 巡で固めた plan ベース)

- **`env_type: 1` 維持** (= X1 hardware identity、 既存 `x1.env` と同じ) + **`os_type: 4` 新規** (= OS なし) + `defines: { X1NATIVE: 1 }` (= SLANG `#IF X1NATIVE` 条件分岐用)
- 新規 asm 3 ファイル (= LSX 完全切離 + native 化):
  - `libx1native_base.asm`: SLANGINIT (DI + SP set + __WORK__ clear + cursor init + IY + MAIN call + inline HALT loop) + STOP + sWORK
  - `libx1native_input.asm`: sGETKY (X1 sub CPU 80C49 @ $1900 polling、 X1_compatible_rom KBHIT 相当) + sFLGET / sINKEY / INKEY
  - `libx1native_print.asm`: sPRINT (text VRAM $3000 port-mapped OUT 書込 + attribute 白 + cursor 自動進行 + line wrap、 **scroll なし = 最終行固定上書き**、 Phase C 候補) + SLANGINIT に 8255 init + text/attribute VRAM clear (= 起動状態非依存) + libsos_print.asm から PRT / PSTR / PCRONE / PCHR / PHEX / PMSG / P10toN 等の上位 routine を copy 流用
- 既存 `libx1_base.asm` (VSYNC、 LSX 非依存) のみ reuse、 `libx1_psg/grp/magic/sgl.asm` は OS_TYPE==0 で LSX 固定 addr 使用するため Phase A scope 外 (= 後続 Phase C で native branch 追加予定)
- file I/O (FOPEN/FCLOSE/FREAD/FWRITE/FSEEK) は linker undefined symbol で reject (= user 判断、 必要なら `lsx`/`sosx1` env を使う)
- D88 boot は Phase A scope 外 (= `DiskImageBuilder` は OS template に file 追加するだけで OS なしでは loader が起動しない、 Phase B の tap header で OS なし boot を実現)
- 完了条件: asm/bin 生成 + emulator memory load + PC jump で動作確認

### 出典 / ライセンス (= 全互換)

- **LSX-Dodgers** (MIT、 Gaku 1995): SLANGINIT 構造 / sWORK pattern
- **X1_compatible_rom** (CC0、 Meister 2020-): KBHIT / WAIT_80C49_WR / READ_80C49 シーケンス、 X1 memory layout 定数 (= text VRAM $3000, attribute VRAM $2000, TXTCUR $FF80)

各 asm file の header に出典 attribution comment 付き。

### 残課題 (= 本 PR scope 外、 Phase B / C で対応)

- **Phase B**: ~/projects/tapcnv (= 自作 C# net8.0 lib, MIT) を ProjectReference で SLANGCompiler.Build に組み込み、 .tap / .wav 出力 + tape boot (= tap header に load/exec addr 持つので OS なし boot 自然に実現)
- **Phase C**: graphics / PSG / PCG / magic / sgl の native branch 追加、 x1native env で graphics sample 動作確認

## Test plan

- [x] `dotnet test` 全 462/462 pass (= 既存 + X1NativeEnvTests 5 件)
- [x] X1NativeEnvTests 5 件全 pass: env load / X1NATIVE define / native asm libraries / default_org $1000 / output bin
- [x] 生成 asm の LSX 痕跡不在確認 (= `grep -v '^\s*;' HELLO.asm | grep -E "CALL.*\\\$0005|\(\\\$0001\)|\\\$EE8C|\\\$EE8E|\\\$EE92"` で 0 hit)
- [x] native symbol 含まれる (= sGETKY / sPRINT / $1900 (sub CPU) / $1A01 (8255B) / $3000 (text VRAM))
- [x] 既存 env (x1 / lsx / sosx1) 完全無触 (= 私の変更は新規 file のみ)、 regression risk 極小
- [x] **user 側 verification**: X1 emulator (xmil / X-millenium) で `HELLO.bin` を `$1000` に memory load + PC=$1000 jump → "HELLO, X1 NATIVE!" 表示 + キー入力で停止解除 (= sPRINT logic に subtle bug 残ってる可能性あり、 実機テスト推奨)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
