### PR TITLE
chore: git-add-safety (= PR #215 事故再発防止 hook + .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,76 @@ apps/PROG.*
 # で書き換えられる作業ファイル)。pristine template は images/templates/ に
 # 分離済み (PR #157)。
 images/LSXPROG.d88
+
+# ============================================================
+# PR #215 事故 (= git add -A で 1166 file 巻込) 再発防止
+# ============================================================
+# 個別 file を tracked にしたい場合は `git add -f <path>` で強制可能。
+# ここに list された path は全て「事故防止 ignore」 で、 user の意図的な
+# commit を妨げる意図はない。
+
+# 配布 zip (= リリース ZIP、 GitHub release で別配布)
+SLANG-compiler-*.zip
+publish/
+publish-new/
+
+# build artifacts (= 拡張子 base、 既存 *.ASM / *.bin / *.com を拡張)
+*.tap
+*.wav
+*.CMT
+*.int
+*.lbl
+*.map
+*.prg
+*.dsk
+examples/**/*.d88
+examples/**/*.bin
+examples/**/*.zip
+examples/MODTEST.inc
+
+# emulator logs
+*_d3d10.log
+even-terminal-*.log
+
+# user 個人 dir / scratch (= experimental sample / backup / harness state)
+.backup-api-cleanup/
+.harness-mem/
+apps/
+refs/
+SLTEST.SL
+install
+lineasm.sh
+run_old.sh
+check_sizes.sh
+P.COM
+BattleBattleUpwards.tap
+examples/127.0.0.1:*
+examples/CFUNCTEST.*
+examples/FURUI.d88
+examples/INDTEST.SL
+examples/PROG
+examples/PRTEST.*
+examples/STARS.*
+examples/STARS_X1.d88
+examples/WIDTHTEST.SL
+examples/X1GRP.d88
+examples/X1NATIVE_HELLO.tap
+examples/X1NATIVE_HELLO.wav
+examples/X1NATIVE_MTREAD/MTREADSMP_LOCAL.*
+examples/X1SGL.d88
+examples/XBIOS.CMT
+examples/disp_hello.c
+examples/vice-screen-*.png
+
+# 第三者 binary / 外部 image (= license 別、 重複配置済 or 別 path で管理)
+tools/AILZ80ASM
+tools/HuDisk.exe
+tools/ndc
+tools/ndcmsg.txt
+images/SOSPROG.D88
+images/dosformsx.dsk
+images/templates/SOSPROG.D88
+
+# misc
+include/.source.txt
+src/src.sln

--- a/scripts/githooks/pre-commit
+++ b/scripts/githooks/pre-commit
@@ -1,0 +1,32 @@
+#!/bin/sh
+# SLANG-compiler pre-commit hook: 大量 file 巻込防止
+#
+# PR #215 で `git add -A` 事故 (= 1166 file 巻込、 第三者 IP / backup 含む) が
+# 起きたため、 50 file 超の staged commit を reject する safety net。 通常 PR
+# では多くて 20-30 file、 50 超は明らかに「全部 add してしまった」 状態。
+#
+# Setup (= 一度だけ):
+#   git config core.hooksPath scripts/githooks
+#
+# 意図的な大量 commit (= initial commit / 大規模 refactor 等) は
+# `git commit --no-verify` で bypass 可能、 ただし全 file の origin を
+# `git diff --cached --stat` で必ず確認すること。
+
+STAGED_COUNT=$(git diff --cached --name-only | wc -l | tr -d ' ')
+
+if [ "$STAGED_COUNT" -gt 50 ]; then
+    cat >&2 <<EOF
+ERROR: pre-commit hook: $STAGED_COUNT files staged (threshold = 50).
+
+This is likely an accidental \`git add -A\` / \`git add .\` capture.
+Review staged files:
+  git diff --cached --stat
+
+If intentional (= initial commit / massive refactor), bypass with:
+  git commit --no-verify
+
+To unstage everything and start over:
+  git reset HEAD
+EOF
+    exit 1
+fi


### PR DESCRIPTION
## Summary

PR #215 で \`git add -A\` 1 回で **1166 file** (= 第三者 binary / 配布 zip / backup / experimental sample / emulator log) を巻込 commit + push する事故が発生 (= force push 禁止で履歴整理に苦慮、 PR close + branch 再 push で対応)。 三段防御で再発防止。

## 三段防御

### 1. 包括 `.gitignore` (= 本 PR で commit)
既存 untracked 全 path を category 別 ignore:
- 配布 zip (\`SLANG-compiler-*.zip\` / \`publish/\` / \`publish-new/\`)
- build artifacts (\`*.tap\` / \`*.wav\` / \`*.CMT\` / \`*.int\` / \`*.lbl\` / \`*.map\` / \`*.prg\` / \`*.dsk\` / \`examples/**/*.d88\` / \`examples/**/*.bin\` / 等)
- emulator logs (\`*_d3d10.log\` / \`even-terminal-*.log\`)
- user 個人 / scratch (\`.backup-api-cleanup/\` / \`.harness-mem/\` / \`apps/\` / \`refs/\` / 各 experimental .SL / 等)
- 第三者 binary (\`tools/AILZ80ASM\` / \`tools/HuDisk.exe\` / \`tools/ndc\` / \`images/SOSPROG.D88\` / 等)

**効果**: \`git status\` 上 untracked file 数 **1166 → 1** (= scripts/ のみ)。 個別 file 必要時は \`git add -f <path>\` で強制 add 可能。

### 2. \`scripts/githooks/pre-commit\` (= 本 PR で commit)
staged file > 50 で reject:
- 通常 PR は多くて 20-30 file、 50 超は明らかに \`git add -A\` 事故
- 意図的な大量 commit は \`git commit --no-verify\` で bypass

### 3. \`.claude/settings.local.json\` (= 個人 setting、 本 commit には含めず)
\`Bash(git add -A)\` / \`git add .\` / \`git add -u\` / \`git commit -a\` 系を deny rule に追加、 claude が実行 attempt 段階で blocked。

## Setup 手順 (= user 一度のみ)

\`\`\`sh
git config core.hooksPath scripts/githooks
\`\`\`

これで pre-commit hook が有効化。 dummy で大量 stage → \`git commit\` 試行で reject 確認可能。

## Test plan

- [x] \`.gitignore\` 適用後 \`git status\` で untracked 1166 → 1
- [x] \`scripts/githooks/pre-commit\` 実行権 + shebang 確認
- [x] user 側で \`git config core.hooksPath scripts/githooks\` 実行 + 動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)