### PR TITLE
Fix Issue #209: Local mode overlay の sWORK BSS sym EXTERN + _CRTCD 共有 fix

### DIFF
--- a/docs/X1.md
+++ b/docs/X1.md
@@ -175,11 +175,19 @@ X1 慣習で多段 tape 運用が可能 (= loader が後続 block を任意 addr
 
 SLANG の `#MODULE $XXXX [RESIDENT] ~ #END` で overlay 定義すると、 `slangbuild --emit tape` が `main.bin + overlay._mN.bin` を自動的に多段 .tap に連結。 各 overlay の load addr は `#MODULE` 指定値 (= ORG 整合は overlay 機構 auto)、 各段 標準 sync 仕様 (= info 40/41 leader 8000、 data 20/21 leader 4000) で emit。
 
-#### `RESIDENT` 指定推奨
+#### `RESIDENT` mode (= 推奨、 overlay 縮小)
 
 `#MODULE $XXXX RESIDENT` で **RESIDENT mode** 指定すると、 overlay 内 runtime call (= `PRINT` 等) は main 側 shared runtime への EXTERN 参照に変換される (= shared promotion)。 overlay binary 大幅縮小 (= 例: 248 byte → 36 byte、 -85%) + overlay 内で SLANG runtime 全部使える。
 
-`RESIDENT` 指定なし (= Local default) だと overlay 内に runtime routine が複製され、 さらに sWORK 内 BSS sym (= `sXYADR` / `AT_WIDTH` 等) の EXTERN 宣言不足で assemble fail する (= 既存 #MODULE + x1native の組合せ問題)。 多段 tape では **必ず RESIDENT 指定** を推奨。
+#### Local mode (= RESIDENT 指定なし、 default)
+
+`#MODULE $XXXX` (= RESIDENT 省略) では overlay 内に runtime routine が **local copy** される (= 各 overlay が独立 runtime 持つ)。 runtime work sym (= `sXYADR` / `AT_WIDTH` 等) は main 側 sWORK を **EXTERN 参照** (= main work area 共有、 Issue #209 fix で対応)。 overlay binary は RESIDENT mode より大きい (= 例: 36 → 517 byte) が、 通常の overlay 運用 (= main work area 共有) で動作する。
+
+両 mode とも overlay 内で `PRINT` 等 SLANG runtime call が使える。 sample 例:
+- RESIDENT mode: `examples/X1NATIVE_MTREAD/MTREADSMP.SL` (= overlay 36 byte、 推奨)
+- Local mode: `examples/X1NATIVE_MTREAD/MTREADSMP_LOCAL.SL` (= overlay 517 byte、 self-contained 寄り)
+
+注意: **self-contained overlay (= main work area 完全上書き、 overlay 単独動作)** は本 PR scope 外 (= 別 Issue で検討)。
 
 例 (= `examples/X1NATIVE_MTREAD/MTREADSMP.SL`):
 ```sl

--- a/examples/X1NATIVE_MTREAD/MTREADSMP_LOCAL.SL
+++ b/examples/X1NATIVE_MTREAD/MTREADSMP_LOCAL.SL
@@ -1,0 +1,43 @@
+// X1 多段 tape ロード sample (= #MODULE Local mode、 RESIDENT 指定なし)
+//
+// build: slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP_LOCAL.SL \
+//        -o /tmp/MTREADSMP_LOCAL --emit tape
+//
+// Local mode (= #MODULE $4000、 RESIDENT 省略) では overlay 内に runtime
+// routine が **local copy** される。 runtime work sym (sXYADR / AT_WIDTH 等)
+// は main 側 sWORK を EXTERN 参照 (= main work area 共有前提、 Issue #209 fix
+// で対応)。 overlay binary は RESIDENT mode より大きい (= runtime routine 全
+// コピー) が、 通常の overlay 運用で動作する。
+//
+// 注: overlay 単独動作 (= main work area 完全上書き、 self-contained mode)
+//     は本 PR scope 外 (= 別 Issue 対応予定)。
+
+VAR OVERLAY_RESULT;
+
+#MODULE $4000
+
+// overlay 内 関数 (= Local mode で local copy された runtime 経由)。
+// PRINT 等 SLANG runtime call も使える (= main 側 sWORK BSS sym を EXTERN
+// 参照、 Issue #209 fix で動作可能になった)。
+overlay_entry()
+BEGIN
+    PRINT("STAGE2 OVERLAY LOADED (LOCAL MODE)!");
+    PRINT(/);
+    OVERLAY_RESULT = 42;
+END;
+
+#END
+
+MAIN()
+BEGIN
+    PRINT("STAGE1: LOADING OVERLAY (LOCAL MODE)...");
+    PRINT(/);
+    OVERLAY_RESULT = 0;
+    MTREAD($4000);
+    overlay_entry();    // prelink が CALL 解決 (= 既存 #MODULE 機構)
+    PRINT("STAGE2 RESULT = ");
+    PRINT(%(OVERLAY_RESULT));
+    PRINT(/);
+    PRINT("PRESS ANY KEY...");
+    INKEY(1);
+END;

--- a/runtime/libx1native_base.asm
+++ b/runtime/libx1native_base.asm
@@ -115,7 +115,7 @@ JR .stop_halt
 
 ; @name INIT_CRTC
 ; @resident shared
-; @calls _CRTCD
+; @calls X1CRT_WORK
 ; CRTC 80 mode / 40 mode 切替 + 画面 mode 設定。
 ; HL = source PARM table (= _C8025L / _C4025L 等、 16 byte)、 _CRTCD work area
 ; に LDIR copy してから CRTC R0-R11 を $1800/$1801 経由 OUT + 8255 port C
@@ -147,7 +147,7 @@ RET
 
 ; @name AT_VRCALC
 ; @resident shared
-; @calls _CRTCD
+; @calls X1CRT_WORK
 ; H = Y、 L = X 入力 → HL = Y * width + X 出力 (= text VRAM 内 offset)。
 ; width は _CRTCD の R1 (byte 1) から動的取得 (= WIDTH() 切替に追従)。
 ; Russian peasant 乗算 (8 回 ADD HL,HL + carry 時 ADD DE)、 libx1_print fork。
@@ -219,14 +219,20 @@ POP AF
 RET
 
 
-; @name _CRTCD
+; @name X1CRT_WORK
 ; @resident shared
-; CRTC 設定 work area (= 16 byte、 INIT_CRTC で current PARM table を LDIR copy)。
-; layout: byte 0-11 = R0-R11 (CRTC reg)、 byte 12-13 = LSX 内部 cache 用 (OUT
-; しない)、 byte 14 = 8255 port C 値、 byte 15 = WK1FD0 値。
-; AT_VRCALC は byte 0-1 を WORD 読みして R1 (= width = byte 1) を取得する。
-; DS 16 で uninit、 SLANGINIT 内 INIT_CRTC で _C8025L から最初の copy が走る。
-DS 16
+; @param_count 0
+; @works _CRTCD:16
+; CRTC 設定 work area provider。 _CRTCD は INIT_CRTC で current PARM table を
+; LDIR copy する mutable shadow work (= 16 byte)。 layout: byte 0-11 = R0-R11
+; (CRTC reg)、 byte 12-13 = LSX 内部 cache 用 (OUT しない)、 byte 14 = 8255
+; port C 値、 byte 15 = WK1FD0 値。 AT_VRCALC は byte 0-1 を WORD 読みして
+; R1 (= width = byte 1) を取得する。
+;
+; @works 経由 main __WORK__ 内 BSS として確保 (= Local mode overlay からも
+; main 共有 EXTERN で参照、 SLANGINIT INIT_CRTC で init 済値を読める)。
+; 旧 `@name _CRTCD` DS 16 (= overlay 内 local copy で init 走らず壊滅) からの
+; refactor。
 
 
 ; @name _C8025L

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -42,7 +42,7 @@
 ; @name sPRINT
 ; @resident shared
 ; @param_count 0
-; @calls sWORK, AT_VRCALC
+; @calls sWORK, AT_VRCALC, clear_screen
 ; A = char code
 ; - $0D (CR): sp_do_cr (= X=0, Y++、 Y=25 で scroll_up)
 ; - $0B (HOME): cursor を 0,0 へ (画面 clear なし)

--- a/src/SLANGCompiler.Build/OverlayImportsBuilder.cs
+++ b/src/SLANGCompiler.Build/OverlayImportsBuilder.cs
@@ -22,6 +22,9 @@ public static class OverlayImportsBuilder
         "; === Shared Runtime References (resolved via two-stage assembly) ===",
         "; === Shared Symbols (from main) ===",
         "; === String references (from main) ===",
+        // Issue #209 fix: overlay local copy runtime function が参照する main 側
+        // sWORK BSS sym (sXYADR / AT_WIDTH 等) を EXTERN で列挙する section。
+        "; === Shared Work Labels (from main, for local copy runtime functions) ===",
     };
 
     // `; EXTERN <name>` または `; EXTERN <name>  ; <comment>`

--- a/src/SLANGCompiler.Build/PrelinkPlan.cs
+++ b/src/SLANGCompiler.Build/PrelinkPlan.cs
@@ -44,6 +44,10 @@ public class PrelinkPlan
         "; === Shared Runtime References (resolved via two-stage assembly) ===",
         "; === Shared Symbols (from main) ===",
         "; === String references (from main) ===",
+        // Issue #209 fix: overlay local copy runtime function が参照する main 側
+        // sWORK BSS sym (sXYADR / AT_WIDTH 等) を Pass 1 dummy imports でも認識
+        // するため (= 認識しないと Pass 1 overlay assemble で sym 未定義 fail)。
+        "; === Shared Work Labels (from main, for local copy runtime functions) ===",
     };
 
     /// <summary>

--- a/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
+++ b/src/SLANGCompiler.Core/CodeGen/CodeGenerator.cs
@@ -265,6 +265,28 @@ public class CodeGenerator
                 _e.Raw($"; EXTERN {label}");
         }
 
+        // Issue #209 fix: Shared Work Labels — overlay local copy runtime function が
+        // 参照する main 側 sWORK BSS sym (sXYADR / AT_WIDTH 等) を EXTERN 宣言する。
+        // EmitWorkArea で GetMainAllocatedWorksFunctions 経由で main __WORK__ に
+        // allocate + main.sym に EQU 出力 → ここで EXTERN 宣言 → 2 段アセンブル
+        // (OverlayImportsBuilder / PrelinkPlan) で main.sym 経由解決される。
+        // 既存 overlay.Works は OverlayModule に未定義のため O = ∅ (= union だけで simpler)。
+        var overlayLocalWorksFuncs = _runtimePlan?.GetOverlayWorksFunctions(overlay.Index).ToList()
+                                     ?? new List<RuntimeFunction>();
+        var sharedWorkLabels = overlayLocalWorksFuncs
+            .SelectMany(f => f.Works!)
+            .Select(w => w.Label)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(l => l, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        if (sharedWorkLabels.Count > 0)
+        {
+            _e.Blank();
+            _e.Comment("=== Shared Work Labels (from main, for local copy runtime functions) ===");
+            foreach (var label in sharedWorkLabels)
+                _e.Raw($"; EXTERN {label}");
+        }
+
         var result = _e.ToAssembly();
 
         // エミッタを復元
@@ -806,7 +828,7 @@ public class CodeGenerator
             var seenLabels = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
             var flatItems = new List<(string Label, int Size, string? LibName, int Alignment)>();
             var worksSourceFuncs = _runtimePlan != null
-                ? _runtimePlan.GetMainWorksFunctions()
+                ? _runtimePlan.GetMainAllocatedWorksFunctions()
                 : _runtimeManager.GetUsedFunctions();
 
             foreach (var func in worksSourceFuncs)

--- a/src/SLANGCompiler.Core/Runtime/RuntimePlanner.cs
+++ b/src/SLANGCompiler.Core/Runtime/RuntimePlanner.cs
@@ -119,6 +119,39 @@ public class RuntimePlan
         return set.OrderBy(n => n, StringComparer.OrdinalIgnoreCase);
     }
 
+    /// <summary>overlay i 用: local copy 出力される関数のうち @works を持つもの (LoadOrder 順)。
+    /// 各 function の Works property を呼出側で集めて overlay ASM の 「Shared Work
+    /// Labels」 EXTERN listing 構築に使う (= Issue #209、 main 側 sWORK BSS sym を
+    /// EXTERN 参照する形に変換)。</summary>
+    public IEnumerable<RuntimeFunction> GetOverlayWorksFunctions(int overlayIndex)
+    {
+        if (!OverlayLocalFunctions.TryGetValue(overlayIndex, out var set))
+            return Enumerable.Empty<RuntimeFunction>();
+        return set
+            .Select(n => _runtime.Functions.TryGetValue(n, out var f) ? f : null)
+            .Where(f => f != null && f!.Works != null && f.Works.Count > 0)
+            .Distinct()
+            .OrderBy(f => f!.LoadOrder)!;
+    }
+
+    /// <summary>main __WORK__ に allocate すべき @works を持つ関数 (= MainResident +
+    /// MainInline + 全 OverlayLocalFunctions の union、 LoadOrder 順)。
+    /// EmitWorkArea から呼ばれ、 overlay local copy runtime function の Works sym も
+    /// main __WORK__ に確保される (= Issue #209、 overlay からは EXTERN で main 側参照)。
+    /// main が当該 runtime call を使わなくても overlay のみ使う場合に main.sym へ EQU 出力
+    /// される保証。</summary>
+    public IEnumerable<RuntimeFunction> GetMainAllocatedWorksFunctions()
+    {
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<RuntimeFunction>();
+        foreach (var f in GetMainWorksFunctions())
+            if (seen.Add(f.Name)) result.Add(f);
+        foreach (var kv in OverlayLocalFunctions)
+            foreach (var f in GetOverlayWorksFunctions(kv.Key))
+                if (seen.Add(f.Name)) result.Add(f);
+        return result.OrderBy(f => f.LoadOrder);
+    }
+
     internal static string Normalize(string name, RuntimeManager runtime)
     {
         // alias 名 → 正規名へ。RuntimeManager.Functions には alias 経由でも引けるよう

--- a/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
+++ b/tests/SLANGCompiler.Tests/X1NativeEnvTests.cs
@@ -107,7 +107,7 @@ public class X1NativeEnvTests
     [InlineData("clear_screen")]   // text + attribute + kanji 3 plane 初期化
     [InlineData("_C8025L")]        // CRTC PARM 80 col Lo-res table
     [InlineData("_C4025L")]        // CRTC PARM 40 col Lo-res table
-    [InlineData("_CRTCD")]         // CRTC 現在設定 work area (= R1 から動的 width 取得)
+    [InlineData("X1CRT_WORK")]     // _CRTCD provider (= @works _CRTCD:16、 main __WORK__ allocate)
     public void Libx1NativeBase_DefinesRoutine(string name)
     {
         var content = File.ReadAllText(RuntimeAsmPath("libx1native_base.asm"));
@@ -532,6 +532,117 @@ public class X1NativeEnvTests
             // overlay 関連 intermediate も cleanup
             foreach (var ext in new[] { "._m0.ASM", "._m0.bin", "._m0.LST", "._m0.dummy.imports.asm",
                                         ".dummy.imports.asm", ".ASM", ".inc", ".sym" })
+                if (File.Exists(output + ext)) File.Delete(output + ext);
+        }
+    }
+
+    // === Issue #209 fix: Local overlay の sWORK BSS sym EXTERN + main __WORK__ 確保 ===
+
+    [Fact]
+    public void MtreadsmpLocalSample_BuildsSuccessfully()
+    {
+        // Local mode (= #MODULE $4000、 RESIDENT 省略) で overlay 内 PRINT 動作 pin
+        // (= Issue #209 fix の核心 sample)。 build success + 多段 .tap 構造確認。
+        var repoRoot = RepoRoot();
+        var sample = Path.Combine(repoRoot, "examples", "X1NATIVE_MTREAD", "MTREADSMP_LOCAL.SL");
+        var include = Path.Combine(repoRoot, "include");
+        var output = Path.Combine(Path.GetTempPath(), $"MTREADSMP_LOCAL_test_{Guid.NewGuid():N}");
+        try
+        {
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{sample}\" -o \"{output}\" --emit tape");
+            Assert.True(rc == 0,
+                $"MTREADSMP_LOCAL build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.True(File.Exists(output + ".tap"), "MTREADSMP_LOCAL.tap not generated");
+            // 多段 .tap 構造 (= main + overlay._m0、 stage 2 件) + load addr 確認
+            var tap = SLANGCompiler.Build.TapeFormats.TapFile.Load(output + ".tap");
+            var programs = SLANGCompiler.Build.TapeFormats.X1Program.DecodeAll(tap);
+            Assert.Equal(2, programs.Count);
+            Assert.Equal(0x1000, programs[0].Info.LoadAddress);  // main
+            Assert.Equal(0x4000, programs[1].Info.LoadAddress);  // overlay._m0
+            // overlay は Local mode で runtime routine 複製済 = RESIDENT (36 byte) より大きい
+            Assert.True(programs[1].Data.Length > 100,
+                $"Local mode overlay size too small (= {programs[1].Data.Length}, expected > 100)");
+        }
+        finally
+        {
+            CleanupBuildArtifacts(output);
+            foreach (var ext in new[] { "._m0.ASM", "._m0.bin", "._m0.LST", "._m0.dummy.imports.asm",
+                                        "._m0.imports.asm", ".dummy.imports.asm",
+                                        ".ASM", ".inc", ".sym" })
+                if (File.Exists(output + ext)) File.Delete(output + ext);
+        }
+    }
+
+    [Fact]
+    public void ModtestSample_BuildsOnX1Native()
+    {
+        // 既存 MODTEST.SL (= #MODULE $3000 Local、 LSX/x1 では動くが x1native では
+        // 既存 bug で fail してた) が Issue #209 fix 後 build success する pin
+        // (= 既存問題解消の最重要 test)
+        var repoRoot = RepoRoot();
+        var sample = Path.Combine(repoRoot, "examples", "MODTEST.SL");
+        var include = Path.Combine(repoRoot, "include");
+        var output = Path.Combine(Path.GetTempPath(), $"MODTEST_X1N_test_{Guid.NewGuid():N}");
+        try
+        {
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{sample}\" -o \"{output}\" --emit tape");
+            Assert.True(rc == 0,
+                $"MODTEST.SL on x1native build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            Assert.True(File.Exists(output + ".tap"), "MODTEST.tap not generated");
+        }
+        finally
+        {
+            CleanupBuildArtifacts(output);
+            foreach (var ext in new[] { "._m0.ASM", "._m0.bin", "._m0.LST", "._m0.dummy.imports.asm",
+                                        "._m0.imports.asm", ".dummy.imports.asm",
+                                        ".ASM", ".inc", ".sym" })
+                if (File.Exists(output + ext)) File.Delete(output + ext);
+        }
+    }
+
+    [Fact]
+    public void OverlayOnlyPrintSample_BuildsOnX1Native()
+    {
+        // 「main で PRINT 不使用、 overlay だけ PRINT 使う」 minimal ケース (= Codex
+        // 指摘の核心 test、 main.sym に sXYADR / AT_WIDTH が出る pin = main __WORK__
+        // allocate 確認の最重要 test)
+        var repoRoot = RepoRoot();
+        var include = Path.Combine(repoRoot, "include");
+        var slPath = Path.Combine(Path.GetTempPath(), $"overlay_only_print_{Guid.NewGuid():N}.SL");
+        var output = Path.Combine(Path.GetTempPath(), $"overlay_only_print_test_{Guid.NewGuid():N}");
+        try
+        {
+            File.WriteAllText(slPath, @"
+MAIN()
+BEGIN
+    MODFUNC();
+END;
+
+#MODULE $4000
+MODFUNC()
+BEGIN
+    PRINT(""X"");
+END;
+#END
+");
+            var (rc, stdout, stderr) = RunSlangBuild(
+                $"-E x1native -I \"{include}\" \"{slPath}\" -o \"{output}\" --emit bin");
+            Assert.True(rc == 0,
+                $"overlay-only-PRINT build failed exit={rc}\nstdout:\n{stdout}\nstderr:\n{stderr}");
+            // overlay._m0.bin 生成確認 (= main は MODFUNC call のみ、 overlay 側 PRINT が
+            // resolve できれば overlay._m0.bin が出る)
+            Assert.True(File.Exists(output + "._m0.bin"),
+                "overlay._m0.bin not generated — main __WORK__ に overlay 用 work sym 未 allocate 疑い");
+        }
+        finally
+        {
+            if (File.Exists(slPath)) File.Delete(slPath);
+            CleanupBuildArtifacts(output);
+            foreach (var ext in new[] { "._m0.ASM", "._m0.bin", "._m0.LST", "._m0.dummy.imports.asm",
+                                        "._m0.imports.asm", ".dummy.imports.asm",
+                                        ".ASM", ".inc", ".sym" })
                 if (File.Exists(output + ext)) File.Delete(output + ext);
         }
     }


### PR DESCRIPTION
## Summary

#MODULE Local mode (= RESIDENT 省略 default) で overlay 内 PRINT 等 SLANG runtime を使うと、 overlay 内 sPRINT body が main 側 sWORK BSS sym (sXYADR / AT_WIDTH 等) を参照するが overlay の \`; EXTERN\` listing に出ず assemble fail する既存 bug (= #209) と、 修正過程で発覚した \`_CRTCD\` (= CRTC レジスタ shadow、 mutable work) が overlay 内 local copy で init 走らず width=0 計算で表示位置が壊れる問題を併せて修正。

- **Issue**: closes #209

## 主な変更

### Planner / CodeGen
- `RuntimePlanner.GetOverlayWorksFunctions` + `GetMainAllocatedWorksFunctions` 新 method
- `EmitWorkArea`: overlay 用 work も main \_\_WORK\_\_ に allocate
- `GenerateOverlay`: 「Shared Work Labels」 section emit (= overlay から main 共有 sWORK BSS sym を EXTERN 宣言)
- `OverlayImportsBuilder` / `PrelinkPlan`: 新 section header を解析対象に追加

### Runtime (libx1native)
- `_CRTCD` を新 `X1CRT_WORK` の \`@works\` に refactor
  - main 起動時 INIT_CRTC で init される **mutable shadow work** を main \_\_WORK\_\_ 確保
  - overlay からは EXTERN 共有参照、 Local mode で AT_VRCALC width 計算 fix
  - Codex review 提案採用 (= 「@init 閉包 extern 強制」 ではなく @works 化が自然)
- `sPRINT @calls` に `clear_screen` 追加 (= sCTRL_clear 経由 indirect call の依存閉包漏れ 副次 fix)

## 副次効果

- 既存 `MODTEST.SL` を **x1native env で build success** (= 既存問題解消)
- 新 sample `MTREADSMP_LOCAL.SL` 追加、 emulator 動作確認 OK
- 既存 RESIDENT mode (= `MTREADSMP.SL`) 完全互換維持 (= bin size 同等)
- 既存 7 sample regression 0 (HELLO/STARS/FMANDEL/FURUI/X1GRP/STARS_X1/X1SGL)

## test

- `MtreadsmpLocalSample_BuildsSuccessfully`: 新 sample build + 2 stage .tap 確認
- `ModtestSample_BuildsOnX1Native`: 既存 MODTEST.SL x1native build pin
- `OverlayOnlyPrintSample_BuildsOnX1Native`: main で PRINT 不使用 / overlay だけ PRINT minimal ケース (= main \_\_WORK\_\_ allocate 核心 pin)
- **全 533 pass** (= 既存 530 + 新規 3)

## scope 外 (= 後続別 issue)

- self-contained overlay (= main 完全上書き、 overlay 内 work + init 自前 mode) → ユーザー認識「SELFCONTAIN」、 別 issue で対応予定

## Test plan

- [x] dotnet test 全 533 pass
- [x] MTREADSMP_LOCAL.SL build + emulator 動作確認 (= LOCATE / PRINT 全部 width=80 計算正しく動作)
- [x] 既存 RESIDENT sample MTREADSMP.SL build + bin size 同等維持
- [x] 既存 7 sample build + bin size 同等維持
- [x] x1 env MODTEST.SL asm 生成 OK (= LSX 系 regression 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)