### PR TITLE
x1native: libx1_psg 統合 + CTC IM2 vector + 高位 RAM ISR trampoline

### DIFF
--- a/docs/X1.md
+++ b/docs/X1.md
@@ -160,6 +160,40 @@ CLI option:
 - file I/O API (FOPEN/FCLOSE 等) は x1native 同様 未対応
 - raw bin output env のみ対応 (= `output: cmt` 系 / c64 oscar_c 系では `--emit tape` 不可)
 
+## x1native ABI 予約領域 + IRQ 設計
+
+### 予約領域
+
+x1native runtime は以下のメモリ領域を予約しており、 SLANG プログラムからは触らないこと:
+
+- `$1000-$FFDF`: SLANG プログラム + work area (= `default_org=$1000`)
+- **`$FFE0-$FFFF`: ISR trampoline reserved area (32 byte)**
+  - `$FFE0-$FFE7`: IM2 vector table (= CTC ch0-3 vector × 2 byte)
+  - `$FFE8-$FFEA`: ISR_DUMMY (= 想定外 interrupt 安全網、 `EI; RETI`)
+  - `$FFEB-$FFFF`: ISR_ENTRY (= CTC ch1 用 handler trampoline)
+  - SLANGINIT 内の SETUP_ISR_AREA が初期化、 vector 全 entry は ISR_DUMMY で init
+  - `LD I, $FF` + CTC vector register = `$E0` で IM2 vector base = `$FFE0`
+
+### IRQ 設計 (= 責任分割)
+
+- **runtime (SLANGINIT)**: SETUP_ISR_AREA + `LD I, $FF` + `IM 2` まで実行 (= IRQ 土台のみ)
+  - **EI は SLANGINIT では行わない**
+  - **SEARCHCTC は SLANGINIT では呼ばない** (= 利用 library 側)
+- **device library (PSG_INIT(1) 等)**: SEARCHCTC + CTC ch1 設定 + vector slot 差替
+  - **EI は initialization 完了後** に共通末尾 (= 既存 PSG_INIT INITEND) で実行
+  - 将来 Arkos Tracker 等 別 IRQ driver 入れたとき干渉しない設計
+- 機種判定 / `CALL $1FF7` / S-OS vector 借用 (`$0058` / `$F830`) は使わない、 自前 IM2 vector のため normal / turbo 区別不要 (= ROM bank が $0000-$7FFF にあっても `$FFE0-$FFFF` は常に RAM)
+
+### tape build size 制約
+
+- 実質上限 `load + size - 1 <= $FFDF` (= 末尾 32 byte は runtime 予約)
+- 現状 size reject は未実装 (= MVP では本 docs 明記のみ、 別 PR で `--emit tape` 時の `> $FFDF` reject 強化予定)
+
+### interrupt 制約
+
+- x1native runtime は **BIOS ROM routine を使わない前提** で動作
+- user SLANG コードが ROM call 中に interrupt 発生した場合、 RETI 後の復帰先が ROM routine だと破綻し得る (= 「ROM call 中の interrupt 復帰までは保証しない」)
+
 ## 既存 env (= LSX / S-OS) との比較
 
 既存 `x1.env` (LSX-Dodgers) / `sosx1.env` (S-OS X1) は **完全に無触**、 既存 SLANG

--- a/runtime/env/x1native.env
+++ b/runtime/env/x1native.env
@@ -23,6 +23,7 @@ libraries:
   - libx1_pcg.yml       # supported now (= PCGDEF / PCGDEFS、 X1GRP/STARS_X1 で使用)
   - libx1_grp.yml       # supported now (= LINE / PAINT / BFILL / GRPSETUP 等、 X1GRP で使用)
   - libx1_magic.yml     # registered (= 未使用時は selective link で無害、 動作確認は別 PR)
-  - libx1_sgl.yml       # registered (= SGL_* sprite、 sgl_lsx は除外、 動作確認は psg 整備後)
+  - libx1_sgl.yml       # supported now (= SGL_* sprite、 X1SGL.SL で動作確認、 sgl_lsx は除外)
+  - libx1_psg.yml       # supported now (= PSG_INIT(0)/(1) 両対応、 自前 IM2 vector で割り込み駆動)
   - libcompress.yml
   - libsoroban.yml

--- a/runtime/libx1_psg.asm
+++ b/runtime/libx1_psg.asm
@@ -1221,6 +1221,25 @@ SOUNDDRV_EXEC_END:
 ; @lib PSGLIB
     CALL PSG_STOP
 
+#IF NAME_SPACE_DEFAULT.OS_TYPE == 4
+    ; x1native: PSG_INIT(0) (= 非割り込み mode) 後の PSG_END だと _CTC = 0
+    ; (= SEARCHCTC が走ってない) で `OUT (C), $03` が偽 port に書込、 さらに
+    ; CTC3BACKUP = 0 で vector ch1 slot ($FFE2/$FFE3) を 0 fill して想定外
+    ; interrupt 来たら $0000 飛び。 guard: ch1 vector slot が ISR_ENTRY
+    ; (= _ISRADR、 PSG_INIT(1) で登録済の状態) を指してれば CTC stop + restore
+    ; 実施、 違ったら (= PSG_INIT(0) のまま or 他 device が登録) 即 RET。
+    LD HL,(_CTCVEC)
+    INC L
+    INC L           ; HL = ch1 vector slot ($FFE2)
+    LD E,(HL)
+    INC HL
+    LD D,(HL)       ; DE = ch1 vector slot の現値
+    LD HL,(_ISRADR) ; HL = ISR_ENTRY addr ($FFEB、 SETUP_ISR_AREA で設定)
+    OR A
+    SBC HL,DE
+    RET NZ          ; ch1 vector が ISR_ENTRY 指してない (= PSG 未登録) → early RET
+#ENDIF
+
     ; CTC1を止める
     LD      HL,(_CTC)
     DEC L

--- a/runtime/libx1_psg.asm
+++ b/runtime/libx1_psg.asm
@@ -717,6 +717,23 @@ SOUNDDRV_INIT:
     DEC C
     LD A,(_CTCVEC)
     OUT (C),A
+#ELIF NAME_SPACE_DEFAULT.OS_TYPE == 4
+    ; x1native: 本 path で SEARCHCTC + CTC ch0 vector register 書込
+    ; (= SLANGINIT は SETUP_ISR_AREA + LD I, $FF + IM 2 まで、 SEARCHCTC + EI は
+    ;  device side、 IRQ 基盤と device 責任分割原則)
+    _CTC  EQU   NAME_SPACE_DEFAULT._CTC
+
+    CALL NAME_SPACE_DEFAULT.SEARCHCTC
+    LD BC,(_CTC)
+    LD A,C
+    OR B
+    JP Z,NOCTC          ; CTC 検出失敗時は割り込み無効
+
+    ; CTC ch0 に vector register 値 ($E0 = _CTCVEC 下位 byte) を OUT
+    DEC C
+    DEC C
+    LD A,(_CTCVEC)
+    OUT (C),A
 #ENDIF
 
     ; BCにはCTCのチャンネル2のアクセス先が入っている
@@ -748,6 +765,26 @@ SOUNDDRV_INIT:
     LD      (HL),C
     INC HL
     LD      (HL),B
+#ELIF NAME_SPACE_DEFAULT.OS_TYPE == 4
+    ; x1native: ISR_ENTRY 経由 indirect (= SETUP_ISR_AREA で _ISRADR/_ISRHANDLER 済)。
+    ; vector table ch1 slot (= HL は L743 で _CTCVEC+2 を指してる) に
+    ; ISR_ENTRY addr ($FFEB = _ISRADR) を書く。
+    LD DE,(NAME_SPACE_DEFAULT._ISRADR)
+    LD (HL),E
+    INC HL
+    LD (HL),D
+    ; ISR_ENTRY 内 JP operand に SOUNDDRV_EXEC addr を書く (= _ISRHANDLER 経由)
+    LD DE,SOUNDDRV_EXEC
+    LD HL,(NAME_SPACE_DEFAULT._ISRHANDLER)
+    LD (HL),E
+    INC HL
+    LD (HL),D
+    ; 注: RETI→RET 書換 (LD A,$C9; LD (SOUNDDRV_EXEC_END),A) は実行しない
+    ;     (= x1native ISR_ENTRY は JP handler 単純型、 SOUNDDRV_EXEC RETI で
+    ;      interrupt から直接帰る、 戻り先 trampoline 不要)。
+    ; 注: EI は本 branch では行わない。 PSG_INIT 共通末尾の EI に任せる
+    ;     (= CTC ch1 設定済 + driver state / work area 初期化未完了 + PUSH 済
+    ;      register stack 上の状態で EI すると割り込みで破綻する)。
 #ELIF NAME_SPACE_DEFAULT.OS_TYPE == 1
     ; 割り込み先アドレスが格納されている場合はturboである
     LD DE,(NAME_SPACE_DEFAULT._ISRADR)

--- a/runtime/libx1native_base.asm
+++ b/runtime/libx1native_base.asm
@@ -23,7 +23,12 @@
 
 ; @name SLANGINIT
 ; @resident local
-; @calls sWORK, INIT_CRTC, clear_screen, _C8025L
+; @calls sWORK, INIT_CRTC, clear_screen, _C8025L, SETUP_ISR_AREA, SEARCHCTC
+; 注: SLANGINIT 自体は SEARCHCTC を CALL しない (= IRQ 基盤と device 責任分割
+;      原則、 SEARCHCTC は PSG_INIT(1) 等 device library 側で CALL)、 ただし
+;      link planner が SEARCHCTC を link 対象に積むため declare として記載。
+;      libx1_psg.asm x1native path の `CALL NAME_SPACE_DEFAULT.SEARCHCTC` が
+;      sym 解決できるよう、 ここで依存宣言する。
 DI
 ; SP は default_org ($1000) 直前に置く。 emulator load 時に boot ROM 経由 SP が
 ; 既に有効でも、 安全のため明示設定 (= スタック overflow しても user code に
@@ -60,6 +65,19 @@ CALL INIT_CRTC
 ; LSX 同期 ($FF80 = TXTCUR) は行わない (= native は独立)。
 CALL clear_screen
 
+; IRQ 土台のみ構築 (= IRQ 基盤と device-specific 責任分割):
+;  - SETUP_ISR_AREA: $FFE0-$FFFF に IM2 vector table + ISR_DUMMY + ISR_ENTRY、
+;    vector 全 entry を ISR_DUMMY で init、 _CTCVEC/_ISRADR/_ISRHANDLER 設定
+;  - LD I, $FF + IM 2: IM2 mode 設定、 vector page = $FFxx
+;  - EI は本 routine では行わない (= device library 側 (PSG_INIT(1) 等) が
+;    vector slot 登録 + 初期化完了後の共通末尾で EI、 将来 Arkos Tracker 等
+;    別 IRQ driver 入れたとき干渉しない)
+;  - SEARCHCTC も本 routine では呼ばない (= device 利用時に PSG_INIT 等が call)
+CALL SETUP_ISR_AREA
+LD A, $FF
+LD I, A
+IM 2
+
 LD IY, __IYWORK
 
 CALL MAIN
@@ -86,7 +104,7 @@ JR .stop_halt
 ; @name sWORK
 ; @resident shared
 ; @param_count 0
-; @works sXYADR:2,sKBFAD:128,sKBFAD0:1,sKBFAD1:1,sKBFADX:81,sPRBF:80,sSUBPS:2,sSUBBF:256,_CTCVEC:2,_CTC:2,AT_WIDTH:1
+; @works sXYADR:2,sKBFAD:128,sKBFAD0:1,sKBFAD1:1,sKBFADX:81,sPRBF:80,sSUBPS:2,sSUBBF:256,_CTCVEC:2,_CTC:2,AT_WIDTH:1,_ISRADR:2,_ISRHANDLER:2
 ; LSX 同名 work area を踏襲 (= sPRINT / sGETL 等の互換性確保)。 LSX 固定 addr
 ; ($EE8C / $EE8E / $EE92 等) は使わない、 全て __WORK__ 内 BSS。
 ; AT_WIDTH (1 byte) は現在の column 数 (40 or 80)、 SLANGINIT で 80 に init、
@@ -244,3 +262,119 @@ DB	$A0                                          ; WK1FD0
 ;   互換用 shim、 graphics pcg/grp 単独動作には実質使わないが保守的に provide。
 AT_COLORF: DB $07   ; 前景色 default (= 白、 既存 libx1_print と同初期値)
 _WK1FD0:   DB $00   ; 8255 WK1FD0 cache (= 既存 libx1_print と同初期値)
+
+
+; @name SEARCHCTC
+; @resident shared
+; @calls sWORK
+; CTC port を 4 address 全試行 (= 後勝ち、 最後に成功した CTC が _CTC に残る)、
+; _CTC に CTC ch2 port address を保存。 SLANGINIT からは呼ばない (= device-specific
+; library = PSG_INIT(1) 等 から call、 IRQ 基盤と device 責任分割原則)。
+; priority 調整 (= FM 優先 / 内蔵優先) は後続 PR 検討。
+; libsosx1_base.asm L56-72 + L160-185 fork、 機種判定 + ISR_ENTRY copy 関連は除去。
+; CHKCTC は本 block 内 ローカル label として置く (= linker が CHKCTC を落とさない
+; 構造維持、 別 @name に分けるなら @calls CHKCTC 必要)。
+LD BC, 0
+LD (_CTC), BC
+LD BC, $0A04
+CALL .chkctc
+LD BC, $0704
+CALL .chkctc
+LD BC, $1FA8
+CALL .chkctc
+LD BC, $1FA0
+CALL .chkctc
+RET
+
+; CHKCTC: BC = candidate addr、 CTC chip 応答確認 (= write/read pattern test)、
+;          success なら _CTC = BC+2 (= ch2 port addr)、 fail なら _CTC 変更なし
+.chkctc:
+PUSH BC
+LD DE, $4703
+.inictc1:
+INC C
+OUT (C), D
+DB $ED, $71            ; OUT (C), 0 (= Z80 未定義命令)
+DEC E
+JR NZ, .inictc1
+POP BC
+LD DE, $07FA
+OUT (C), D
+OUT (C), E
+IN A, (C)
+CP E
+RET NZ
+OUT (C), D
+OUT (C), D
+IN A, (C)
+CP D
+RET NZ
+INC C
+INC C
+LD (_CTC), BC
+RET
+
+
+; @name SETUP_ISR_AREA
+; @resident shared
+; @calls sWORK
+; $FFE0-$FFFF に IM2 vector table + ISR_DUMMY + ISR_ENTRY trampoline を構築、
+; vector 全 entry を ISR_DUMMY addr で初期化 (= 想定外 interrupt 安全網)、
+; _CTCVEC / _ISRADR / _ISRHANDLER 設定。 SLANGINIT から call、 device library が
+; 後で個別 vector slot を差し替える形 (= PSG_INIT(1) 等)。
+;
+; memory layout ($FFE0-$FFFF、 32 byte、 x1native ABI 予約領域):
+;  - $FFE0-$FFE7: IM2 vector table (= CTC ch0-3 vector × 2 byte)
+;  - $FFE8-$FFEA: ISR_DUMMY (= 3 byte: EI; RETI)
+;  - $FFEB-$FFFF: ISR_ENTRY (= 9 byte + 余裕 12 byte)
+;
+; ISR_DUMMY_TEMPLATE / ISR_ENTRY_TEMPLATE は本 block 内 ローカル label。
+; ISR_ENTRY 内 JP operand addr = $FFEB + 7 = $FFF2 (= _ISRHANDLER 経由 patch)。
+LD HL, .isr_dummy_template
+LD DE, $FFE8
+LD BC, .isr_dummy_template_end - .isr_dummy_template
+LDIR
+
+LD HL, .isr_entry_template
+LD DE, $FFEB
+LD BC, .isr_entry_template_end - .isr_entry_template
+LDIR
+
+; vector table $FFE0-$FFE7 を ISR_DUMMY ($FFE8) で初期化
+LD HL, $FFE8
+LD DE, $FFE0
+LD B, 4
+.sia_loop:
+LD A, L
+LD (DE), A
+INC DE
+LD A, H
+LD (DE), A
+INC DE
+DJNZ .sia_loop
+
+LD HL, $FFE0
+LD (_CTCVEC), HL
+LD HL, $FFEB
+LD (_ISRADR), HL
+LD HL, $FFEB + 7        ; ISR_ENTRY 内 JP operand addr = $FFF2
+LD (_ISRHANDLER), HL
+RET
+
+; ISR_DUMMY: 想定外 interrupt 安全網 (= EI で割り込み再許可後 RETI で即帰る)
+.isr_dummy_template:
+EI                       ; FB
+DB $ED, $4D              ; RETI
+.isr_dummy_template_end:
+
+; ISR_ENTRY: register 保存 + RAM bank restore (defensive) + handler jump
+; SOUNDDRV_EXEC 等 handler 側で RETI して interrupt から帰る (= ISR_ENTRY 側で
+; POP + RETI する形式ではない、 JP handler 単純型)。 RETI→RET 書換は不要。
+.isr_entry_template:
+PUSH AF
+LD A, $1E                ; X1 BIOS bank port: RAM bank restore (defensive、
+                         ; user code が ROM 使わない前提なら不要だが念のため)
+OUT ($00), A
+POP AF
+JP 0                     ; ← _ISRHANDLER 経由 patch、 SOUNDDRV_EXEC 等を書く
+.isr_entry_template_end:

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -374,6 +374,26 @@ public class X1NativeEnvTests
     }
 
     [Fact]
+    public void Libx1Psg_PsgEnd_HasX1NativeGuard()
+    {
+        // Codex review High fix: PSG_END で x1native の場合 ch1 vector slot が
+        // ISR_ENTRY 指してるかチェック、 違ったら early RET (= PSG_INIT(0) 後の
+        // _CTC=0 で `OUT (C),$03` が偽 port 書込、 CTC3BACKUP=0 で vector
+        // $FFE2/$FFE3 を 0 fill して想定外 interrupt $0000 飛び の bug 再発防止)。
+        // pin: PSG_END routine 区間内に OS_TYPE == 4 #IF block + _ISRADR 比較 +
+        // RET NZ early-return が存在 (= guard 構造)。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1_psg.asm"));
+        var match = Regex.Match(content,
+            @"; @name PSG_END\b(.*?)(?=; @name |\z)",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "PSG_END routine 区間が見つからない");
+        var body = match.Groups[1].Value;
+        Assert.Contains("#IF NAME_SPACE_DEFAULT.OS_TYPE == 4", body);
+        Assert.Contains("LD HL,(_ISRADR)", body);
+        Assert.Contains("RET NZ", body);
+    }
+
+    [Fact]
     public void X1SglSample_BuildsSuccessfully()
     {
         // X1SGL.SL は PSG_INIT(0)/(1) + SGL sprite + PCG を全部使う最小 demo

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -256,6 +256,146 @@ public class X1NativeEnvTests
         Assert.Contains("; @name GRCLS", content);
     }
 
+    // === PSG / IRQ 基盤統合 関連 (= libx1_psg native 統合、 自前 IM2 vector) ===
+
+    [Fact]
+    public void Libx1NativeBase_DefinesIrqInfrastructure()
+    {
+        // IRQ 基盤 routine の存在 pin: SEARCHCTC (= CTC 検出) / SETUP_ISR_AREA
+        // (= IM2 vector table + ISR_DUMMY + ISR_ENTRY 構築)、 + 内部 template
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_base.asm"));
+        Assert.Contains("; @name SEARCHCTC", content);
+        Assert.Contains("; @name SETUP_ISR_AREA", content);
+        Assert.Contains(".isr_dummy_template", content);
+        Assert.Contains(".isr_entry_template", content);
+    }
+
+    [Fact]
+    public void Sworks_IncludesIsrWorkArea()
+    {
+        // sWORK @works に _ISRADR:2 / _ISRHANDLER:2 が含まれる (= libx1_psg
+        // x1native path で _ISRADR / _ISRHANDLER 経由 indirect call に使う)
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_base.asm"));
+        Assert.Matches(@"; @works .*_ISRADR:2", content);
+        Assert.Matches(@"; @works .*_ISRHANDLER:2", content);
+    }
+
+    [Fact]
+    public void Slanginit_SetupsIm2ButNoEi()
+    {
+        // SLANGINIT 内に IM 2 setup (= LD I, A + IM 2) は含むが、 EI は含まない
+        // (= IRQ 基盤と device 責任分割、 device library 側で EI)
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_base.asm"));
+        var match = Regex.Match(content, @"; @name SLANGINIT\b(.*?)(?=; @name |\z)",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "SLANGINIT routine 区間が見つからない");
+        var body = match.Groups[1].Value;
+        Assert.Contains("LD I, A", body);
+        Assert.Contains("IM 2", body);
+        // SLANGINIT 内 単独 EI は存在しない (= device 側で EI、 IRQ 基盤責任分割)
+        Assert.DoesNotMatch(@"\nEI\b", body);
+        // SEARCHCTC を SLANGINIT 内では CALL しない (= device 側で CALL、 ただし
+        // @calls listing には declare する = link 対象に積むため)
+        Assert.DoesNotContain("CALL SEARCHCTC", body);
+    }
+
+    [Fact]
+    public void Libx1Psg_DefinesX1NativeOsTypeBranch()
+    {
+        // libx1_psg.asm に OS_TYPE == 4 (x1native) の #ELIF block が L698 / L746
+        // 両方に追加されてる (= L698 = CTC ch0 vector register 書込、 L746 =
+        // vector table ch1 slot + ISR_ENTRY 内 JP operand 書込)
+        var content = File.ReadAllText(RuntimeAsmPath("libx1_psg.asm"));
+        var elifMatches = Regex.Matches(content, @"#ELIF NAME_SPACE_DEFAULT\.OS_TYPE == 4");
+        Assert.True(elifMatches.Count >= 2,
+            $"OS_TYPE == 4 #ELIF が L698 + L746 両方に必要 (count={elifMatches.Count})");
+    }
+
+    [Fact]
+    public void Libx1Psg_X1NativePath_NoRetiToRetRewrite()
+    {
+        // x1native path で RETI → RET 書換 (= LD A,$C9; LD (SOUNDDRV_EXEC_END),A)
+        // を実行しない pin。 x1native ISR_ENTRY は JP handler 単純型、 SOUNDDRV_EXEC
+        // RETI で interrupt から直接帰る (= libx1_psg S-OS turbo path の RETI→RET
+        // 書換 pattern が x1native 側に紛れ込まないよう設計判断の再発防止)。
+        // 注: comment 行 (= ; で始まる行) は除外して instruction 行のみ判定
+        //     (= 私が書いた「実行しない」 旨の comment が文字列 match で誤 fail
+        //      しないよう)。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1_psg.asm"));
+        // OS_TYPE == 4 block の中身 (= 次の #ELIF or #ENDIF まで) を抽出。
+        // 単純な `(.*?)#ENDIF` だと OS_TYPE == 4 の後に他 #ELIF block が続く場合
+        // それらも巻き込む (= S-OS path の `LD A,$C9` を誤検出した bug)。
+        var match = Regex.Match(content,
+            @"#ELIF NAME_SPACE_DEFAULT\.OS_TYPE == 4(.*?)(?=#ELIF|#ENDIF)",
+            RegexOptions.Singleline);
+        while (match.Success)
+        {
+            var body = match.Groups[1].Value;
+            var instructions = string.Join("\n",
+                body.Split('\n').Where(line => !line.TrimStart().StartsWith(";")));
+            if (instructions.Contains("LD A,$C9") || instructions.Contains("LD A, $C9"))
+                Assert.Fail("x1native path instruction に RETI→RET 書換 (LD A,$C9) が含まれる");
+            if (instructions.Contains("SOUNDDRV_EXEC_END"))
+                Assert.Fail("x1native path instruction に SOUNDDRV_EXEC_END 書換が含まれる");
+            if (Regex.IsMatch(instructions, @"\n\s*EI\b") ||
+                Regex.IsMatch(instructions, @"^\s*EI\b"))
+                Assert.Fail("x1native path instruction に単独 EI が含まれる (= INITEND 共通 EI に任せる)");
+            match = match.NextMatch();
+        }
+    }
+
+    [Fact]
+    public void Libx1Psg_X1NativePath_CallsSearchctc()
+    {
+        // x1native path で SEARCHCTC を CALL する pin (= CTC 検出は device 側責任)
+        var content = File.ReadAllText(RuntimeAsmPath("libx1_psg.asm"));
+        var match = Regex.Match(content,
+            @"#ELIF NAME_SPACE_DEFAULT\.OS_TYPE == 4(.*?)(?=#ELIF|#ENDIF)",
+            RegexOptions.Singleline);
+        var foundCall = false;
+        while (match.Success)
+        {
+            if (match.Groups[1].Value.Contains("CALL NAME_SPACE_DEFAULT.SEARCHCTC"))
+            {
+                foundCall = true;
+                break;
+            }
+            match = match.NextMatch();
+        }
+        Assert.True(foundCall, "x1native path に CALL NAME_SPACE_DEFAULT.SEARCHCTC が必要");
+    }
+
+    [Fact]
+    public void X1NativeEnv_RegistersPsgLibrary()
+    {
+        // x1native env libraries に libx1_psg.asm 含む (= 本 PR で supported now 昇格)
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.Contains("libx1_psg.asm", config.Libraries);
+    }
+
+    [Fact]
+    public void X1SglSample_BuildsSuccessfully()
+    {
+        // X1SGL.SL は PSG_INIT(0)/(1) + SGL sprite + PCG を全部使う最小 demo
+        // (= libx1_psg + libx1_sgl + libx1_pcg + libx1native 全 link 確認)
+        var repoRoot = RepoRoot();
+        var sample = Path.Combine(repoRoot, "examples", "X1SGL.SL");
+        var include = Path.Combine(repoRoot, "include");
+        var output = Path.Combine(Path.GetTempPath(), $"X1SGL_test_{Guid.NewGuid():N}");
+        try
+        {
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{sample}\" -o \"{output}\" --emit tape");
+            Assert.True(rc == 0,
+                $"X1SGL build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.True(File.Exists(output + ".tap"), "X1SGL.tap not generated");
+        }
+        finally
+        {
+            CleanupBuildArtifacts(output);
+        }
+    }
+
     [Fact]
     public void Libmag_DoesNotDefineGrdispGrcls()
     {


### PR DESCRIPTION
## Summary

OS 非依存 `x1native` runtime に libx1_psg を統合し、 **自前 IM2 vector + 高位 RAM ISR trampoline** 設計で `PSG_INIT(0)` (= 非割り込み) / `PSG_INIT(1)` (= CTC 割り込み) 両モード対応。 `examples/X1SGL.SL` build + emulator boot で sprite + PSG sound 出力動作確認 OK (= user 実機確認済、 X1 normal / X1turbo 両 mode で同挙動)。

## 設計判断

- 機種判定 / `CALL $1FF7` / S-OS vector 借用 (`$0058` / `$F830`) **一切しない**
- 自前 IM2 vector table + ISR trampoline を高位 RAM (`$FFE0-$FFFF`) 固定予約 (= ROM bank が $0000-$7FFF にあっても $FFE0-$FFFF は常に RAM、 **normal / turbo 区別不要**、 機種判定 不要)
- **IRQ 基盤と device-specific 責任分割**:
  - **SLANGINIT (= IRQ 土台)**: `SETUP_ISR_AREA` + `LD I, $FF` + `IM 2` まで、 **EI なし**、 **SEARCHCTC CALL なし**
  - **PSG_INIT(1) (= device)**: SEARCHCTC + CTC ch1 設定 + vector slot 差替
  - **EI** は PSG_INIT 共通末尾 (INITEND) で初期化完了後
  - 将来 Arkos Tracker 等 別 IRQ driver 入れたとき干渉しない設計
- ISR_ENTRY は simpler `PUSH AF; OUT bank; POP AF; JP handler` 型、 SOUNDDRV_EXEC は **RETI のまま** (= libx1_psg S-OS turbo の RETI→RET 書換 pattern は不使用)
- vector table 全 entry は ISR_DUMMY (`EI; RETI`) で init (= 想定外 interrupt 安全網)
- SEARCHCTC は CTC port 検出のみ担当、 探索順は既存通り後勝ち

## 主な変更

### `runtime/env/x1native.env`
`libx1_psg.yml` 追加 (= supported now)、 `libx1_sgl` も同分類に昇格。

### `runtime/libx1native_base.asm` (= IRQ 土台拡張)
- **SEARCHCTC / CHKCTC** routine port (= libsosx1_base.asm L56-72 + L160-185、 CHKCTC は同 @name 内 ローカル label で linker 落とし回避)
- **SETUP_ISR_AREA** 追加 (= `$FFE0-$FFFF` に vector table + ISR_DUMMY + ISR_ENTRY 構築、 内部 template も同 @name 内 ローカル label)
- SLANGINIT に `CALL SETUP_ISR_AREA` + `LD I, A` + `IM 2` 追加 (= EI なし、 SEARCHCTC CALL なし、 ただし `@calls` listing に SEARCHCTC を declare 追加 = link 解決のため)
- sWORK `@works` に `_ISRADR:2` / `_ISRHANDLER:2` 追加

### `runtime/libx1_psg.asm` (= device-specific path 追加)
- L698 / L746 #IF block に `#ELIF NAME_SPACE_DEFAULT.OS_TYPE == 4` (x1native) path 追加
- x1native path で `CALL NAME_SPACE_DEFAULT.SEARCHCTC` + vector register 書込 + ISR_ENTRY 経由 indirect call (= `_ISRADR` / `_ISRHANDLER` 経由)
- **RETI→RET 書換 (`LD A,$C9; LD (SOUNDDRV_EXEC_END),A`) は実行しない**
- **branch 内 EI は行わない** (= PSG_INIT 共通末尾 INITEND の EI に任せる)
- 既存 OS_TYPE 0 (LSX) / 1 (S-OS) path は **完全無触**

### `tests/SLANGCompiler.Tests/X1NativeEnvTests.cs`
- 静的 asm 構造 pin 7 件 (= IRQ 基盤 routine 存在 / sWORK 拡張 / SLANGINIT IM2 setup + EI/SEARCHCTC CALL 不在 / libx1_psg x1native path 存在 + RETI→RET 書換不在 + EI 不在 + SEARCHCTC CALL 存在 / x1native env psg 登録)
- CLI spawn build smoke 1 件 (= X1SglSample_BuildsSuccessfully)

### `docs/X1.md`
「x1native ABI 予約領域 + IRQ 設計」 section 新規追加 (= ISR trampoline reserved area / IRQ 責任分割 / tape size 制約 / interrupt 制約 明記)

## Test plan

- [x] `dotnet test` 全 **516 件 pass** (= 既存 508 + 新規 8)、 regression なし
- [x] `slangbuild -E x1native --emit tape` で `examples/X1SGL.SL` build success (bin 20126 / tap 83044 byte)
- [x] 既存 6 sample (HELLO/STARS/FMANDEL/FURUI/X1GRP/STARS_X1) build OK + bin size +149 byte 微増 (= SEARCHCTC declare による dead code link、 MVP 許容範囲)
- [x] x1 env `X1SGL.SL` asm 生成 OK = LSX path regression なし
- [x] emulator 動作確認: X1SGL.tap で **PSG sound 正常出力** (= user 実機確認済、 X1 normal / X1turbo 両 mode で同挙動)

## 注意点 / 既知の問題

- **X1turbo で text/PCG 表示が出ない症状あり** (= user 報告): ただし x1 env でも同症状で **本 PR とは無関係の既存バグ可能性高い**。 merge 後 main に戻って同 build smoke で再現確認 → 既存バグ確定なら別 issue/PR で対応予定。 PSG sound は両 mode 動作するため本 PR の主目的は達成。
- `apps/PSGPLAY.SL` は MAGLOAD (= libmag/file IO) 必須で本 PR scope 外、 動作確認 sample は X1SGL.SL のみ

## 残課題 (= 本 PR scope 外、 後続)

- **X1turbo text 表示問題**: 既存バグ可能性、 main 比較確認 → 別 PR 切り分け対応
- **libx1native_irq.asm 切り出し**: 将来 Arkos Tracker 等 別 IRQ driver 対応時、 IRQ_INIT / IRQ_SET_HANDLER / IRQ_DUMMY / SEARCHCTC を汎用 API として library 化
- tape builder size reject 強化 (= `--emit tape` 時 `$FFDF` 上限 reject)
- CTC 探索 priority 調整 (= FM 音源ボード優先 or 内蔵 CTC 優先)
- libmag / libm8a native 化 (= file IO 一式)
- X1turbo 高解像 mode 対応 (= `_C8025H` 系)

🤖 Generated with [Claude Code](https://claude.com/claude-code)