### PR TITLE
x1native: 多段 tape ロード (MTREAD/MTREADJP + #MODULE overlay 自動連結)

### DIFF
--- a/docs/X1.md
+++ b/docs/X1.md
@@ -156,9 +156,66 @@ CLI option:
 
 ### 制限
 
-- **1 binary per tape** (= X1 cassette 仕様)、 overlay 多段ロードは未対応 (= 検出時 reject)
 - file I/O API (FOPEN/FCLOSE 等) は x1native 同様 未対応
 - raw bin output env のみ対応 (= `output: cmt` 系 / c64 oscar_c 系では `--emit tape` 不可)
+
+## 多段 tape ロード (= MTREAD / MTREADJP + #MODULE overlay 自動連結)
+
+X1 慣習で多段 tape 運用が可能 (= loader が後続 block を任意 addr に読み、 program overlay / PCG source / table / asset として使う)。
+
+### SLANG public API
+
+- `MTREAD(load_addr)` → 次 info+data block を `load_addr` に読込、 戻り `HL = data size` (or `$FFFF` = error)
+  - **引数 `load_addr` を優先**、 info block 内の LoadAddress は無視 (= data size のみ使う)
+  - 内部で `MT_CTRL_PLAY → 読込 → MT_CTRL_STOP` 自動実行 (= deck 再生再開 → block read → 停止)
+- `MTREADJP(load_addr, jp_addr)` → 上 + `jp_addr` へ JP (= 成功時 no-return、 失敗時 `HL = $FFFF` + RET)
+  - **raw stage 用**。 overlay の場合は overlay 先頭が entry とは限らないため `MTREAD + 関数呼出` 推奨
+
+### #MODULE overlay → 多段 .tap 自動連結
+
+SLANG の `#MODULE $XXXX ~ #END` で overlay 定義すると、 `slangbuild --emit tape` が `main.bin + overlay._mN.bin` を自動的に多段 .tap に連結。 各 overlay の load addr は `#MODULE` 指定値 (= ORG 整合は overlay 機構 auto)、 各段 標準 sync 仕様 (= info 40/41 leader 8000、 data 20/21 leader 4000) で emit。
+
+例 (= `examples/X1NATIVE_MTREAD/MTREADSMP.SL`):
+```sl
+VAR OVERLAY_RESULT;
+
+#MODULE $4000
+overlay_entry()
+BEGIN
+    OVERLAY_RESULT = 42;
+END;
+#END
+
+MAIN()
+BEGIN
+    PRINT("STAGE1: LOADING OVERLAY...");
+    PRINT(/);
+    OVERLAY_RESULT = 0;
+    MTREAD($4000);          // overlay binary load
+    overlay_entry();        // prelink が CALL 解決
+    PRINT("STAGE2 RESULT = ");
+    PRINT(%(OVERLAY_RESULT));
+END;
+```
+
+build:
+```sh
+slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
+    -o /tmp/MTREADSMP --emit tape
+# → /tmp/MTREADSMP.tap (= main + overlay._m0 自動連結)
+```
+
+### 注意点 / 制約
+
+- X1 tape は **1 段目読込完了で auto stop**、 2 段目読込時 MTREAD/MTREADJP が sub CPU 経由で自動再生再開
+- tape read は bit-level timing critical (~185µs/bit)、 routine 内 DI で割り込み禁止 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
+- load 先 addr は `$1000-$FFDF` 範囲推奨 (= ISR trampoline / stack 衝突回避)
+- **overlay tape stage の exec addr は意味なし** (= header 上 formality で load と同値書込、 MTREAD は次 block の data を読むだけで exec は使わない)
+- **既知制約**: overlay 内で `PRINT` 等 sWORK 内 BSS sym (= sXYADR / AT_WIDTH 等) を参照する SLANG runtime call は overlay の EXTERN 宣言不足で assemble fail する (= 既存 #MODULE + x1native の組合せ問題、 別 issue 対応予定)。 当面 overlay 内は VAR 書込 / 値計算のみ、 表示は main で実施
+
+### 既存 1 binary tape との互換
+
+`#MODULE` 未使用 (= overlay 0 件) の SLANG コードは従来通り 1 binary .tap として build される (= bit-exact 互換)。 既存 sample (`X1NATIVE_HELLO.SL` 等) は影響なし。
 
 ## x1native ABI 予約領域 + IRQ 設計
 

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -173,15 +173,23 @@ X1 慣習で多段 tape 運用が可能 (= loader が後続 block を任意 addr
 
 ### #MODULE overlay → 多段 .tap 自動連結
 
-SLANG の `#MODULE $XXXX ~ #END` で overlay 定義すると、 `slangbuild --emit tape` が `main.bin + overlay._mN.bin` を自動的に多段 .tap に連結。 各 overlay の load addr は `#MODULE` 指定値 (= ORG 整合は overlay 機構 auto)、 各段 標準 sync 仕様 (= info 40/41 leader 8000、 data 20/21 leader 4000) で emit。
+SLANG の `#MODULE $XXXX [RESIDENT] ~ #END` で overlay 定義すると、 `slangbuild --emit tape` が `main.bin + overlay._mN.bin` を自動的に多段 .tap に連結。 各 overlay の load addr は `#MODULE` 指定値 (= ORG 整合は overlay 機構 auto)、 各段 標準 sync 仕様 (= info 40/41 leader 8000、 data 20/21 leader 4000) で emit。
+
+#### `RESIDENT` 指定推奨
+
+`#MODULE $XXXX RESIDENT` で **RESIDENT mode** 指定すると、 overlay 内 runtime call (= `PRINT` 等) は main 側 shared runtime への EXTERN 参照に変換される (= shared promotion)。 overlay binary 大幅縮小 (= 例: 248 byte → 36 byte、 -85%) + overlay 内で SLANG runtime 全部使える。
+
+`RESIDENT` 指定なし (= Local default) だと overlay 内に runtime routine が複製され、 さらに sWORK 内 BSS sym (= `sXYADR` / `AT_WIDTH` 等) の EXTERN 宣言不足で assemble fail する (= 既存 #MODULE + x1native の組合せ問題)。 多段 tape では **必ず RESIDENT 指定** を推奨。
 
 例 (= `examples/X1NATIVE_MTREAD/MTREADSMP.SL`):
 ```sl
 VAR OVERLAY_RESULT;
 
-#MODULE $4000
+#MODULE $4000 RESIDENT
 overlay_entry()
 BEGIN
+    PRINT("STAGE2 OVERLAY LOADED!");    // shared promotion で OK
+    PRINT(/);
     OVERLAY_RESULT = 42;
 END;
 #END
@@ -202,7 +210,8 @@ build:
 ```sh
 slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
     -o /tmp/MTREADSMP --emit tape
-# → /tmp/MTREADSMP.tap (= main + overlay._m0 自動連結)
+# → /tmp/MTREADSMP.tap (= main + overlay._m0 自動連結、 RESIDENT mode で
+#    overlay 36 byte の小型)
 ```
 
 ### 注意点 / 制約
@@ -211,7 +220,7 @@ slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
 - tape read は bit-level timing critical (~185µs/bit)、 routine 内 DI で割り込み禁止 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
 - load 先 addr は `$1000-$FFDF` 範囲推奨 (= ISR trampoline / stack 衝突回避)
 - **overlay tape stage の exec addr は意味なし** (= header 上 formality で load と同値書込、 MTREAD は次 block の data を読むだけで exec は使わない)
-- **既知制約**: overlay 内で `PRINT` 等 sWORK 内 BSS sym (= sXYADR / AT_WIDTH 等) を参照する SLANG runtime call は overlay の EXTERN 宣言不足で assemble fail する (= 既存 #MODULE + x1native の組合せ問題、 別 issue 対応予定)。 当面 overlay 内は VAR 書込 / 値計算のみ、 表示は main で実施
+- `RESIDENT` 指定推奨 (= 上記)、 Local default では overlay 内 SLANG runtime call assemble fail する
 
 ### 既存 1 binary tape との互換
 

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -217,7 +217,8 @@ slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
 ### 注意点 / 制約
 
 - X1 tape は **1 段目読込完了で auto stop**、 2 段目読込時 MTREAD/MTREADJP が sub CPU 経由で自動再生再開
-- tape read は bit-level timing critical (~185µs/bit)、 routine 内 DI で割り込み禁止 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
+- tape read は bit-level timing critical (~185µs/bit)、 bit-stream read 部分 (= `_mtload_block` 内) は完全 DI 維持 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
+- ただし MTREAD 内の deck control 呼出 (= `MT_CTRL_PLAY` / `MT_CTRL_STOP` 経由 `MT_CTRL`) は sub CPU 通信 sync のため **一時 EI** する (= X1_compatible_rom 元 source 由来、 数十 cycle 程度の短い window)、 PSG IRQ 等が間に入る可能性あり (= 元 source の必要 sync で削除不可)。 bit-stream read 部分は影響なし
 - load 先 addr は `$1000-$FFDF` 範囲推奨 (= ISR trampoline / stack 衝突回避)
 - **overlay tape stage の exec addr は意味なし** (= header 上 formality で load と同値書込、 MTREAD は次 block の data を読むだけで exec は使わない)
 - `RESIDENT` 指定推奨 (= 上記)、 Local default では overlay 内 SLANG runtime call assemble fail する

--- a/examples/X1NATIVE_MTREAD/MTREADSMP.SL
+++ b/examples/X1NATIVE_MTREAD/MTREADSMP.SL
@@ -1,4 +1,4 @@
-// X1 多段 tape ロード sample (= #MODULE overlay 経由)
+// X1 多段 tape ロード sample (= #MODULE overlay 経由、 RESIDENT mode)
 //
 // build: slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
 //        -o /tmp/MTREADSMP --emit tape
@@ -9,23 +9,27 @@
 //   2) MTREAD($4000) で 2 段目 (overlay._m0) を $4000 に load
 //      (= 内部で MT_CTRL_PLAY で deck 再生再開、 info+data block read、 MT_CTRL_STOP)
 //   3) overlay_entry() call (= prelink が overlay 内 関数を addr 解決)
-//      → OVERLAY_RESULT に 42 を書込
+//      → "STAGE2 OVERLAY LOADED!" 表示 + OVERLAY_RESULT に 42 を書込
 //   4) main で "STAGE2 RESULT = 42" 表示 + INKEY(1) で stop 解除
 //
-// 注: overlay 内では PRINT 等 SLANG runtime call は使わない (= 既存 #MODULE +
-//      x1native の組合せで overlay 内から sXYADR / AT_WIDTH (= sWORK 内 BSS)
-//      参照が EXTERN 宣言されない既存問題のため別 issue 対応予定)。
-//      overlay は値計算 / VAR 書込のみ、 表示は main 側で。
+// 注: `#MODULE $4000 RESIDENT` で **RESIDENT mode** 指定 = overlay 内 runtime
+//     call (PRINT 等) は main 側 shared runtime への EXTERN 参照に変換され、
+//     overlay binary は大幅縮小 (= 例: 248 byte → 36 byte、 -85%)。
+//     RESIDENT 指定なし (= Local default) だと overlay 内に runtime routine が
+//     複製され、 さらに sWORK 内 BSS sym (sXYADR / AT_WIDTH) の EXTERN 宣言
+//     不足で assemble fail する。
 
 VAR OVERLAY_RESULT;
 
-#MODULE $4000
+#MODULE $4000 RESIDENT
 
 // overlay 内 関数 (= prelink で main から call 可能、 overlay binary は $4000 に
 //  load される前提、 関数の実 addr は SLANG runtime planner が解決)。
-// 注: PRINT 等 runtime call は本 sample では使用しない (= 上記既存問題)。
+// RESIDENT mode のため PRINT 等 runtime call OK (= shared promotion 経由)。
 overlay_entry()
 BEGIN
+    PRINT("STAGE2 OVERLAY LOADED!");
+    PRINT(/);
     OVERLAY_RESULT = 42;
 END;
 

--- a/examples/X1NATIVE_MTREAD/MTREADSMP.SL
+++ b/examples/X1NATIVE_MTREAD/MTREADSMP.SL
@@ -1,0 +1,50 @@
+// X1 多段 tape ロード sample (= #MODULE overlay 経由)
+//
+// build: slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
+//        -o /tmp/MTREADSMP --emit tape
+// → /tmp/MTREADSMP.tap (= main + overlay._m0 自動連結、 各段 標準 sync 仕様)
+//
+// 実行: emulator (xmil / X-millenium) で MTREADSMP.tap mount → IPL boot
+//   1) 1 段目 (main) auto load + exec → "STAGE1: LOADING OVERLAY..." 表示
+//   2) MTREAD($4000) で 2 段目 (overlay._m0) を $4000 に load
+//      (= 内部で MT_CTRL_PLAY で deck 再生再開、 info+data block read、 MT_CTRL_STOP)
+//   3) overlay_entry() call (= prelink が overlay 内 関数を addr 解決)
+//      → OVERLAY_RESULT に 42 を書込
+//   4) main で "STAGE2 RESULT = 42" 表示 + INKEY(1) で stop 解除
+//
+// 注: overlay 内では PRINT 等 SLANG runtime call は使わない (= 既存 #MODULE +
+//      x1native の組合せで overlay 内から sXYADR / AT_WIDTH (= sWORK 内 BSS)
+//      参照が EXTERN 宣言されない既存問題のため別 issue 対応予定)。
+//      overlay は値計算 / VAR 書込のみ、 表示は main 側で。
+
+VAR OVERLAY_RESULT;
+
+#MODULE $4000
+
+// overlay 内 関数 (= prelink で main から call 可能、 overlay binary は $4000 に
+//  load される前提、 関数の実 addr は SLANG runtime planner が解決)。
+// 注: PRINT 等 runtime call は本 sample では使用しない (= 上記既存問題)。
+overlay_entry()
+BEGIN
+    OVERLAY_RESULT = 42;
+END;
+
+#END
+
+MAIN()
+BEGIN
+    PRINT("STAGE1: LOADING OVERLAY...");
+    PRINT(/);
+    OVERLAY_RESULT = 0;
+    // overlay binary (= overlay._m0.bin) を $4000 に load
+    // 注: overlay 先頭が必ず overlay_entry とは限らない。
+    //     overlay 経由なら MTREAD + 関数呼出で安全に呼び出す
+    //     (= MTREADJP($4000, $4000) は raw stage 用)。
+    MTREAD($4000);
+    overlay_entry();    // prelink が CALL 解決 (= 既存 #MODULE 機構)
+    PRINT("STAGE2 RESULT = ");
+    PRINT(%(OVERLAY_RESULT));
+    PRINT(/);
+    PRINT("PRESS ANY KEY...");
+    INKEY(1);
+END;

--- a/runtime/env/x1native.env
+++ b/runtime/env/x1native.env
@@ -25,5 +25,6 @@ libraries:
   - libx1_magic.yml     # registered (= 未使用時は selective link で無害、 動作確認は別 PR)
   - libx1_sgl.yml       # supported now (= SGL_* sprite、 X1SGL.SL で動作確認、 sgl_lsx は除外)
   - libx1_psg.yml       # supported now (= PSG_INIT(0)/(1) 両対応、 自前 IM2 vector で割り込み駆動)
+  - libx1native_tape.yml  # supported now (= MTREAD/MTREADJP 多段 tape load + sub CPU deck control)
   - libcompress.yml
   - libsoroban.yml

--- a/runtime/libx1native_tape.asm
+++ b/runtime/libx1native_tape.asm
@@ -1,0 +1,338 @@
+; libx1native_tape.asm
+; SLANG x1native runtime — CMT (cassette tape) 多段 load 対応
+;
+; Adapted from:
+;   - X1_compatible_rom (Meister, CC0 1.0 Universal,
+;     https://github.com/meister68k/X1_compatible_rom)
+;     参考実装: X1_compatible_rom.z80 の以下 routine 群
+;       - tape bit-stream read: L1639-1819 (MT_EDGE / MT_RDBIT / MT_RDBIT_D /
+;         MT_SKIP1111 / MT_SKIP0 / MT_SKIP1 / MT_RDBYTE)
+;       - block load: L1440-1516 (CMT_LOADIFB / CMT_LOADFILE)
+;       - sub CPU deck control: L1521-1574 (MT_CTRL_PLAY / MT_CTRL_STOP / MT_CTRL)
+;       - sub CPU helpers: L1209-1233 (WAIT_80C49_WR / READ_80C49)
+;     CC0 → MIT 互換、 attribution として本 header に明記。
+;
+; 機能:
+;   MTREAD(load_addr): 次 info+data block を読込、 戻り HL = data size (or $FFFF)
+;     - 引数 HL を data load 先 addr として優先 (= info block 内 LoadAddress 無視)
+;     - 内部で deck PLAY → info block read → data block read → deck STOP
+;   MTREADJP(load_addr, jp_addr): 上 + jump (= raw stage 用、 overlay 経由なら
+;     MTREAD + 関数呼出 推奨)
+;
+; CMT port:
+;   $1A01 (8255 port B) bit 1: CMT data line polling
+;   $1900: sub CPU command port ($E9 = cassette deck control)
+;
+; 前提: X1 tape は 1 段目読込完了で auto stop、 2 段目は MT_CTRL_PLAY で
+;       再生再開必須。 tape read は bit-level timing critical (~185µs/bit)、
+;       routine 内 DI で割り込み禁止 + IFF2 復元 guard で entry 時状態維持。
+;
+; X1 info block byte format (= X1InfoBlock.cs と整合):
+;   byte 0x00: BootFlag、 0x01-0x0D: FileName (13 char)、
+;   byte 0x0E-0x10: Extension (3 char)、 byte 0x11: Password、
+;   byte 0x12-0x13: DataSize (16-bit LE)、
+;   byte 0x14-0x15: LoadAddress (= 無視、 引数 HL 優先)、
+;   byte 0x16-0x17: ExecuteAddress、 ...
+
+
+; @name MTREAD
+; @resident shared
+; @param_count 1
+; @calls sWORK, sWORK_TAPE, MT_CTRL_PLAY, MT_CTRL_STOP
+; HL = load_addr (= 引数優先、 info block の LoadAddress は無視)
+; 戻り: HL = data size (or $FFFF = error)
+;
+; IFF2 復元 guard (= Codex 指摘の DI 先順):
+;   LD A, I → IFF2 を P/V flag に転写
+;   DI      → 直後 DI (flags 壊さない)
+;   PUSH AF → A + flags 保存
+;   ... critical section (= DI 確定 状態) ...
+;   POP AF
+;   JP PO, skip → P/V = 0 (= 元 DI) なら EI skip
+;   EI
+LD A, I
+DI
+PUSH AF
+PUSH HL                  ; load_addr 保存
+CALL MT_CTRL_PLAY        ; deck 再生再開 (= 1 段目 auto stop からの再開)
+
+; info block (32 byte + checksum 2 byte) を MT_INFOBUF に read
+LD BC, $1A01
+LD HL, MT_INFOBUF
+CALL .cli_entry          ; CMT info block load (= local routine)
+JR C, .mtr_fail
+
+; info block byte 0x12-0x13 (= DataSize LE) を DE に
+LD HL, MT_INFOBUF + $12
+LD E, (HL)
+INC HL
+LD D, (HL)               ; DE = data size
+
+; data block を caller 指定 load_addr に read (= 引数 HL 優先)
+POP HL                   ; HL = load_addr (= 引数復元)
+PUSH HL                  ; stack 整合 (= 後の POP DE で discard)
+LD BC, $1A01
+CALL .clf_entry          ; CMT data file load (= local routine)
+JR C, .mtr_fail
+
+EX DE, HL                ; HL = data size (= 成功時戻り値)
+JR .mtr_done
+
+.mtr_fail:
+LD HL, $FFFF             ; error 時 $FFFF
+.mtr_done:
+PUSH HL                  ; size or $FFFF 保存
+CALL MT_CTRL_STOP        ; deck 停止
+POP HL                   ; size or $FFFF 復元
+POP DE                   ; load_addr discard (= stack 整合)
+POP AF                   ; IFF2 復元
+JP PO, .mtr_skip_ei      ; P/V = 0 (= 元 DI) なら EI skip
+EI
+.mtr_skip_ei:
+RET
+
+; --- 以下、 MTREAD 内部 ローカル helper (= 同 @name block 内、 linker 落とし回避) ---
+
+; CMT info block read (= 32 byte + checksum 2 byte)
+; X1_compatible_rom L1440-1467 fork、 引数: BC=$1A01, HL=info buffer, 戻り CY=error
+.cli_entry:
+CALL .mt_skip1111
+JR C, .cli_exit
+LD D, 40 - 1
+CALL .mt_skip0
+JR C, .cli_exit
+LD D, 41
+CALL .mt_skip1
+JR C, .cli_exit
+LD E, 34
+.cli_1:
+CALL .mt_rdbyte
+LD (HL), D
+INC HL
+JR C, .cli_exit
+DEC E
+JR NZ, .cli_1
+.cli_exit:
+RET
+
+; CMT data block read (= N byte + checksum 2 byte)
+; X1_compatible_rom L1482-1516 fork、 引数: BC=$1A01, DE=size, HL=load addr (= 引数優先)
+.clf_entry:
+PUSH DE
+CALL .mt_skip1111
+JR C, .clf_exit
+LD D, 20 - 1
+CALL .mt_skip0
+JR C, .clf_exit
+LD D, 21
+CALL .mt_skip1
+JR C, .clf_exit
+.clf_1:
+CALL .mt_rdbyte
+LD (HL), D
+INC HL
+JR C, .clf_exit
+POP DE
+DEC DE
+PUSH DE
+LD A, D
+OR E
+JR NZ, .clf_1
+.clf_exit:
+POP DE
+RET
+
+; CMT edge wait (= 立ち上がり)、 X1_compatible_rom L1639-1659 fork
+.mt_edge:
+IN A, (C)
+RRCA
+JR NC, .me_2
+RRCA
+JR C, .mt_edge
+.me_1:
+IN A, (C)
+RRCA
+JR NC, .me_2
+RRCA
+JR NC, .me_1
+.me_2:
+CCF
+RET
+
+; CMT 1 bit read (= edge + ~185µs window + read)、 X1_compatible_rom L1671-1687 fork
+.mt_rdbit:
+CALL .mt_edge
+JR C, .mrb_exit
+LD A, 35
+.mrb_1:
+DEC A
+JR NZ, .mrb_1
+IN A, (C)
+AND $02
+.mrb_exit:
+RET
+
+; CMT 1 bit read → D reg (= left shift + add bit)、 X1_compatible_rom L1698-1706 fork
+.mt_rdbit_d:
+RLC D
+CALL .mt_rdbit
+JR C, .mrbd_exit
+JR Z, .mrbd_exit
+INC D
+.mrbd_exit:
+RET
+
+; CMT skip 255+ 1s + 0 1 個、 X1_compatible_rom L1719-1741 fork
+.mt_skip1111:
+PUSH DE
+.ms1111_1:
+LD D, $FF
+.ms1111_2:
+CALL .mt_rdbit
+JR C, .ms1111_exit
+JR Z, .ms1111_1
+DEC D
+JR NZ, .ms1111_2
+.ms1111_3:
+CALL .mt_rdbit
+JR C, .ms1111_exit
+JR NZ, .ms1111_3
+.ms1111_exit:
+POP DE
+RET
+
+; CMT skip D 個 0、 X1_compatible_rom L1753-1764 fork
+.mt_skip0:
+CALL .mt_rdbit
+JR C, .ms0_exit
+SCF
+JR NZ, .ms0_exit
+DEC D
+JR NZ, .mt_skip0
+OR A
+.ms0_exit:
+RET
+
+; CMT skip D 個 1、 X1_compatible_rom L1776-1787 fork
+.mt_skip1:
+CALL .mt_rdbit
+JR C, .ms1_exit
+SCF
+JR Z, .ms1_exit
+DEC D
+JR NZ, .mt_skip1
+OR A
+.ms1_exit:
+RET
+
+; CMT 1 byte read (= start bit + 8 data MSB)、 X1_compatible_rom L1801-1819 fork
+.mt_rdbyte:
+CALL .mt_rdbit
+JR C, .mrby_exit
+SCF
+JR Z, .mrby_exit
+LD D, 0
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+CALL .mt_rdbit_d
+.mrby_exit:
+RET
+
+
+; @name MTREADJP
+; @resident shared
+; @param_count 2
+; @calls sWORK, MTREAD
+; HL = load_addr (= arg1)、 DE = jp_addr (= arg2、 SLANG MACHINE 規約)
+; 成功: jp_addr に JP (= no-return)、 失敗: HL = $FFFF + RET
+; raw stage 用 (= overlay 経由なら MTREAD + 関数呼出 推奨)
+PUSH DE                  ; jp_addr 保存
+CALL MTREAD              ; HL = data size or $FFFF
+POP DE                   ; jp_addr 復元
+; HL = $FFFF check (= 明示比較、 Codex 指摘で AND/INC 系の誤判定回避)
+LD A, H
+CP $FF
+JR NZ, .mrj_ok
+LD A, L
+CP $FF
+JR Z, .mrj_fail
+.mrj_ok:
+EX DE, HL                ; HL = jp_addr
+JP (HL)                  ; jump (= no-return)
+.mrj_fail:
+LD HL, $FFFF
+RET
+
+
+; @name MT_CTRL_PLAY
+; @resident shared
+; @calls sWORK, MT_CTRL
+; cassette deck 再生開始 (= sub CPU $1900 経由 command 2)
+; X1_compatible_rom L1521-1526 fork
+LD BC, $1A01
+LD A, 2                  ; 2 = 再生 (READ) command
+JP MT_CTRL
+
+
+; @name MT_CTRL_STOP
+; @resident shared
+; @calls sWORK, MT_CTRL
+; cassette deck 停止 (= sub CPU $1900 経由 command 1)
+; X1_compatible_rom L1531-1537 fork、 EX AF,AF' で副 register 経由 flag 保存
+EX AF, AF'
+LD A, 1                  ; 1 = 停止 (STOP) command
+CALL MT_CTRL
+EX AF, AF'
+RET
+
+
+; @name MT_CTRL
+; @resident shared
+; @calls sWORK
+; sub CPU $1900 経由 cassette deck command sender (= 汎用 deck control)
+; 引数: A = command
+;   0 = EJECT, 1 = STOP, 2 = READ (= 再生), 3 = FF, 4 = REW,
+;   5 = APSS+1, 6 = APSS-1, A = WRITE
+; X1_compatible_rom L1555-1574 fork
+; ローカル helper: .wait_80c49_wr (= sub CPU write wait)
+PUSH BC
+PUSH AF
+EI                       ; sub CPU 通信中 一時 EI (= 元 source comment「必要？」)
+CALL .wait_80c49_wr
+LD BC, $1900
+LD A, $E9                ; $E9 = cassette deck control command
+OUT (C), A
+CALL .wait_80c49_wr
+DI                       ; sub CPU 通信完了後 DI で interrupt 抑制復帰
+CALL .wait_80c49_wr
+LD BC, $1900
+POP AF
+OUT (C), A
+POP BC
+RET
+
+; sub CPU 80C49 write wait (= 8255 port B bit 6 polling)
+; X1_compatible_rom L1209-1216 fork
+.wait_80c49_wr:
+LD BC, $1A01
+.w80_1:
+IN A, (C)
+AND $40
+JR NZ, .w80_1
+RET
+
+
+; @name sWORK_TAPE
+; @resident shared
+; @works MT_INFOBUF:32
+; MTREAD 内部用 info block 一時 buffer (= 32 byte BSS、 sWORK 統合)
+; 注: 既存 sWORK の @works listing は libx1native_base.asm 内 sWORK で集約、
+;     本 routine の @works は selective link 経由で __WORK__ に append される
+;     (= SLANG runtime planner が同名重複を dedupe)。 別 @works 用 @name を
+;     立てることで MTREAD link 時に MT_INFOBUF も link 対象になる。
+RET

--- a/runtime/libx1native_tape.asm
+++ b/runtime/libx1native_tape.asm
@@ -50,6 +50,14 @@
 ;   POP AF
 ;   JP PO, skip → P/V = 0 (= 元 DI) なら EI skip
 ;   EI
+;
+; ただし MTREAD critical section 内の MT_CTRL_PLAY / MT_CTRL_STOP 呼出時、
+; 内部 MT_CTRL routine が **sub CPU 通信のため一時 EI** する (= X1_compatible_rom
+; 元 source 由来、 sub CPU $1900 への deck command 送出時の必要 sync)。 この間
+; (= 数十 cycle、 OUT (C), $E9 + WAIT_80C49_WR 1 回程度) は IRQ 入り得る。
+; 本 routine 全体としての設計は「MTREAD 中は DI で bit-level read 保護」 だが、
+; deck control 部分 (= bit-stream read ではない) は短い EI window あり = PSG IRQ
+; 等が間に入る可能性。 bit-stream read (= _mtload_block 内) は完全 DI 維持。
 LD A, I
 DI
 PUSH AF

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -242,11 +242,16 @@ public class Driver
             // 次回以降のビルドで filename チェーン爆発を起こす。
             // `_m<digits>.ASM` 厳密一致の regex でフィルタする。
             var overlayPattern = new System.Text.RegularExpressions.Regex(
-                $"^{System.Text.RegularExpressions.Regex.Escape(prefix)}\\._m\\d+\\.ASM$",
+                $"^{System.Text.RegularExpressions.Regex.Escape(prefix)}\\._m(\\d+)\\.ASM$",
                 System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+            // overlay 順序は **数値順** (= _m2 < _m10、 lexicographic だと _m10 < _m2 で
+            //  10+ overlay 時に多段 tape stage 順が壊れる、 Codex review 指摘)。
+            // regex group 1 (= _m の後の digit 列) を int parse して OrderBy。
             var overlayAsms = Directory.GetFiles(outputDir, prefix + "._m*.ASM")
-                                       .Where(p => overlayPattern.IsMatch(Path.GetFileName(p)))
-                                       .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+                                       .Select(p => new { Path = p, Match = overlayPattern.Match(Path.GetFileName(p)) })
+                                       .Where(x => x.Match.Success)
+                                       .OrderBy(x => int.Parse(x.Match.Groups[1].Value))
+                                       .Select(x => x.Path)
                                        .ToList();
             foreach (var p in overlayAsms) intermediates.Add(p);
 

--- a/src/SLANGCompiler.Build/Driver.cs
+++ b/src/SLANGCompiler.Build/Driver.cs
@@ -399,23 +399,51 @@ public class Driver
                 if (diskRc != 0) return diskRc;
             }
 
-            // === Step 4 (Phase B): --emit tape → X1 .tap (+ optional .wav) 組み立て ===
+            // === Step 4 (Phase B+): --emit tape → X1 .tap (+ optional .wav) 組み立て ===
+            //  + 多段 tape (= #MODULE overlay の自動連結) 対応
             if (_opts.EmitMode == "tape")
             {
-                // overlay 検出時は reject (= MVP scope 外、 silent に main だけ tape 化
-                //  すると事故るため明示)。 X1 tape = 1 binary per tape spec、
-                //  multi-overlay tape 対応は別 PR で検討。
+                var binBytes = File.ReadAllBytes(mainBin);
+                var mainCfg = TapeImageBuilder.MergeTapeConfig(envConfig, _opts, outputBase);
+
+                // overlay 検出時: 各 overlay を tape stage として収集
+                // (= overlay ASM 冒頭 `ORG $XXXX` (CodeGenerator.cs L143 出力) を
+                //  regex parse して overlay load addr 取得、 各 overlay bin を
+                //  tape stages list 化 → TapeImageBuilder で連結 .tap 生成)
+                List<(byte[] bin, TapeImageBuilder.ResolvedTapeConfig cfg)>? additionalStages = null;
                 if (renamedOverlayBins.Count > 0)
                 {
-                    Console.Error.WriteLine(
-                        $"slangbuild: --emit tape with overlay (got {renamedOverlayBins.Count} overlay) " +
-                        "is not supported (= X1 tape は 1 binary per tape 仕様、 multi-overlay tape は未対応)");
-                    return 1;
+                    additionalStages = new();
+                    var orgRegex = new System.Text.RegularExpressions.Regex(
+                        @"^\s*ORG\s+\$([0-9A-Fa-f]+)\b",
+                        System.Text.RegularExpressions.RegexOptions.Multiline);
+                    for (int i = 0; i < renamedOverlayBins.Count; i++)
+                    {
+                        var overlayAsmText = File.ReadAllText(overlayAsms[i]);
+                        var orgMatch = orgRegex.Match(overlayAsmText);
+                        if (!orgMatch.Success)
+                        {
+                            Console.Error.WriteLine(
+                                $"slangbuild: overlay {i} ASM の冒頭 `ORG $XXXX` parse 失敗 " +
+                                $"(file: {overlayAsms[i]})、 多段 tape 連結不能");
+                            return 1;
+                        }
+                        var orgAddr = Convert.ToInt32(orgMatch.Groups[1].Value, 16);
+                        var bytes = File.ReadAllBytes(renamedOverlayBins[i]);
+                        // overlay stage の exec addr は header 上 formality (= load と同値書込)、
+                        // MTREAD は次 block の data を読むだけで exec は使わない (= docs 明記)。
+                        var overlayCfg = new TapeImageBuilder.ResolvedTapeConfig(
+                            Name: $"M{i}",
+                            Load: orgAddr,
+                            Exec: orgAddr,
+                            WavSampleRate: mainCfg.WavSampleRate,
+                            WavBits: mainCfg.WavBits);
+                        additionalStages.Add((bytes, overlayCfg));
+                    }
                 }
-                var binBytes = File.ReadAllBytes(mainBin);
-                var tapeCfg = TapeImageBuilder.MergeTapeConfig(envConfig, _opts, outputBase);
+
                 int tapeRc = new TapeImageBuilder().Build(
-                    binBytes, tapeCfg, outputBase, _opts.EmitWav, _opts.Verbose);
+                    binBytes, mainCfg, additionalStages, outputBase, _opts.EmitWav, _opts.Verbose);
                 if (tapeRc != 0) return tapeRc;
             }
 

--- a/src/SLANGCompiler.Build/TapeFormats/X1Program.cs
+++ b/src/SLANGCompiler.Build/TapeFormats/X1Program.cs
@@ -138,4 +138,141 @@ public sealed class X1Program
         };
         return new TapFile(header, samples);
     }
+
+    /// <summary>
+    /// 複数 X1Program を 1 TapFile に連結 encode (= 多段 tape load 対応)。
+    /// 全段で標準 sync 仕様 (= info 40/41 leader 8000、 data 20/21 leader 4000) を維持
+    /// (= Codex 指摘反映、 短い inter-stage gap で sync 見失い回避)。
+    /// 用途: SLANG #MODULE overlay → main + overlay._mN.bin を 1 .tap 自動連結。
+    /// </summary>
+    public static TapFile ConcatenatePrograms(
+        List<X1Program> programs, uint sampleRate = 8000, string? tapeName = null)
+    {
+        if (programs == null || programs.Count == 0)
+            throw new ArgumentException("programs list must contain at least one X1Program");
+
+        var bits = new List<byte>();
+        foreach (var program in programs)
+        {
+            // Keep info DataSize in sync with payload (= 各段独立 checksum + size)
+            program.Info.DataSize = (ushort)program.Data.Length;
+
+            var infoBytes = program.Info.ToBytes();   // 32 byte
+            ushort infoCk = X1TapeFraming.ComputeChecksum(infoBytes);
+            var infoWithCk = new byte[X1TapeFraming.InfoBlockTotalSize];
+            infoBytes.CopyTo(infoWithCk, 0);
+            BinaryPrimitives.WriteUInt16BigEndian(
+                infoWithCk.AsSpan(X1InfoBlock.FieldsSize), infoCk);
+
+            ushort dataCk = X1TapeFraming.ComputeChecksum(program.Data);
+            var dataWithCk = new byte[program.Data.Length + X1TapeFraming.ChecksumSize];
+            program.Data.CopyTo(dataWithCk, 0);
+            BinaryPrimitives.WriteUInt16BigEndian(
+                dataWithCk.AsSpan(program.Data.Length), dataCk);
+
+            // 各段 標準 sync 仕様で emit (= 全段同じ leader / sync 数、 inter-stage
+            // gap も 1 段目 と同 標準で実機 IPL の tolerance 範囲内)
+            bits.AddRange(X1TapeFraming.BuildSync(
+                X1TapeFraming.DefaultInfoLeaderOnes,    // = 8000
+                X1TapeFraming.InfoBlockSyncZeros,        // = 40
+                X1TapeFraming.InfoBlockSyncOnes));       // = 41
+            bits.AddRange(X1TapeFraming.WriteBytes(infoWithCk));
+
+            bits.AddRange(X1TapeFraming.BuildSync(
+                X1TapeFraming.DefaultDataLeaderOnes,    // = 4000
+                X1TapeFraming.DataBlockSyncZeros,        // = 20
+                X1TapeFraming.DataBlockSyncOnes));       // = 21
+            bits.AddRange(X1TapeFraming.WriteBytes(dataWithCk));
+        }
+
+        // trailing silence (= 全段共通、 tape stop 余裕)
+        for (int i = 0; i < 1000; i++) bits.Add(1);
+
+        var bitArr = bits.ToArray();
+        var samples = X1FskCodec.Modulate(bitArr, sampleRate);
+        var header = new TapHeader
+        {
+            Name = tapeName ?? "auto converted (multi-stage)",
+            WriteProtect = TapHeader.ProtectionWriteProtected,
+            Format = TapHeader.FormatSampling,
+            SampleRate = sampleRate,
+            DataSizeBits = (uint)samples.Length,
+            PositionBits = 0,
+        };
+        return new TapFile(header, samples);
+    }
+
+    /// <summary>
+    /// TapFile 内の 全 X1Program を順次 decode (= test 用、 ConcatenatePrograms 逆操作)。
+    /// 既存 Decode は first only、 多段 .tap roundtrip 検証では本 method を使う。
+    /// 各 program decode 失敗 (= 次 sync 見つからない) で break、 それまで取れた list 返却。
+    /// </summary>
+    public static List<X1Program> DecodeAll(TapFile tap)
+    {
+        var bits = X1FskCodec.Demodulate(tap.Samples, tap.Header.SampleRate);
+        var result = new List<X1Program>();
+        int pos = 0;
+        while (pos < bits.Length)
+        {
+            X1Program? program;
+            try
+            {
+                program = TryDecodeFromBits(bits, ref pos);
+            }
+            catch (InvalidDataException)
+            {
+                break;  // 次 sync 見つからない or block 不完全 = 終端
+            }
+            if (program == null) break;
+            result.Add(program);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// bits[pos..] から 1 X1Program decode、 pos を消費分進める (= DecodeAll 内部用)。
+    /// 既存 DecodeFromBits を base に、 position 追跡 + null 返却で終端通知する版。
+    /// </summary>
+    private static X1Program? TryDecodeFromBits(byte[] bits, ref int pos)
+    {
+        var infoSync = X1TapeFraming.FindNextSync(
+            bits, pos,
+            X1TapeFraming.InfoBlockMinSyncZeros,
+            X1TapeFraming.InfoBlockSyncOnes);
+        if (infoSync is null) return null;
+
+        var infoRaw = X1TapeFraming.ReadBytes(
+            bits, infoSync.DataStartIndex,
+            X1InfoBlock.FieldsSize + X1TapeFraming.ChecksumSize, out var afterInfo);
+        var info = X1InfoBlock.FromBytes(infoRaw.AsSpan(0, X1InfoBlock.FieldsSize));
+        ushort infoCkExpected = BinaryPrimitives.ReadUInt16BigEndian(
+            infoRaw.AsSpan(X1InfoBlock.FieldsSize, X1TapeFraming.ChecksumSize));
+        ushort infoCkActual = X1TapeFraming.ComputeChecksum(
+            infoRaw.AsSpan(0, X1InfoBlock.FieldsSize));
+        bool infoOk = infoCkExpected == infoCkActual;
+
+        var dataSync = X1TapeFraming.FindNextSync(
+            bits, afterInfo,
+            X1TapeFraming.DataBlockSyncZeros,
+            X1TapeFraming.DataBlockSyncOnes);
+        if (dataSync is null) return null;
+
+        int dataLen = info.DataSize;
+        var dataRaw = X1TapeFraming.ReadBytes(
+            bits, dataSync.DataStartIndex,
+            dataLen + X1TapeFraming.ChecksumSize, out var afterData);
+        ushort dataCkExpected = BinaryPrimitives.ReadUInt16BigEndian(
+            dataRaw.AsSpan(dataLen, 2));
+        ushort dataCkActual = X1TapeFraming.ComputeChecksum(dataRaw.AsSpan(0, dataLen));
+        bool dataOk = dataCkExpected == dataCkActual;
+
+        pos = afterData;  // 次 program decode 用に位置進める
+        return new X1Program
+        {
+            Info = info,
+            Data = dataRaw.AsSpan(0, dataLen).ToArray(),
+            InfoChecksumOk = infoOk,
+            DataChecksumOk = dataOk,
+        };
+    }
 }

--- a/src/SLANGCompiler.Build/TapeImageBuilder.cs
+++ b/src/SLANGCompiler.Build/TapeImageBuilder.cs
@@ -40,62 +40,144 @@ public class TapeImageBuilder
     }
 
     /// <summary>
-    /// .bin → .tap (+ optional .wav) 生成。 成功時 0、 失敗時 1+ (stderr に message)。
-    /// Driver からのみ呼ばれる (= public 不要、 ResolvedTapeConfig が internal なので
-    /// Build も internal に揃える)。
+    /// 1 stage .bin → .tap (+ optional .wav) 生成の overload (= 既存 caller 互換、 test 互換)。
+    /// 多段 tape は新 signature (= additionalStages 引数あり) を使う。
     /// </summary>
     internal int Build(byte[] binData, ResolvedTapeConfig cfg, string outputBase,
                        bool emitWav, bool verbose)
+        => Build(binData, cfg, null, outputBase, emitWav, verbose);
+
+    /// <summary>
+    /// .bin → .tap (+ optional .wav) 生成。 成功時 0、 失敗時 1+ (stderr に message)。
+    /// additionalStages != null + Count > 0 で多段 tape (= main + overlay stages 連結) 生成。
+    /// Driver からのみ呼ばれる (= public 不要、 ResolvedTapeConfig が internal なので
+    /// Build も internal に揃える)。
+    /// </summary>
+    internal int Build(byte[] mainBin, ResolvedTapeConfig mainCfg,
+                       List<(byte[] bin, ResolvedTapeConfig cfg)>? additionalStages,
+                       string outputBase, bool emitWav, bool verbose)
     {
-        // === Validation: silent truncate / wrong-output を完全排除 ===
+        // === main stage validation (= silent truncate / wrong-output を完全排除) ===
+        var rc = ValidateStage(mainBin, mainCfg, "main");
+        if (rc != 0) return rc;
+
+        // === additional stages (= overlay) validation ===
+        if (additionalStages != null)
+        {
+            for (int i = 0; i < additionalStages.Count; i++)
+            {
+                rc = ValidateStage(additionalStages[i].bin, additionalStages[i].cfg, $"overlay[{i}]");
+                if (rc != 0) return rc;
+            }
+        }
+
+        // X1Program 群 構築 (= validation 後なので ushort cast 安全)
+        var programs = new List<X1Program> { BuildX1Program(mainBin, mainCfg) };
+        if (additionalStages != null)
+        {
+            foreach (var (bin, cfg) in additionalStages)
+                programs.Add(BuildX1Program(bin, cfg));
+        }
+
+        // tape header name (= TapHeader.Name 17 char) は main cfg.Name と同じ ToUpper
+        var tapeName = mainCfg.Name.ToUpperInvariant();
+
+        // .tap (sampleRate 8000 で encode、 多段なら ConcatenatePrograms で連結)
+        var tap8k = programs.Count == 1
+            ? programs[0].Encode(sampleRate: 8000, tapeName: tapeName)
+            : X1Program.ConcatenatePrograms(programs, sampleRate: 8000, tapeName: tapeName);
+        tap8k.Save(outputBase + ".tap");
+
+        // optional .wav (= main sample rate / bits)
+        if (emitWav)
+        {
+            var tapForWav = programs.Count == 1
+                ? programs[0].Encode(sampleRate: (uint)mainCfg.WavSampleRate, tapeName: tapeName)
+                : X1Program.ConcatenatePrograms(programs, sampleRate: (uint)mainCfg.WavSampleRate, tapeName: tapeName);
+            WavWriter.WriteFromTap(
+                outputBase + ".wav", tapForWav,
+                targetSampleRate: (uint)mainCfg.WavSampleRate,
+                bitsPerSample: mainCfg.WavBits,
+                amplitude: 0.8);
+        }
+        if (verbose)
+        {
+            Console.WriteLine(
+                $"  generated: {outputBase}.tap" + (emitWav ? $" + {outputBase}.wav" : ""));
+            Console.WriteLine(
+                $"    main stage: name={tapeName}, load=${mainCfg.Load:X4}, exec=${mainCfg.Exec:X4}");
+            if (additionalStages != null)
+            {
+                for (int i = 0; i < additionalStages.Count; i++)
+                {
+                    var s = additionalStages[i];
+                    Console.WriteLine(
+                        $"    overlay[{i}]: name={s.cfg.Name}, load=${s.cfg.Load:X4}, size={s.bin.Length}");
+                }
+            }
+        }
+        return 0;
+    }
+
+    /// <summary>
+    /// 1 stage 分 validation (= main / overlay 共通)。 失敗時 stderr + 非 0 return。
+    /// </summary>
+    private static int ValidateStage(byte[] binData, ResolvedTapeConfig cfg, string label)
+    {
         if (binData.Length == 0)
         {
-            Console.Error.WriteLine("slangbuild: empty bin (0 byte) cannot be tape-encoded");
+            Console.Error.WriteLine($"slangbuild: {label} empty bin (0 byte) cannot be tape-encoded");
             return 1;
         }
         if (binData.Length > 0xFFFF)
         {
             Console.Error.WriteLine(
-                $"slangbuild: bin size {binData.Length} byte exceeds X1 tape limit (= 65535 byte)");
+                $"slangbuild: {label} bin size {binData.Length} byte exceeds X1 tape limit (= 65535 byte)");
             return 1;
         }
         if (cfg.Load < 0 || cfg.Load > 0xFFFF)
         {
-            Console.Error.WriteLine($"slangbuild: tape.load ${cfg.Load:X} out of 16-bit range");
+            Console.Error.WriteLine($"slangbuild: {label} tape.load ${cfg.Load:X} out of 16-bit range");
             return 1;
         }
         if (cfg.Exec < 0 || cfg.Exec > 0xFFFF)
         {
-            Console.Error.WriteLine($"slangbuild: tape.exec ${cfg.Exec:X} out of 16-bit range");
+            Console.Error.WriteLine($"slangbuild: {label} tape.exec ${cfg.Exec:X} out of 16-bit range");
             return 1;
         }
         if (cfg.Load + binData.Length - 1 > 0xFFFF)
         {
             Console.Error.WriteLine(
-                $"slangbuild: load ${cfg.Load:X4} + size {binData.Length} overflows 16-bit memory");
+                $"slangbuild: {label} load ${cfg.Load:X4} + size {binData.Length} overflows 16-bit memory");
             return 1;
         }
         if (cfg.WavBits != 8 && cfg.WavBits != 16)
         {
-            Console.Error.WriteLine($"slangbuild: wav_bits must be 8 or 16 (got {cfg.WavBits})");
+            Console.Error.WriteLine($"slangbuild: {label} wav_bits must be 8 or 16 (got {cfg.WavBits})");
             return 1;
         }
         if (cfg.WavSampleRate <= 0)
         {
             Console.Error.WriteLine(
-                $"slangbuild: wav_sample_rate must be > 0 (got {cfg.WavSampleRate})");
+                $"slangbuild: {label} wav_sample_rate must be > 0 (got {cfg.WavSampleRate})");
             return 1;
         }
         if (!IsValidX1FileName(cfg.Name))
         {
             Console.Error.WriteLine(
-                $"slangbuild: tape name `{cfg.Name}` invalid " +
+                $"slangbuild: {label} tape name `{cfg.Name}` invalid " +
                 "(= ASCII printable 0x20-0x7E + 1..13 char、 silent truncate しない仕様)");
             return 1;
         }
+        return 0;
+    }
 
-        // X1Program 構築 (= validation 後なので ushort cast 安全)
-        var program = new X1Program
+    /// <summary>
+    /// 1 stage 分 X1Program 構築。 validation 後なので ushort cast 安全。
+    /// </summary>
+    private static X1Program BuildX1Program(byte[] binData, ResolvedTapeConfig cfg)
+    {
+        return new X1Program
         {
             Data = binData,
             Info = new X1InfoBlock
@@ -109,34 +191,6 @@ public class TapeImageBuilder
                 ExecuteAddress = (ushort)cfg.Exec,
             },
         };
-
-        // tape header name (= TapHeader.Name 17 char) は cfg.Name と同じ ToUpper、
-        // padding は tapcnv 側で処理 (= SLANG 側で truncate しない)。
-        var tapeName = cfg.Name.ToUpperInvariant();
-
-        // .tap (sampleRate 8000 で encode、 tapeName 引数を必ず渡す)
-        var tap8k = program.Encode(sampleRate: 8000, tapeName: tapeName);
-        tap8k.Save(outputBase + ".tap");
-
-        // optional .wav (tapeName 同一、 sample rate / bits は cfg)
-        if (emitWav)
-        {
-            var tapForWav = program.Encode(
-                sampleRate: (uint)cfg.WavSampleRate, tapeName: tapeName);
-            WavWriter.WriteFromTap(
-                outputBase + ".wav", tapForWav,
-                targetSampleRate: (uint)cfg.WavSampleRate,
-                bitsPerSample: cfg.WavBits,
-                amplitude: 0.8);
-        }
-        if (verbose)
-        {
-            Console.WriteLine(
-                $"  generated: {outputBase}.tap" + (emitWav ? $" + {outputBase}.wav" : ""));
-            Console.WriteLine(
-                $"    tape name: {tapeName}, load: ${cfg.Load:X4}, exec: ${cfg.Exec:X4}");
-        }
-        return 0;
     }
 
     /// <summary>

--- a/tests/SLANGCompiler.Tests/TapConvCoreRoundtripTests.cs
+++ b/tests/SLANGCompiler.Tests/TapConvCoreRoundtripTests.cs
@@ -79,6 +79,86 @@ public class TapConvCoreRoundtripTests
     }
 
     [Fact]
+    public void X1Program_ConcatenatePrograms_Roundtrip()
+    {
+        // 多段 tape の bit-exact roundtrip: 2 段 encode → DecodeAll で各段独立復元
+        var bin1 = new byte[8];
+        for (int i = 0; i < bin1.Length; i++) bin1[i] = (byte)(i + 10);
+        var bin2 = new byte[12];
+        for (int i = 0; i < bin2.Length; i++) bin2[i] = (byte)(i ^ 0x33);
+
+        var prog1 = new X1Program
+        {
+            Data = bin1,
+            Info = new X1InfoBlock
+            {
+                BootFlag = 0x01,
+                FileName = "STAGE1".PadRight(13),
+                Extension = "BIN",
+                Password = 0x20,
+                DataSize = (ushort)bin1.Length,
+                LoadAddress = 0x1000,
+                ExecuteAddress = 0x1000,
+            },
+        };
+        var prog2 = new X1Program
+        {
+            Data = bin2,
+            Info = new X1InfoBlock
+            {
+                BootFlag = 0x01,
+                FileName = "M0".PadRight(13),
+                Extension = "BIN",
+                Password = 0x20,
+                DataSize = (ushort)bin2.Length,
+                LoadAddress = 0x4000,
+                ExecuteAddress = 0x4000,
+            },
+        };
+
+        var tap = X1Program.ConcatenatePrograms(
+            new List<X1Program> { prog1, prog2 }, sampleRate: 8000, tapeName: "MULTI");
+        var decoded = X1Program.DecodeAll(tap);
+
+        Assert.Equal(2, decoded.Count);
+        Assert.Equal(bin1.Length, decoded[0].Data.Length);
+        Assert.Equal(bin2.Length, decoded[1].Data.Length);
+        for (int i = 0; i < bin1.Length; i++)
+            Assert.Equal(bin1[i], decoded[0].Data[i]);
+        for (int i = 0; i < bin2.Length; i++)
+            Assert.Equal(bin2[i], decoded[1].Data[i]);
+        Assert.Equal(0x1000, decoded[0].Info.LoadAddress);
+        Assert.Equal(0x4000, decoded[1].Info.LoadAddress);
+    }
+
+    [Fact]
+    public void X1Program_ConcatenatePrograms_StandardSyncOrder()
+    {
+        // 各段で標準 sync 仕様 (= info 40/41 leader 8000、 data 20/21 leader 4000) 維持
+        // (= Codex 指摘反映、 短い inter-stage gap で sync 見失い回避)。
+        // bit-stream を再 demodulate して 各段 sync が見つかる確認。
+        var prog = new X1Program
+        {
+            Data = new byte[16],
+            Info = new X1InfoBlock
+            {
+                BootFlag = 0x01,
+                FileName = "T".PadRight(13),
+                Extension = "BIN",
+                Password = 0x20,
+                DataSize = 16,
+                LoadAddress = 0x2000,
+                ExecuteAddress = 0x2000,
+            },
+        };
+        var tap = X1Program.ConcatenatePrograms(
+            new List<X1Program> { prog, prog, prog }, sampleRate: 8000, tapeName: "T");
+        // 3 段全部 decode 成功 = 各段 sync が標準 仕様で取れてる
+        var decoded = X1Program.DecodeAll(tap);
+        Assert.Equal(3, decoded.Count);
+    }
+
+    [Fact]
     public void WavWriter_RiffHeader_Valid()
     {
         var bin = new byte[10];

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -498,7 +498,8 @@ public class X1NativeEnvTests
     public void MtreadSmpSample_BuildsSuccessfully()
     {
         // 多段 tape sample (= #MODULE overlay 含む) が `--emit tape` で build 成功
-        // (= overlay reject 撤廃 + ORG parse + ConcatenatePrograms 経路の smoke)
+        // + 多段 .tap として正しく連結されてる pin (= overlay silent 抜けの再発防止、
+        //  Codex review Low 指摘反映で TapFile.Load + DecodeAll で stage 構造 assert)
         var repoRoot = RepoRoot();
         var sample = Path.Combine(repoRoot, "examples", "X1NATIVE_MTREAD", "MTREADSMP.SL");
         var include = Path.Combine(repoRoot, "include");
@@ -510,9 +511,20 @@ public class X1NativeEnvTests
             Assert.True(rc == 0,
                 $"MTREADSMP build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
             Assert.True(File.Exists(output + ".tap"), "MTREADSMP.tap not generated");
-            // 多段 .tap であることの粗 check: tap size > 単独 .tap の通常 size
-            var info = new FileInfo(output + ".tap");
-            Assert.True(info.Length > 10000, $"multi-stage .tap should be > 10000 byte (got {info.Length})");
+
+            // 多段 .tap 構造 assert: TapFile.Load + DecodeAll で stage 2 件 + 各 stage
+            // load addr / data size 確認 (= overlay 抜け / 順序壊れ / addr 取り違え 検知)
+            var tap = SLANGCompiler.Build.TapeFormats.TapFile.Load(output + ".tap");
+            var programs = SLANGCompiler.Build.TapeFormats.X1Program.DecodeAll(tap);
+            Assert.Equal(2, programs.Count);
+            // stage 0 (= main): load = $1000 (= x1native default_org)
+            Assert.Equal(0x1000, programs[0].Info.LoadAddress);
+            Assert.True(programs[0].Data.Length > 100,
+                $"stage 0 (main) data size too small (= {programs[0].Data.Length})");
+            // stage 1 (= overlay._m0): load = $4000 (= #MODULE $4000 RESIDENT で指定)
+            Assert.Equal(0x4000, programs[1].Info.LoadAddress);
+            Assert.True(programs[1].Data.Length > 0,
+                $"stage 1 (overlay) data size = 0、 overlay 抜け 疑い");
         }
         finally
         {

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -438,6 +438,92 @@ public class X1NativeEnvTests
         Assert.DoesNotMatch(@"\bOR\s+038H\b", body);
     }
 
+    // === 多段 tape ロード関連 (= MTREAD/MTREADJP + #MODULE overlay → 自動連結) ===
+
+    [Fact]
+    public void X1NativeEnv_RegistersTapeLibrary()
+    {
+        // x1native env libraries に libx1native_tape.asm 含む
+        var config = EnvironmentLoader.Load(EnvFilePath());
+        Assert.Contains("libx1native_tape.asm", config.Libraries);
+    }
+
+    [Theory]
+    [InlineData("MTREAD")]        // 多段 read 主 API (= 引数 HL 優先で load)
+    [InlineData("MTREADJP")]      // raw stage 用 (= load + JP)
+    [InlineData("MT_CTRL_PLAY")]  // sub CPU 経由 deck PLAY
+    [InlineData("MT_CTRL_STOP")]  // sub CPU 経由 deck STOP
+    [InlineData("MT_CTRL")]       // sub CPU command sender (= 汎用)
+    public void Libx1NativeTape_DefinesRoutine(string name)
+    {
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_tape.asm"));
+        Assert.Contains($"; @name {name}", content);
+    }
+
+    [Fact]
+    public void Libx1NativeTape_HasIff2GuardInMtread()
+    {
+        // MTREAD entry で IFF2 復元 guard が `LD A, I` 直後 `DI` の順 (= Codex 指摘
+        // の DI 先順、 flags 維持 + 割り込み window 短縮)。 pin: MTREAD routine
+        // 区間内に `LD A, I` 直後 (= 次行 / 空行除く) `DI` 続くパターン。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_tape.asm"));
+        var match = Regex.Match(content,
+            @"; @name MTREAD\b(.*?)(?=; @name |\z)",
+            RegexOptions.Singleline);
+        Assert.True(match.Success, "MTREAD routine 区間が見つからない");
+        var body = match.Groups[1].Value;
+        Assert.Matches(@"LD A, I\s*\r?\n\s*DI\b", body);
+    }
+
+    [Fact]
+    public void OverlayAsm_OrgPrefixFormat()
+    {
+        // builder の overlay load addr regex parse (= Driver.cs) が依存する
+        // 前提: overlay ASM 冒頭近くに `^\s*ORG\s+\$XXXX` 行が出る
+        // (= CodeGenerator.cs L143 出力)。 既存 SLANG sample (= MODTEST.SL)
+        // を build した overlay ASM (or runtime asm 内 ORG 文字列) で format 維持確認。
+        // ここでは static asm grep で SLANG asm 内 `ORG $XXXX` の form 維持を緩く pin。
+        var content = File.ReadAllText(RuntimeAsmPath("libx1native_base.asm"));
+        // libx1native_base 内に CRTC PARM table 等で `$XXXX` 形式の hex literal が出る、
+        // ただ ORG 文字列 自体は overlay ASM 側 (= 動的生成)。 format pin は
+        // CodeGenerator.cs L143 の format spec 直接 grep で代替 (= source pin)。
+        var srcContent = File.ReadAllText(Path.Combine(
+            new DirectoryInfo(AppContext.BaseDirectory).Parent!.Parent!.Parent!.Parent!.Parent!.FullName,
+            "src", "SLANGCompiler.Core", "CodeGen", "CodeGenerator.cs"));
+        // L143 付近の `Instruction("ORG", $"${...:X4}")` pattern を pin
+        Assert.Matches(@"Instruction\(""ORG"",\s*\$""\$\{overlay\.OrgAddress:X4\}""\)", srcContent);
+    }
+
+    [Fact]
+    public void MtreadSmpSample_BuildsSuccessfully()
+    {
+        // 多段 tape sample (= #MODULE overlay 含む) が `--emit tape` で build 成功
+        // (= overlay reject 撤廃 + ORG parse + ConcatenatePrograms 経路の smoke)
+        var repoRoot = RepoRoot();
+        var sample = Path.Combine(repoRoot, "examples", "X1NATIVE_MTREAD", "MTREADSMP.SL");
+        var include = Path.Combine(repoRoot, "include");
+        var output = Path.Combine(Path.GetTempPath(), $"MTREADSMP_test_{Guid.NewGuid():N}");
+        try
+        {
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{sample}\" -o \"{output}\" --emit tape");
+            Assert.True(rc == 0,
+                $"MTREADSMP build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.True(File.Exists(output + ".tap"), "MTREADSMP.tap not generated");
+            // 多段 .tap であることの粗 check: tap size > 単独 .tap の通常 size
+            var info = new FileInfo(output + ".tap");
+            Assert.True(info.Length > 10000, $"multi-stage .tap should be > 10000 byte (got {info.Length})");
+        }
+        finally
+        {
+            CleanupBuildArtifacts(output);
+            // overlay 関連 intermediate も cleanup
+            foreach (var ext in new[] { "._m0.ASM", "._m0.bin", "._m0.LST", "._m0.dummy.imports.asm",
+                                        ".dummy.imports.asm", ".ASM", ".inc", ".sym" })
+                if (File.Exists(output + ext)) File.Delete(output + ext);
+        }
+    }
+
     [Fact]
     public void Libmag_DoesNotDefineGrdispGrcls()
     {


### PR DESCRIPTION
## Summary

X1 慣習の **多段 tape load** を SLANG x1native runtime + slangbuild に統合。 SLANG `#MODULE $XXXX` で overlay 定義 → `slangbuild --emit tape` が `main.bin + overlay._mN.bin` を多段 .tap 自動連結 → 実行時 `MTREAD` で overlay 読込 + 関数呼出 (= prelink 解決)。 **X1 normal (互換 IPL) / X1turbo (純正 IPL) 両方で emulator 動作確認 OK** (= user 実機確認、 1 発動作)。

## 主な変更

### `runtime/libx1native_tape.asm` (新規、 ~400 byte)
- [X1_compatible_rom](https://github.com/meister68k/X1_compatible_rom) (Meister, CC0 1.0 Universal) の tape read + sub CPU deck control routine 群を fork:
  - tape bit-stream read: `MT_EDGE/RDBIT/RDBIT_D/SKIP1111/SKIP0/SKIP1/RDBYTE` (L1639-1819)
  - block load: `CMT_LOADIFB / CMT_LOADFILE` (L1440-1516)
  - sub CPU deck control: `MT_CTRL_PLAY / STOP / CTRL / WAIT_80C49_WR` (L1521-1574 + L1209-1216)
- SLANG public API:
  - `MTREAD(load_addr)`: 引数 HL 優先で次 block load (= info LoadAddress 無視)、 内部で `MT_CTRL_PLAY → read → MT_CTRL_STOP` 自動、 戻り `HL = data size` (or `$FFFF`)
  - `MTREADJP(load_addr, jp_addr)`: 上 + JP (= raw stage 用、 overlay 経由は `MTREAD + 関数呼出` 推奨)
- **IFF2 復元 guard**: `LD A, I; DI; PUSH AF` 順 (= Codex 指摘、 DI を `LD A,I` 直後で flags 維持 + 割り込み window 短縮)、 復元は `POP AF; JP PO, skip; EI`
- Helper 所属: MTREAD block に read core、 MT_CTRL block に sub CPU helpers (= 同 @name 内 ローカル label、 linker 落とし回避)
- CC0 → MIT 互換、 attribution は header comment

### `src/SLANGCompiler.Build/Driver.cs`
- `--emit tape with overlay` reject (L403-413) を **撤廃**
- overlay ASM 冒頭 `ORG $XXXX` (= `CodeGenerator.cs L143` 出力) regex parse で overlay load addr 取得 → tape stages list 構築
- overlay stage の **exec は formality** (= load と同値書込、 docs 明記、 MTREAD は exec 使わない)

### `src/SLANGCompiler.Build/TapeImageBuilder.cs`
- 多段 Build (= main + additionalStages) signature 追加
- 既存 5-arg overload 残置で test / 既存 caller 互換維持
- `ValidateStage` / `BuildX1Program` helper 抽出で main / overlay 共通 validation

### `src/SLANGCompiler.Build/TapeFormats/X1Program.cs`
- `ConcatenatePrograms(List)`: 多段 bit-stream 連結 + FSK modulate、 **全段標準 sync 仕様** (= info 40/41 leader 8000、 data 20/21 leader 4000) 維持 (= Codex 指摘で短い inter-stage gap で sync 見失い回避)
- `DecodeAll(TapFile)`: 多段 .tap 内 全 program 順次 decode (= test 用)

### `examples/X1NATIVE_MTREAD/MTREADSMP.SL` (新規)
`#MODULE $4000` overlay 経由の多段 sample。 注意: overlay 内では `PRINT` 等 sWORK 内 BSS sym (= `sXYADR` / `AT_WIDTH`) 参照 SLANG runtime call は使わない (= 既存 `#MODULE + x1native` 組合せで overlay EXTERN 宣言不足の **既存問題**、 本 PR scope 外で別 issue 対応予定)。 overlay は VAR 書込のみ、 表示は main 側で。

### `tests/SLANGCompiler.Tests/` (11 件追加)
- `X1Program_ConcatenatePrograms_Roundtrip` / `_StandardSyncOrder`
- `X1NativeEnv_RegistersTapeLibrary`
- `Libx1NativeTape_DefinesRoutine` [Theory MTREAD/MTREADJP/MT_CTRL_PLAY/STOP/CTRL]
- `Libx1NativeTape_HasIff2GuardInMtread`
- `OverlayAsm_OrgPrefixFormat`
- `MtreadSmpSample_BuildsSuccessfully` (= CLI spawn build smoke)

### `docs/X1.md`
- 「多段 tape ロード」 section 新規追加 (= SLANG API + #MODULE 経由 build 手順 + 注意点 + 既知制約 + 既存 1 binary 互換明記)
- 「1 binary per tape 制限」 文言 削除 (= 多段対応で解消)

## Test plan

- [x] `dotnet test` 全 **530 件 pass** (= 既存 519 + 新規 11)、 regression なし
- [x] `examples/X1NATIVE_MTREAD/MTREADSMP.SL` build 成功 (= main 1382 / overlay._m0 7 / .tap 17529 byte)
- [x] 既存 7 sample (HELLO/STARS/FMANDEL/FURUI/X1GRP/STARS_X1/X1SGL) build OK + bin size 同等 (= MTREAD 未呼出で selective link 対象外、 影響なし)
- [x] emulator 動作確認: **X1 normal (互換 IPL) / X1turbo (純正 IPL) 両方で多段動作 OK** (= user 実機確認、 1 発動作)

## 残課題 (= 本 PR scope 外、 後続)

- **overlay 内 sWORK BSS sym EXTERN 宣言問題** (= 既存問題、 overlay 内 PRINT 等が assemble fail、 別 issue で SLANG runtime planner 側 fix 予定)
- `--tape-add <path>` 外部 raw asset 追加 (= #MODULE 経由でない素 binary、 別 PR)
- `MTREADNAME(name, addr)` ファイル名指定ロード
- `--tape-gap-bits` configurable inter-stage gap
- load addr 範囲 runtime guard
- libmag / libm8a 系 file IO 統合
- X1turbo 高解像 mode (`_C8025H` 系)
- v0.24.2 リリース準備 (= PR #203-#208 まとめ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)