### PR TITLE
x1native: graphics 系 4 lib reuse + GRDISP/GRCLS + sPRINT attribute fix

### DIFF
--- a/runtime/env/x1native.env
+++ b/runtime/env/x1native.env
@@ -19,5 +19,10 @@ libraries:
   - libx1native_input.yml
   - libx1native_print.yml
   - libx1_base.yml
+  # graphics 系 reuse (= 既存 libx1_* asm、 LSX 直接依存 0 件で x1native でも動く)
+  - libx1_pcg.yml       # supported now (= PCGDEF / PCGDEFS、 X1GRP/STARS_X1 で使用)
+  - libx1_grp.yml       # supported now (= LINE / PAINT / BFILL / GRPSETUP 等、 X1GRP で使用)
+  - libx1_magic.yml     # registered (= 未使用時は selective link で無害、 動作確認は別 PR)
+  - libx1_sgl.yml       # registered (= SGL_* sprite、 sgl_lsx は除外、 動作確認は psg 整備後)
   - libcompress.yml
   - libsoroban.yml

--- a/runtime/libx1_grp.asm
+++ b/runtime/libx1_grp.asm
@@ -2635,3 +2635,67 @@ CALL X1GLINE.SET320
 JP	X1PAINT.WIDTHPATCH
 
 
+; @name GRDISP
+; @resident shared
+; @calls X1WORK
+; H/L = 0 で graphics 非表示 (= palette を全 0)、 非 0 で graphics 表示 (= Z 互換
+; 8 色モード、 palette 設定 + bank 0 select)。
+; libmag 既存 GRDISP routine と同一実装、 ただし本 PR では x1native env で
+; libmag を使わないため libx1_grp 側にも提供 (= 既存 x1 env では last-wins で
+; libmag 側が優先される、 影響無し)。 _WK1FD0 は X1WORK alias 経由で provide。
+LD A,H
+OR L
+JR Z,.gr_nodisp
+; Z 互換 (8 色) モード
+LD	BC,$1FB0
+DB	$ED,$71         ; OUT (C), 0
+; $10xx = $AA (BLUE)
+LD	BC,$10AA
+OUT	(C),C
+; $11xx = $CC (RED)
+LD	BC,$11CC
+OUT	(C),C
+; $12xx = $F0 (GREEN)
+LD	BC,$12F0
+OUT	(C),C
+; BANK0 選択 (08h 系統)、 graphics 表示 (80h 立てると非表示、 落ちてると表示。 反転)
+LD  A,(_WK1FD0)
+AND 077h
+LD  BC,$1FD0
+OUT (C),A
+LD  (_WK1FD0),A
+RET
+.gr_nodisp:
+; palette を全 0 にして非表示
+LD	B,$10
+DB	$ED,$71         ; OUT (C), 0
+INC	B
+DB	$ED,$71
+INC	B
+DB	$ED,$71
+INC	B
+DB	$ED,$71
+RET
+
+
+; @name GRCLS
+; @resident shared
+; 現在の VRAM bank のみ port-mapped で 0 fill (= 単純消去、 エフェクト無し)。
+; libmag 既存 GRCLS と同一実装 (= MAGBASE 依存なし、 単純 inner/outer loop)。
+; bank 切替は GRDISP 側で行う想定、 GRCLS は現状 bank のみクリア。
+XOR A
+LD  C,A
+LD  HL,$4003
+.cls1:
+LD  B,H
+.cls2:
+DB  $ED,$71         ; OUT (C), 0
+INC B
+JR  NZ,.cls2
+;
+ADD A,L
+LD  C,A
+JR  NZ,.cls1
+RET
+
+

--- a/runtime/libx1native_base.asm
+++ b/runtime/libx1native_base.asm
@@ -230,3 +230,17 @@ DB	$00, $07                                     ; R8-R9
 DW	0 - 40 * 25, 0 - 40                          ; R10/R11 + LSX cache
 DB	$0D                                          ; 8255 port C
 DB	$A0                                          ; WK1FD0
+
+
+; @name X1WORK
+; @resident shared
+; LSX 系 libx1_print の X1WORK alias。 graphics 系 (libx1_grp / libx1_pcg 等) が
+; @calls X1WORK で link 上 declare する依存を満たす shim。
+; - AT_WIDTH: x1native の sWORK 内 BSS で provide 済 (= 重複定義回避のため
+;   X1WORK alias 側では持たない、 @works dedupe = 最初出現が勝ち)。
+; - _TXADR ($EE8E): LSX 固定 addr のため意図的に提供しない (= x1native の
+;   境界保持、 graphics 系で実参照無いことは grep 確認済)。
+; - AT_COLORF / _WK1FD0: 将来 libmag native 化 (= 別 PR) で reuse される予定の
+;   互換用 shim、 graphics pcg/grp 単独動作には実質使わないが保守的に provide。
+AT_COLORF: DB $07   ; 前景色 default (= 白、 既存 libx1_print と同初期値)
+_WK1FD0:   DB $00   ; 8255 WK1FD0 cache (= 既存 libx1_print と同初期値)

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -80,7 +80,12 @@ LD HL, (sXYADR)
 .sp_putc:
 ; HL = (sXYADR.H << 8) | sXYADR.L = (Y, X)、 AT_VRCALC で Y*width+X (VRAM offset)
 CALL AT_VRCALC
-; port-mapped OUT (libx1_print.asm PRT sequence、 kanji=0 上書き含む)
+; port-mapped OUT (= libx1_print.asm PRT sequence と同じく、 attribute は触らない)
+; attribute を書込みすると PCG 用に設定された attribute (= PCG flag 含む) を
+; 消してしまうため、 LSX / S-OS 慣例通り sPRINT では text + kanji=0 のみ書込。
+; 初期 attribute ($07 = 白) は SLANGINIT 内 clear_screen で全 cell に fill 済、
+; scroll_up の最終行 fill / CLEAR ($0C) でも attribute $07 で塗り直されるため
+; 通常 text 表示には影響なし。
 LD B, H
 LD C, L
 LD A, B
@@ -89,10 +94,6 @@ LD B, A
 DB $ED, $71   ; OUT (C), 0 = kanji area に 0 (= ANK 文字、 Z80 未定義命令)
 RES 3, B      ; bit 3 clear ($38→$30、 text region)
 OUT (C), E    ; OUT text (= 文字コード)
-; attribute も白で書込 (= boot ROM 初期色依存を回避、 IPL_PUTCHAR 同戦略)
-RES 4, B      ; bit 4 clear ($30→$20、 attribute region)
-LD A, $07
-OUT (C), A
 ; cursor X 進行
 LD HL, sXYADR
 INC (HL)

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Text.RegularExpressions;
 using SLANGCompiler.Runtime;
 using Xunit;
@@ -185,5 +186,157 @@ public class X1NativeEnvTests
         Assert.Contains("LD H, 8", body);
         Assert.Contains("DEC H", body);
         Assert.DoesNotContain("LD A, 8", body);
+    }
+
+    // === graphics 系 library reuse 関連 (= libx1_pcg / grp / magic / sgl) ===
+
+    [Fact]
+    public void Libx1NativeBase_DefinesX1WorkAlias()
+    {
+        // graphics 系 (libx1_grp / libx1_pcg 等) が @calls X1WORK で link 上
+        // declare する依存を満たす shim alias。 AT_COLORF / _WK1FD0 は libmag
+        // (= 後続 PR) で reuse される予定の互換用 DB、 AT_WIDTH は sWORK 内
+        // BSS で既に provide 済のため X1WORK alias には含めない。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_base.asm"));
+        Assert.Contains("; @name X1WORK", content);
+        Assert.Contains("AT_COLORF: DB", content);
+        Assert.Contains("_WK1FD0:", content);
+    }
+
+    [Theory]
+    [InlineData("libx1_pcg.asm")]    // supported now: PCGDEF (X1GRP / STARS_X1 で使用)
+    [InlineData("libx1_grp.asm")]    // supported now: LINE / PAINT / GRPSETUP / GRDISP / GRCLS
+    [InlineData("libx1_magic.asm")]  // registered (= 未使用時は selective link で無害)
+    [InlineData("libx1_sgl.asm")]    // registered (= 動作確認は psg 整備後の別 PR)
+    public void X1NativeEnv_RegistersGraphicsLibraries(string lib)
+    {
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.Contains(lib, config.Libraries);
+    }
+
+    [Fact]
+    public void X1NativeEnv_DoesNotRegisterSglLsx()
+    {
+        // libx1_sgl_lsx は LSX 専用 wrapper、 x1native では使わない (= 境界保持、
+        // x1native は libx1_sgl 本体のみ使う)。
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.DoesNotContain("libx1_sgl_lsx.asm", config.Libraries);
+    }
+
+    [Fact]
+    public void Sprint_DoesNotOverwriteAttribute()
+    {
+        // LSX / S-OS 慣例 + 既存 libx1_print.asm PRT 同様、 sPRINT は attribute
+        // plane を上書きしない (= text + kanji=0 のみ書込)。 attribute は SLANGINIT
+        // の clear_screen で初期 $07 fill 済、 scroll / CLEAR でも reset されるため
+        // 通常表示影響なし。 attribute 上書きすると PCG flag 等 attribute 経由設定
+        // (= STARS_X1.SL の PCG 表示等) が消えるため厳禁。
+        // pin: sPRINT routine 区間内に attribute 書込 sequence (= RES 4, B
+        // + LD A, $07) が無い (= scroll_up / clear_screen 等 他 routine では使用 OK)。
+        // sPRINT 区間切り出し: `; @name sPRINT` から sPRINT 最終 `\nRET\n` まで
+        // (= sp_do_cr / scroll_up 等 後続 routine は除外、 行頭 RET で区切る)。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_print.asm"));
+        var match = Regex.Match(content, @"; @name sPRINT\b(.*?)\nRET\n",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "sPRINT routine 区間が見つからない (= 最終 RET まで)");
+        var body = match.Groups[1].Value;
+        Assert.DoesNotContain("RES 4, B", body);
+        Assert.DoesNotContain("LD A, $07", body);
+    }
+
+    [Fact]
+    public void Libx1Grp_DefinesGrdispAndGrclsForX1Native()
+    {
+        // GRDISP / GRCLS は元々 libmag に定義されてたが、 x1native では libmag を
+        // 使わないため libx1_grp 側に新規追加 (= ユーザー指示「GRDISP/GRCLS は
+        // graphics 責務なので libx1_grp に移すのがスジ」)。 既存 x1 env では
+        // last-wins (= dictionary 上書き) で libmag.GRDISP/GRCLS が優先採用、
+        // 既存挙動 維持。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1_grp.asm"));
+        Assert.Contains("; @name GRDISP", content);
+        Assert.Contains("; @name GRCLS", content);
+    }
+
+    // === CLI spawn build smoke (= 実 slangbuild を Process で起動して exit 0 +
+    //     .tap 生成を pin、 user review feedback で「build smoke も入れる」 要求) ===
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir != null && !File.Exists(Path.Combine(dir.FullName, "runtime", "env", "x1native.env")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static (int exitCode, string stdout, string stderr) RunSlangBuild(string args)
+    {
+        var repoRoot = RepoRoot();
+        var slangbuildProj = Path.Combine(repoRoot, "src", "SLANGCompiler.Build", "SLANGCompiler.Build.csproj");
+        var psi = new ProcessStartInfo("dotnet", $"run --project \"{slangbuildProj}\" --no-build -- {args}")
+        {
+            WorkingDirectory = repoRoot,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        using var proc = Process.Start(psi)!;
+        var exited = proc.WaitForExit(120 * 1000);  // 2 min timeout
+        Assert.True(exited, "slangbuild process timeout (= 2 min)");
+        return (proc.ExitCode, proc.StandardOutput.ReadToEnd(), proc.StandardError.ReadToEnd());
+    }
+
+    private static void CleanupBuildArtifacts(string outputBase)
+    {
+        foreach (var ext in new[] { ".bin", ".tap", ".wav", ".LST", ".ASM" })
+            if (File.Exists(outputBase + ext)) File.Delete(outputBase + ext);
+    }
+
+    [Fact]
+    public void X1GrpSample_BuildsSuccessfully()
+    {
+        // examples/X1GRP.SL は libx1_grp + libx1_pcg + libx1native 全部を使う最小
+        // graphics demo。 GRDISP / GRCLS / LINE / BFILL / PAINT / PCGDEF / WIDTH /
+        // LOCATE / PRINT 等 全部 link されて tap 生成成功する pin (= regression
+        // 検出価値高、 ユーザー review feedback 反映)。
+        var repoRoot = RepoRoot();
+        var sample = Path.Combine(repoRoot, "examples", "X1GRP.SL");
+        var include = Path.Combine(repoRoot, "include");
+        var output = Path.Combine(Path.GetTempPath(), $"X1GRP_test_{Guid.NewGuid():N}");
+        try
+        {
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{sample}\" -o \"{output}\" --emit tape");
+            Assert.True(rc == 0,
+                $"X1GRP build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.True(File.Exists(output + ".tap"), "X1GRP.tap not generated");
+        }
+        finally
+        {
+            CleanupBuildArtifacts(output);
+        }
+    }
+
+    [Fact]
+    public void StarsX1Sample_BuildsSuccessfully()
+    {
+        // examples/STARS_X1.SL は PCGDEF (= libx1_pcg) で星型 PCG 文字定義 +
+        // STARS.SL 風 動作。 libx1_pcg + libx1native の最小組合せで動く pin。
+        var repoRoot = RepoRoot();
+        var sample = Path.Combine(repoRoot, "examples", "STARS_X1.SL");
+        var include = Path.Combine(repoRoot, "include");
+        var output = Path.Combine(Path.GetTempPath(), $"STARS_X1_test_{Guid.NewGuid():N}");
+        try
+        {
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{sample}\" -o \"{output}\" --emit tape");
+            Assert.True(rc == 0,
+                $"STARS_X1 build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.True(File.Exists(output + ".tap"), "STARS_X1.tap not generated");
+        }
+        finally
+        {
+            CleanupBuildArtifacts(output);
+        }
     }
 }

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -281,9 +281,18 @@ public class X1NativeEnvTests
             UseShellExecute = false,
         };
         using var proc = Process.Start(psi)!;
+        // pipe buffer 詰まり回避: WaitForExit より先に stdout/stderr の非同期 read 開始
+        // (= 大量出力 + 同期 ReadToEnd 後置きだと子プロセスが書込ブロックで止まり、
+        //  WaitForExit が timeout まで進まなくなる、 Codex review Low 指摘)
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
         var exited = proc.WaitForExit(120 * 1000);  // 2 min timeout
-        Assert.True(exited, "slangbuild process timeout (= 2 min)");
-        return (proc.ExitCode, proc.StandardOutput.ReadToEnd(), proc.StandardError.ReadToEnd());
+        if (!exited)
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { /* 既に exit 済等は無視 */ }
+            Assert.Fail("slangbuild process timeout (= 2 min)、 kill 済み");
+        }
+        return (proc.ExitCode, stdoutTask.Result, stderrTask.Result);
     }
 
     private static void CleanupBuildArtifacts(string outputBase)


### PR DESCRIPTION
## Summary

OS 非依存 `x1native` runtime に graphics 系 4 library (libx1_pcg / libx1_grp / libx1_magic / libx1_sgl) を統合し、 `examples/X1GRP.SL` / `examples/STARS_X1.SL` を `slangbuild -E x1native --emit tape` で build + 実 X1 emulator boot で graphics 描画 + PCG 表示動作可能にする。 同時に PR #203 で sPRINT に誤って入れた attribute 上書きを fix (= PCG flag 等の attribute 経由設定を消さないよう、 LSX / S-OS 慣例に整合)。

## 主な変更

### `runtime/env/x1native.env`
libraries に graphics 4 lib を 3 分類で追加 (= review しやすさのため comment 明示):
- **supported now** (= 主動作確認対象): `libx1_pcg.yml` (PCGDEF) / `libx1_grp.yml` (LINE/PAINT/GRDISP/GRCLS 等)
- **registered** (= 未使用時 selective link で無害、 動作確認は後続 PR): `libx1_magic.yml` / `libx1_sgl.yml`
- **除外**: `libx1_sgl_lsx.yml` (= LSX 専用 wrapper、 境界保持)

### `runtime/libx1native_base.asm`
- `@name X1WORK` alias block 追加 (= AT_COLORF / _WK1FD0 DB、 graphics 系の `@calls X1WORK` 依存解決 shim)。 AT_WIDTH は sWORK 内 BSS で provide 済のため X1WORK alias 側には含めない (= dedupe 衝突回避)。 _TXADR ($EE8E) は LSX 固定 addr のため意図的に非提供 (= x1native の境界保持)。 AT_COLORF / _WK1FD0 は将来 libmag native 化 (= 別 PR) で reuse 予定の互換 shim。

### `runtime/libx1_grp.asm`
- **`GRDISP` / `GRCLS` を末尾に新規追加** (= 元々 libmag.asm 内、 ユーザー判断「graphics 責務として libx1_grp に移すのがスジ」 反映、 GRCLS は単純消去版)。 既存 x1 env では `_functions[func.Name] = func` の last-wins 仕様 (= load order で libmag が後) で libmag.GRDISP/GRCLS が引き続き dictionary に残る = **既存挙動維持** (= x1 env での X1GRP / MAGICSMPL asm 生成 smoke で確認済)。 x1native env は libmag 不使用、 libx1_grp 経由で resolve される。

### `runtime/libx1native_print.asm`
- **sPRINT 内の attribute 書込 sequence (= `RES 4, B; LD A, $07; OUT (C), A`) を削除**。 PR #203 で「boot ROM 初期色依存を回避」 として誤って入れた箇所、 LSX / S-OS 慣例 + 既存 libx1_print.asm PRT 同様に **attribute は触らない** のが正解。 attribute 上書きすると PCG flag 等 attribute 経由設定が消えて PCG 文字が plain ANK として表示される症状 (= STARS_X1.SL の星 PCG が表示されない問題、 user 報告) を fix。 初期 attribute ($07 = 白) は SLANGINIT 内 clear_screen で fill 済 + scroll / CLEAR でも reset されるため通常表示影響なし。

### `tests/SLANGCompiler.Tests/X1NativeEnvTests.cs`
- 静的 asm 構造 pin 8 件追加: X1WORK alias 存在 / graphics 4 lib include theory / sgl_lsx 不在 / libx1_grp の GRDISP/GRCLS 存在 / sPRINT 内 attribute 書込 sequence 不在 (= PCG 表示崩れ再発防止)
- CLI spawn build smoke 2 件追加: X1GRP.SL / STARS_X1.SL を `Process.Start("dotnet run --project ... --no-build")` で実 build + tap 生成 pin (= user review feedback で「regression 検出価値あり」 反映、 dotnet run --no-build で計 3 秒程度)

## Test plan

- [x] `dotnet test` 全 **507 件 pass** (= 既存 497 + 新規 10)、 regression なし
- [x] `slangbuild -E x1native --emit tape` で X1GRP.SL / STARS_X1.SL build 成功 (= bin 5127 / 2056 byte)
- [x] 実 X1 emulator で X1GRP / STARS_X1 boot + graphics 描画 + **PCG 表示動作確認 OK** (= user 実機確認済)
- [x] 既存 4 sample (HELLO/STARS/FMANDEL/FURUI) build OK + bin size -6 byte 微減 (= sPRINT attribute 書込削除分)
- [x] 既存 x1 env で X1GRP / MAGICSMPL asm 生成 smoke OK = regression なし

## 残課題 (= 本 PR scope 外、 後続)

- **libx1_psg native 化**: `_CTC EQU $EE8C` 固定 addr 衝突 fix 必要、 fix 後 X1SGL.SL の build + 動作確認可能 (= sgl は本 PR で env 登録済、 psg 揃えば即動作)
- **libmag native 化**: FOPEN/FREAD/FSEEK 等 file IO 一式の x1native 実装が必要 (= 大規模、 tape sequential read or 別 boot media 連携)、 fix 後 MAGICSMPL.SL 動作確認可能 (= magic も本 PR で env 登録済)
- **既存 x1 env での GRDISP/GRCLS 移行**: ユーザー判断「あとから x1 環境も libx1_grp 経由に統一」、 別 PR で libmag 側 GRDISP/GRCLS 削除 + 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)