### PR TITLE
v0.25.0 リリース準備

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,38 @@
 # 更新履歴
 
-## Unreleased
+## Version 0.25.0
 
-- Commodore 64 (6502) 対応 (experimental) を追加。oscar64 を別途インストールして `SLANG → C ソース → .prg` の二段変換、 詳細は [docs/C64.md](docs/C64.md) 参照。
-- env file の `c_bindings:` セクションで ホスト C 関数を SLANG 標準 API として一括公開できる仕組みを導入 (= CFUNC 宣言不要、 SLANG コードからそのまま呼べる)。
-- SLANG → C transpiler 実装 (`CFUNC` 宣言 + `VOID` 型 + `BACKEND` const + `slangbuild --c-source` 等)。
-- oscar_c backend で `ARRAY BYTE NAME[N] = { 値, %値, ... }` 初期化対応 (= `%` 前置で WORD を LE 2 byte に展開)。
-- c64 backend に VIC sprite + VSYNC 同期 + joystick + KERNAL file I/O + SID 音源 (register direct + 単発 SFX + HVSC `.sid` BGM 再生 + oscar64 `audio/sidfx` priority SFX overlay) の bridge と sample 一式を追加。
-- 既存 Z80 backend の codegen / runtime の挙動は無変更 (= 言語側で `VOID` 予約語追加・`CFUNC` 構文追加が入っているため Parser には影響あり、 ただし既存 Z80 SLANG コードへの regression は確認なし)。
-- ARRAY initializer の容量超過 check / ARRAY symbol 代入 guard を SemanticAnalyzer に集約し全 backend で揃えた (Closes #190、 oscar_c の非 BYTE InitialCode emit 対応は別 PR 候補)。
-- oscar_c backend で `ARRAY WORD W[N] = { 値, %値, ... }` 初期化対応 (= CODE byte stream を 2 byte ずつ little-endian で WORD literal に grouping、 容量埋めは C implicit zero fill 任せ、 #194 配下 v3b-E first PR)。
-- oscar_c backend で `ARRAY BYTE S[N] = { "..." }` の StringLiteral 単独初期化対応 (= C string literal `static unsigned char V_S[N+1] = "...";` で emit、 oscar64 `-psci` で PETSCII 自動変換、 #194 配下 v3b-E (3a))。mixed (= StringLiteral + 数値) と ARRAY WORD への StringLiteral は scope 外で error。
-- oscar_c backend の ARRAY initializer で `%FUNC` / `%ARRAY` の address 参照 (= jump table / pointer table 用途) を **permanent backend gap** として明示 reject + workaround メッセージ (= MAIN 冒頭等で runtime 初期化に書き換え) を出すよう更新 (= oscar64 が static integer initializer で address-to-integer cast を constant initializer と認めない、 error 3008 を実機検証で確認、 #194 配下 v3b-E (3b))。Z80 backend は `DW LABEL` で linker reloc 解決可能、 backend gap として明示。
-- oscar_c CEmitter の `ARRAY ...:address = { ... }` (= fixed addr + InitialCode) 防衛 error を削除 (= SLANG parser が文法レベルで reject するため到達不能、 #194 配下 v3b-E (5))。 parser reject を pin する test を追加。
-- oscar_c backend で `ARRAY FLOAT FA[N] = { 1.0, 2.0, ... }` 初期化対応 (= oscar64 native float32 で `static float V_FA[N+1] = {1.0, 2.0};` emit、 整数 element は自動的に float promote、 容量未満は C implicit zero fill、 #194 配下 v3b-E (1b))。非定数 element は oscar64 制約で reject + runtime 初期化 hint message。 `ARRAY BYTE/WORD` 内の `%%` FLOAT prefix は SLANG parser 文法上未対応 + oscar_c は f24 byte stream 表現を持たないため意味的にも対応不能、 ARRAY FLOAT を使う旨を CEmitter defensive guard で diagnose (= #194 配下 v3b-E (2))。
-- oscar_c backend で `ARRAY BYTE/WORD A[][M] = { ... }` (= multi-dim 第 1 次元省略) の InitialCode 対応 (= C99 auto dim 推論 `static T V_A[][M+1] = {flat init};` で emit、 第 1 次元は C compiler が init 量から推定、 #194 配下 v3b-E (4))。ARRAY FLOAT multi-dim および第 2 次元以降の `[]` 省略は scope 外で error (= C99 仕様で第 1 次元のみ省略可)。これで #194 配下 v3b-E は完了。
-- X1 環境に **OS 非依存の `x1native` env** を新設 (= Phase A、 将来 .tap / .wav テープ出力対応のための土台)。 既存 `x1.env` / `sosx1.env` (= LSX-Dodgers / S-OS 依存) は完全無触、 新規 `libx1native_base/input/print.asm` 3 ファイルで SLANGINIT / sGETKY (X1 sub CPU $1900 polling) / sPRINT (text VRAM $3000 直書き) を native 実装、 `libx1_base.asm` (VSYNC) のみ既存 reuse。 file I/O は linker undefined symbol で reject (= 必要なら lsx / sosx1 env を使う)、 D88 boot / graphics / PSG / PCG は Phase A scope 外。 出典: LSX-Dodgers (MIT) / X1_compatible_rom (CC0) を参考実装、 各 asm header に attribution。 詳細は [docs/X1.md](docs/X1.md) 参照。
-- slangbuild に `--emit tape` を追加 (= x1native env の bin → X1 cassette tape `.tap` + optional PCM `.wav` 自動生成)。 env file の `tape:` section または CLI option (`--tape-name` / `--tape-load` / `--tape-exec` / `--wav`) で tape header の name / load / exec address を指定、 IPL 経由で OS なし auto boot。 X1 tape は 1 binary per tape 仕様のため overlay 多段ロードは未対応 (= 検出時 reject)。 WAV は default 48kHz/8bit/mono (= xmil 互換)、 16bit option あり。 詳細は [docs/X1.md](docs/X1.md) 参照。
+- Commodore 64 (6502) backend 正式対応 — oscar64 を別途インストールして `SLANG → C ソース → .prg` の二段変換、 詳細は [docs/C64.md](docs/C64.md)
+  - SLANG → C transpiler (`CFUNC` 宣言 + `VOID` 予約語 + `BACKEND` const + `slangbuild --c-source`)、 env file `c_bindings:` でホスト C 関数を SLANG 標準 API として一括公開 (= CFUNC 宣言不要、 SLANG コードからそのまま呼べる)
+  - VIC sprite (1 個 + VSYNC 同期) / joystick / KERNAL file I/O / SID 音源 (register direct + 単発 SFX + HVSC `.sid` BGM 再生 + oscar64 `audio/sidfx` priority SFX overlay) の bridge と sample
+  - 最低限ゲーム API: mmap 切替 (`MMAP_SET` / `MMAP_TRAMPOLINE`)、 VIC mode / bank 切替 (`VIC_SETMODE` / `VIC_SETBANK`)、 memory 操作 (`MEMCPY` / `MEMSET`) の bridge と sample (`examples/c64/MMAPVIC.SL`)
+  - ARRAY initializer: `ARRAY BYTE/WORD/FLOAT NAME[N] = { ... }`、 `%値` で WORD LE 2 byte 展開、 `"..."` で string literal (= `-psci` で PETSCII 自動変換)、 `[][M]` 形式 multi-dim (= 第 1 次元省略)。 ARRAY initializer 内の address 参照や ARRAY FLOAT 内の非定数 element は backend 上の制約として明示診断 + workaround メッセージ
+  - ARRAY initializer 容量超過 check / ARRAY symbol への代入 guard を `SemanticAnalyzer` に集約し全 backend で揃えた (#190)
+  - 40 桁版 mandelbrot demo (`examples/c64/FMANDEL.SL`)、 sprite / joystick / SID / file I/O の sample 一式 (`examples/c64/`)
+  - 既存 Z80 backend の codegen / runtime 挙動は無変更だが、 `VOID` 予約語追加 + `CFUNC` 構文追加で Parser には影響あり (= 既存 Z80 SLANG コードへの regression は確認なし)
+
+- X1 環境に OS 非依存の `x1native` env を新設 — D88 boot 不要、 cassette tape (`.tap` / `.wav`) 直接対応、 詳細は [docs/X1.md](docs/X1.md)
+  - 新規 `libx1native_*.asm` で SLANGINIT / sGETKY (sub CPU `$1900` polling) / sPRINT (text VRAM `$3000` 直書き) を native 実装、 既存 `x1.env` / `sosx1.env` (= LSX-Dodgers / S-OS 依存) は完全無触
+  - text 周り: CRTC init + `WIDTH` / `LOCATE` / `SCREEN` + scroll + `HOME` / `CLEAR` + kanji selector 修正
+  - graphics: 既存 graphics 4 library reuse + `GRDISP` / `GRCLS` + sPRINT attribute 修正、 `x1.env` / `sosx1.env` でも `GRDISP` / `GRCLS` を `libmag` → `libx1_grp` に migrate (= libmag 非同梱でも `GRDISP` / `GRCLS` が使える)
+  - PSG: `libx1_psg` 統合 + CTC IM2 vector + 高位 RAM ISR trampoline、 `PSG_INIT(0)` 後の不正 OUT を guard
+  - file I/O は linker undefined symbol で reject (= 必要なら lsx / sosx1 env を使う)
+  - 出典: LSX-Dodgers (MIT) / X1_compatible_rom (CC0) 参考実装、 各 asm header に attribution
+
+- X1turbo: text VRAM 計算 bug 修正 (#207) — `SGL_VRCALC` の text VRAM addr を `$038H` → `$030H` に (= X1turbo で text 表示が崩れていた)
+
+- slangbuild に `--emit tape` を追加 — x1native env の bin → X1 cassette tape `.tap` + optional PCM `.wav` 自動生成
+  - env file `tape:` section または CLI option (`--tape-name` / `--tape-load` / `--tape-exec` / `--wav`) で tape header の name / load / exec address を指定、 IPL 経由で OS なし auto boot
+  - 多段 cassette tape ロード: `MTREAD` / `MTREADJP` runtime API + `#MODULE` overlay の自動連結対応
+  - WAV は default 48kHz/8bit/mono (= xmil 互換)、 16bit option あり
+  - `.tap` format は純正 / 互換 IPL の両方で boot 可能 (= sync 41/21 全 9 bit/byte + popcount mod 65536 BE checksum)
+
+- Z80 backend: Local mode overlay の sWORK BSS sym EXTERN + `_CRTCD` 共有を修正 (#209) — overlay 経由で生成された `_CRTCD` が main 側と別実体となり、 環境によっては text I/O / scroll が overlay 側で動作しないことがあった
+
+- SLANG File System (SLFS) を追加 — x1native 環境向けの minimal file I/O
+  - 2D D88 disk image に asset を packed file system として収納、 SLANG 側 API `FS_READ_BY_ID` / `FS_SAVE_R` / `FS_SAVE_W` (= read-only main 領域 + read/write save 領域) で読み書き
+  - ホスト側ツール `slfs-pack` を同梱 — asset を D88 に pack + `list` / `info` / `extract` / `extract-main` / `extract-save` subcommand
+  - generated header — SL コード上から symbol 名で asset を参照可能 (= numeric ID 直書き不要)
 
 ## Version 0.24.1
 

--- a/README.md
+++ b/README.md
@@ -1,20 +1,41 @@
 # SLANG-compiler
-SLANG Compiler (Z80) 0.24.1
+SLANG Compiler (Z80 + C64/oscar64) 0.25.0
 
 # 概要
 
 これは主に国産8bit PCで使われたOS「S-OS」オリジナルの構造型コンパイラ言語「SLANG」のクロスコンパイラです。
 
-コンパイルする事で、Z80のアセンブラソースを出力するため、柔軟な活用が可能です。
+コンパイルする事で、 Z80 backend ではアセンブラソースを、 C64 backend では oscar64 向けの C ソースを出力するため、 柔軟な活用が可能です。
 
-現状、LSX-Dodgers及びS-OSで動作するように作られていますが、OS依存部分を個々作る事で、CPUにZ80を採用している様々な環境で動かす事が出来るはずです。
+現状、 Z80 backend は LSX-Dodgers / S-OS / X1 / PC-8001mkII / PC-8801mkIISR / MZ-2500 等の各種 8bit 環境で、 C64 backend は oscar64 経由で Commodore 64 で動作します。 OS 依存部分を個々作る事で、 様々な環境を追加できる設計です。
 
 > **Note:** 旧コンパイラ(SLANGCompiler)のソースは `obsolete/` フォルダに移動しています。旧コンパイラを使用する場合は `obsolete/Makefile` を参照してください。
 
 # 使い方
 
+主要なビルドコマンドの例:
+
+```sh
+# Z80 (= LSX-Dodgers disk image)
+slangbuild -E lsx -I include examples/STARS.SL -o STARS --emit disk
+
+# Z80 + X1 OS なし (= cassette tape)
+slangbuild -E x1native -I include examples/X1NATIVE_HELLO.SL -o HELLO --emit tape
+
+# Z80 + X1 OS なし (= D88 disk image with SLFS asset)
+slangbuild --emit disk -E x1native_slfs examples/X1NATIVE_SLFS/SLFSDEMO.SL -o SLFSDEMO \
+  --slfs-add examples/X1NATIVE_SLFS/assets/
+
+# 6502 + Commodore 64 (= .prg via oscar64)
+slangbuild -E c64 -I include examples/c64/SPRITE.SL -o SPRITE
 ```
-SLANG Compiler v0.24.1
+
+環境別の詳細: [docs/X1.md](docs/X1.md) (x1native / SLFS) / [docs/SLFS.md](docs/SLFS.md) (SLFS) / [docs/C64.md](docs/C64.md) (Commodore 64)。
+
+## slangc 単体 (= compile のみ、 link しない)
+
+```
+SLANG Compiler v0.25.0
 Usage: slangc [options] <input.sl>
 
 Options:
@@ -77,6 +98,20 @@ WIDTH関数が正常に動作し、文字表示について高速化されます
 ただし、LSX-Dodgers側との整合性は取っていないので、入力関連や、OSに戻ってからの挙動については保証しません。
 
 また、PCG定義関数が追加されます。
+
+## x1native ( SHARP X1 native - OS なし環境 )
+
+OS (LSX-Dodgers / S-OS) に依存せず X1 hardware を直接叩く環境です。 cassette tape (`.tap` / `.wav`) でのゲーム配布を主目的とした最小構成で、 text VRAM 直接書き込み + sub CPU `$1900` polling での key 入力、 CRTC 初期化 + WIDTH / LOCATE / SCREEN / HOME / CLEAR + scroll、 graphics (GRDISP / GRCLS)、 PSG (CTC IM2 vector + 高位 RAM ISR trampoline) に対応します。
+
+file I/O は linker error で reject されます (= 必要なら `lsx` / `sosx1` 環境を選択)。
+
+`slangbuild --emit tape` で X1 cassette tape (`.tap` + optional `.wav`) を生成、 X1 標準 IPL 経由で OS なし auto boot します。 多段 cassette tape ロード (`MTREAD` / `MTREADJP` runtime API + `#MODULE` overlay の自動連結) にも対応します。 詳細は [docs/X1.md](docs/X1.md) を参照してください。
+
+## x1native_slfs ( x1native + SLANG File System )
+
+`x1native` 環境をベースに、 ゲーム asset を 2D D88 disk image に packed file system として収納する **SLANG File System (SLFS)** を利用する環境です。 SLANG 側 API (`FS_READ_BY_ID` / `FS_SAVE_R` / `FS_SAVE_W`) で asset の読み込みと save area の read/write を行います。
+
+ホスト側ツール `slfs-pack` を同梱、 asset を D88 に pack するほか `list` / `info` / `extract` / `extract-main` / `extract-save` subcommand に対応します。 詳細は [docs/SLFS.md](docs/SLFS.md) を参照してください。
 
 ## sos ( S-OS )
 
@@ -178,7 +213,7 @@ Layer 2グラフィックス、タイルマップ、スプライト、パレッ�
 
 > **注**: `examples/zxn/Makefile` の `make build` (default) は NextDAW なし版 (`game_nomusic.nex`) を build します。NextDAW を含む完全版 (`game.nex`) を build するには `make music` を使い、`examples/zxn/NextDAW_RuntimePlayer_E000.bin` (= NextDAW Runtime Player) を `examples/zxn/` 配下に配置してください。NextDAW ([https://nextdaw.biasillo.com/](https://nextdaw.biasillo.com/)) は外部製品のため配布物には含まれません。**2026-04-30 時点で公式サイトでの入手はできない状態**で、再公開された場合も driver の仕様変更等により `examples/zxn/game.cfg` や `game.sl` の修正が必要となる可能性があります。
 
-## c64 (Commodore 64 / oscar64) — experimental
+## c64 (Commodore 64 / oscar64)
 
 Commodore 64 (6502) 用の環境です。本環境のみ SLANG コンパイラは 6502 アセンブラを直接出力せず、**SLANG → C ソース → oscar64 → .prg** の二段変換で 6502 バイナリを生成します。oscar64 ([https://github.com/drmortalwombat/oscar64](https://github.com/drmortalwombat/oscar64)) は本配布物に含まれないため別途インストールが必要です。drmortalwombat 氏 + oscar64 project に感謝。
 
@@ -363,6 +398,8 @@ make TARGET=examples/STARS ENV=x1 run
 |-----|---------|
 | lsx | LSX-Dodgers (標準) |
 | x1 | SHARP X1 (LSX-Dodgers + X1専用最適化) |
+| x1native | SHARP X1 (OS なし、 cassette tape boot) |
+| x1native_slfs | SHARP X1 (OS なし、 SLFS disk image 出力) |
 | sos | S-OS（機種非依存） |
 | sosx1 | S-OS for SHARP X1（X1固有ライブラリ同梱・従来のsos互換） |
 | msx2 | MSX-DOS2 |
@@ -398,6 +435,7 @@ template の入手:
 | lsx / x1 | `images/LSXPROG.d88` | `images/templates/LSXPROG.D88` | repo 同梱 |
 | sos / sosx1 / sosmz2500 | `images/SOSPROG.D88` | `images/templates/SOSPROG.D88` | `make setup-tools` で取得 (S-OS 配布物 + AUTOEXEC.BAT 注入)。MZ-2500 では本ディスクを B ドライブに挿入し X1 用 SOSPROG から呼び出す運用 |
 | pc88mk2sr | `images/PC88MK2SR.d88` | `images/templates/PC88MK2SR.D88` | repo 同梱 (Bookworm's Library 由来、`THIRD_PARTY_NOTICES.md` 参照) |
+| x1native_slfs | (slfs-pack による生成) | (template 不要) | `slfs-pack` で都度生成 (= pristine 2D D88 を内部生成し、 main + asset を pack) |
 | mz25iocs | `<output dir>/M25PROG.d88` | (template 不要) | `mzd88 -blank` で都度生成、`runtime/mz2500/J8000.bas.bsd` を起動用 BASIC ローダとして格納 |
 | MSX-DOS 系 | `images/dosformsx.dsk` | `tools/disk-add-overlays.py` 経路 | `make setup-tools` で取得 |
 

--- a/docs/C64.md
+++ b/docs/C64.md
@@ -1,4 +1,4 @@
-# c64 (Commodore 64 / oscar64) backend — experimental
+# c64 (Commodore 64 / oscar64) backend
 
 Commodore 64 (6502) 用の環境です。SLANG コンパイラは 6502 アセンブラを直接出力する代わりに、**SLANG → C ソース → oscar64 → .prg** という二段変換で 6502 バイナリを生成します。
 
@@ -32,6 +32,28 @@ slangbuild -E c64 -o examples/FMANDEL examples/FMANDEL.SL
 
 **`-o` のセマンティクス**: `slangc -o <path>` は完全パス (`.c` 拡張子込み)、`slangbuild -o <prefix>` は prefix (`<prefix>.c` と `<prefix>.prg` を生成) という Z80 経路と同じ慣行です。
 
+## 最小ゲーム作成 API sample
+
+最低限ゲーム API (= mmap 切替 + VIC mode 切替 + memcpy / memset) を使って自前 charset を表示する sample `examples/c64/MMAPVIC.SL` で動作確認できます。
+
+```sh
+slangbuild -E c64 -I include examples/c64/MMAPVIC.SL -o MMAPVIC
+x64sc MMAPVIC.prg
+```
+
+flow:
+
+1. `MMAP_TRAMPOLINE` + `MMAP_SET(MMAP_NO_BASIC)` で BASIC disable + I/O visible
+2. SLANG ARRAY に bake-in した「空白 char (= 全 0)」 と「顔風 char (= 8x8 outline)」 を `MEMCPY` で自前 font area ($3000) の char 32 / char 0 に書込
+3. `VIC_SETMODE(VICM_TEXT, $0400, $3000)` で自前 font 切替
+4. `MEMSET` で screen RAM 全 1000 byte を char 32 で fill (= 起動時 BASIC 残骸 clear)
+5. `MEMSET` で screen 中央 3 char に char 0 (= 顔) を書込
+6. キー押下後、 `VIC_SETMODE` で font を ROM CHARSET (`VIC_FONT_ROM`) に戻すと、 screen char index 0 が ROM の '@' 3 個に変化 (= font 切替の visual 確認)
+
+各 binding (`MMAP_SET` / `MMAP_TRAMPOLINE` / `VIC_SETMODE` / `VIC_SETBANK` / `MEMCPY` / `MEMSET`) の signature や `MMAP_*` / `VICM_*` 定数の詳細は次の「提供 API」 節を参照。
+
+**c64 backend INKEY 注意**: `INKEY(mode)` は **常時 non-blocking** (= mode 値関係なし、 押下中なら PETSCII / 未押下で 0)。 wait したい場合は `WHILE K == 0 { K = INKEY(0); }` 自前 loop が必要 (= 既存 SIDBGM.SL / SIDSFX.SL 同 pattern)。
+
 ## 提供 API
 
 env file `c64.env` が以下を C backend builtin として公開しているため、SLANG コードからそのまま呼べます (CFUNC 宣言不要、`#IF BACKEND==1` の gate も不要 = env 提供 API は自動的に有効):
@@ -39,7 +61,7 @@ env file `c64.env` が以下を C backend builtin として公開しているた
 | 種別 | API |
 |---|---|
 | I/O | `PRINT` 全構文 (`"..."` / `/` / `%(v)` / `!(s)` / `HEX2$(v)` / `HEX4$(v)` / `DECI$(v)` / `FORM$(v,n)` / `MSG$(p)` / `MSX$(p)` / `STR$(c,n)` / `CHR$(n)` / `SPC$(n)` / `CR$(n)` / `TAB$(n)` / `FL$(f)` / `PN$(v)`) |
-| 入力 | `INKEY(mode)` (即時状態取得、押下中=値、離した瞬間=0)、`INPUT()` (1 行入力 → 数値 parse、ESC=`$FFFF`)、`GETL(buf)` / `GETLIN(buf, x)` / `LINPUT(buf, x)` (1 行文字列入力、戻り値=入力文字数、ESC=`$FFFF`)。Z80 backend の `_CARRY` 機構は v1 未対応 |
+| 入力 | `INKEY(mode)` (即時状態取得、押下中=値、離した瞬間=0)、`INPUT()` (1 行入力 → 数値 parse、ESC=`$FFFF`)、`GETL(buf)` / `GETLIN(buf, x)` / `LINPUT(buf, x)` (1 行文字列入力、戻り値=入力文字数、ESC=`$FFFF`)。Z80 backend の `_CARRY` 機構は c64 backend では未対応 |
 | ジョイスティック | `JOY_POLL(port)` (1 frame 1 回呼ぶ) + `JOY_DIR(port)` (5 bit bitmask) + `JOY_X(port)` / `JOY_Y(port)` (signed、-1=`$FFFF`) + `JOY_B(port)` (0/1 fire)。bitmask + port 定数は `#INCLUDE "C64_JOY.LIB"` で取得 (`JOY_UP/DOWN/LEFT/RIGHT/FIRE/PORT1/PORT2`)。色定数は別途 `C64_VIC.LIB` |
 | **SID 音源 (基盤)** | 初期化: `SID_INIT_QUIET()` (= 全 register 0 で停止状態)、master volume: `SID_VOLUME(v)` (0..15)、voice direct (voice = 0..2): `SID_FREQ(voice, f)` / `SID_PWM(voice, pw)` (= PULSE 波形時必須、duty 12-bit) / `SID_ADSR(voice, ad, sr)` / `SID_CTRL(voice, ctrl)` / `SID_GATE_ON(voice)` / `SID_GATE_OFF(voice)`、SFX wrapper: `SID_SFX(voice, freq, ad, sr, waveform)` (= ADSR + waveform 設定 + GATE on を 1 関数化、release は user 側 `SID_GATE_OFF` で開始)。frequency は PAL clock 基準の register 値、`NOTE_C2..NOTE_B6` 60 個と ADSR/waveform/CTRL/pwm preset 定数は `#INCLUDE "C64_SID.LIB"` で取得 (= `SID_PWM_SQR` = $0800 で 50% duty)。**PULSE 波形は事前に `SID_PWM` 設定必須** (= pwm=0 だと duty 0% で無音) |
 | **SID 音源 (priority SFX overlay)** | oscar64 `audio/sidfx` の priority-based 多 voice SFX を bridge 経由で公開。`SIDFX_INIT()` / `SIDFX_PLAY(chn, fx_byte_ptr, cnt)` / `SIDFX_STOP(chn)` / `SIDFX_IDLE(chn) → word` / `SIDFX_CNT(chn) → word` / `SIDFX_LOOP()` (= 3 voice all tick、 BGM 不使用構成用) / `SIDFX_LOOP_2()` (= voice 2 only tick、 BGM 併用構成用)。SIDFX struct (= 14 byte、 freq/pwm/ctrl/adsr/dfreq/dpwm/time1/time0/priority) は SLANG コード側で `ARRAY BYTE FX[] = { %$1500, %$0000, ..., SIDFX_PRIO_MID };` の ARRAY initializer + `%WORD` prefix で 1 行記述可。voice 番号 + priority 定数は `#INCLUDE "C64_SIDFX.LIB"`。priority 比較は oscar64 sidfx 仕様で `<=` (= 同 priority も上書き) のため、 連続発射は SLANG 側で fire 押下 edge detection 推奨。oscar64 `audio/sidfx.c` (= GPL-3.0) は `#include` declaration 参照のみで実体は user の oscar64 install から link 解決 |
@@ -47,15 +69,47 @@ env file `c64.env` が以下を C backend builtin として公開しているた
 | **KERNAL file I/O** | open/close: `KIO_OPEN_NAMED(fnum, dev, ch, name)` / `KIO_OPEN(fnum, dev, ch)` / `KIO_SETNAM(name)` / `KIO_CLOSE(fnum)`、channel: `KIO_CHKIN(fnum)` / `KIO_CHKOUT(fnum)` / `KIO_CLRCHN()`、1 byte: `KIO_CHRIN()` / `KIO_CHROUT(ch)` / `KIO_GETCH(fnum)` / `KIO_PUTCH(fnum, ch)`、buffer: `KIO_READ(fnum, buf, n)` / `KIO_WRITE(fnum, buf, n)`、文字列: `KIO_GETS(fnum, buf, n)` / `KIO_PUTS(fnum, str)`、status: `KIO_STATUS()` (= krnioerr 取得)。文字列は NUL terminated PETSCII で **全小文字** で書く (= SLANG リテラル `"score,s,r"` が oscar64 `-psci` 経由で PETSCII unshifted 大文字に変換され 1541 の `,S,R` token parse と整合)。SEQ ファイルの主部は起動 PRG と別名にする (= 1541 emu の同主部 PRG/SEQ 共存制約回避)。bool 系は 0/1、I/O 系はエラー時 SLANG WORD で `$FFFx` (sign extension で届く)。krnioerr / device / channel 定数は `#INCLUDE "C64_KIO.LIB"` で取得。raw address 用 (`KIO_*_ADDR`) も併設 |
 | 端末 | `WIDTH(w)` (no-op = C64 は 40 桁固定)、`LOCATE(x, y)`、`SCREEN(x, y)`、`PRMODE(m)` |
 | 数学 | `ABS / SQR / SIN / COS / TAN / LOG / EXP / ATN / RND / SRND` |
-| メモリ | `MEM[addr]` / `MEMW[addr]` (= 絶対アドレス access、`SLANG_MEM` / `SLANG_MEMW` マクロに展開) |
+| メモリ | `MEM[addr]` / `MEMW[addr]` (= 絶対アドレス access、`SLANG_MEM` / `SLANG_MEMW` マクロに展開)、`MEMCPY(dst, src, size)` / `MEMSET(dst, value, size)` (= oscar64 `memcpy` / `memset` 経由) |
 | ビット | `BIT(v, b)` / `SET(p, b)` / `RESET(p, b)` |
 | 文字列長 | `STRLEN(s)` |
 | **VIC sprite** | `SPR_INIT(screen_addr)` / `SPR_SET(sp, show, x, y, image, color, multi, xex, yex)` / `SPR_MOVE(sp, x, y)` / `SPR_SHOW(sp, show)` / `SPR_POSX(sp)` / `SPR_POSY(sp)` / `SPR_COLOR(sp, c)` / `SPR_IMAGE(sp, image)` |
 | **VIC 同期** | `VIC_WAIT()` (= 1 フレーム VSYNC 待ち、tearing 防止) |
+| **memmap** | `MMAP_SET(mode) → byte` (= oscar64 `mmap_set` 経由、 旧 mode を返す)、`MMAP_TRAMPOLINE()` (= IRQ/NMI が KERNAL ROM 不在 mmap 中も動作する trampoline install)。`MMAP_*` 定数は `#INCLUDE "C64_MEMMAP.LIB"` |
+| **VIC mode** | `VIC_SETMODE(mode, screen, font)` (= text/bitmap mode 切替)、 `VIC_SETBANK(bank)` (= VIC bank 切替、 16KB 単位 0..3)。`VICM_*` mode 定数 + `VIC_SCREEN_DEFAULT` / `VIC_FONT_ROM` / `VIC_COLOR_RAM` は `#INCLUDE "C64_VIC.LIB"` |
 
 VIC 色定数 (`VCOL_BLACK..VCOL_LT_GREY`、16 色) は `#INCLUDE "C64_VIC.LIB"` で取り込めます。
 
-サンプル (`examples/c64/`):
+### `MMAP_*` 定数 (= `C64_MEMMAP.LIB`)
+
+| 名前 | 値 | 内容 (I/O visible?) |
+|---|---|---|
+| `MMAP_RAM` | $30 | ALL RAM (= **I/O 不可視**、 mmap 状態切替 user 責任) |
+| `MMAP_CHAR_ROM` | $31 | CHAR ROM のみ (= $D000-$DFFF char ROM、 **I/O 不可視**) |
+| `MMAP_ALL_ROM` | $33 | BASIC + CHAR + KERNAL (= **I/O 不可視**) |
+| `MMAP_NO_ROM` | $35 | I/O + COLOR RAM のみ ROM (= I/O visible) |
+| `MMAP_NO_BASIC` | $36 | I/O + KERNAL (= BASIC のみ disable、 **I/O visible**、 推奨) |
+| `MMAP_ROM` | $37 | default (= BASIC + I/O + KERNAL、 I/O visible) |
+
+### `VICM_*` 定数 (= `C64_VIC.LIB`)
+
+| 名前 | 値 | mode |
+|---|---|---|
+| `VICM_TEXT` | 0 | standard text |
+| `VICM_TEXT_MC` | 1 | text multicolor |
+| `VICM_TEXT_ECM` | 2 | text extended color mode |
+| `VICM_HIRES` | 3 | hires bitmap |
+| `VICM_HIRES_MC` | 4 | hires multicolor bitmap |
+
+### MEMCPY / MEMSET の caveat
+
+`MEMCPY` / `MEMSET` は **現在の CPU memory map に従う**。 C64 では $D000-$DFFF が mmap 状態で I/O / CHAR ROM / RAM に切替わるため、 想定 memory layout 確認後に呼ぶこと:
+
+- `VIC_SETMODE` / `SID_*` / `KIO_*` 等の **I/O register を叩く binding は I/O visible mmap で呼ぶ必要** (= `MMAP_NO_BASIC` / `MMAP_NO_ROM` / `MMAP_ROM`)。 `MMAP_RAM` 中は I/O 不可視で hang
+- CHAR ROM 複写 (= 例 `memcpy($D000, $D000, 2048)` で MMAP_CHAR_ROM 中に同 addr 複写) は oscar64 `memcpy` の byte 順依存で挙動不安定、 安全 wrapper は今後の検討項目
+
+### サンプル
+
+`examples/c64/`:
 
 ```sh
 # checkout 状態: -I include 必須 (= C64_*.LIB 取り込み用)
@@ -67,7 +121,8 @@ slangbuild -E c64 -I include examples/c64/SIDBGM.SL     -o examples/c64/SIDBGM
 slangbuild -E c64 -I include examples/c64/SIDOVERLAY.SL -o examples/c64/SIDOVERLAY
 slangbuild -E c64 -I include examples/c64/SIDBGM_SFX.SL -o examples/c64/SIDBGM_SFX
 slangbuild -E c64 -I include examples/c64/HISCORE.SL    -o examples/c64/HISCORE
-x64sc -autostart examples/c64/SPRITE.prg          # VICE (sprite/FMANDEL/JOYSPR/SIDSFX/SIDOVERLAY)
+slangbuild -E c64 -I include examples/c64/MMAPVIC.SL    -o examples/c64/MMAPVIC
+x64sc -autostart examples/c64/SPRITE.prg          # VICE で autostart (= .prg を差し替えて他 sample も同じ流儀で実行可: SPRITE / FMANDEL / JOYSPR / SIDSFX / SIDOVERLAY / MMAPVIC)
 # HISCORE / SIDBGM / SIDBGM_SFX は KERNAL file I/O で D64 が必要、autostart 不可。
 # c1541 で空 D64 + PRG (+ 必要なら tune) を入れて、x64sc -8 で attach + 手動 LOAD/RUN:
 c1541 -format "hiscore,01" d64 disks/hiscore.d64 -write examples/c64/HISCORE.prg hiscore
@@ -94,66 +149,6 @@ RUN
 ```
 
 **c64 backend の oscar64 最適化レベル**: `runtime/env/c64.env` で `oscar_optimize: Os` 固定 (= 既定 `-O1` で SLANG `IF N AND $8000` 等の bitwise AND パターンが誤評価される oscar64 最適化バグを踏むため、`-Os` に切替で回避 + size 最小化)。
-
-### v0.25.0: 最低限ゲーム作成 API (= mmap / vic / mem)
-
-oscar64 sample (= breakout.c 等) で典型的に必要な「memory map 切替 + VIC mode 切替 + memcpy」 を SLANG 側から呼ぶための binding。 bridge は `runtime/c64/slang_memmap.c` / `slang_vic.c` / `slang_mem.c` (= oscar64 `c64/memmap.h` / `c64/vic.h` / `string.h` 経由の薄い wrapper)。
-
-| 機能 | binding | params / return | 説明 |
-|---|---|---|---|
-| **memmap** | `MMAP_SET(mode)` → byte | byte → byte (= 旧 mode、 復元用) | oscar64 `mmap_set` 経由、 `MMAP_*` 定数は `#INCLUDE "C64_MEMMAP.LIB"` |
-| | `MMAP_TRAMPOLINE()` | () → void | IRQ/NMI が KERNAL ROM 不在 mmap 中も動作する trampoline install |
-| **VIC** | `VIC_SETMODE(mode, screen, font)` | byte, word, word → void | text/bitmap mode 切替、 `VICM_*` 定数は `#INCLUDE "C64_VIC.LIB"` |
-| | `VIC_SETBANK(bank)` | byte → void | VIC bank 切替 (= 16KB 単位、 0..3) |
-| **mem** | `MEMCPY(dst, src, size)` | word, word, word → void | 通常 memory copy (= oscar64 `memcpy` 経由) |
-| | `MEMSET(dst, value, size)` | word, byte, word → void | memory fill (= oscar64 `memset` 経由) |
-
-#### `MMAP_*` 定数 (= `C64_MEMMAP.LIB`)
-
-| 名前 | 値 | 内容 (I/O visible?) |
-|---|---|---|
-| `MMAP_RAM` | $30 | ALL RAM (= **I/O 不可視**、 mmap 状態切替 user 責任) |
-| `MMAP_CHAR_ROM` | $31 | CHAR ROM のみ (= $D000-$DFFF char ROM、 **I/O 不可視**) |
-| `MMAP_ALL_ROM` | $33 | BASIC + CHAR + KERNAL (= **I/O 不可視**) |
-| `MMAP_NO_ROM` | $35 | I/O + COLOR RAM のみ ROM (= I/O visible) |
-| `MMAP_NO_BASIC` | $36 | I/O + KERNAL (= BASIC のみ disable、 **I/O visible**、 推奨) |
-| `MMAP_ROM` | $37 | default (= BASIC + I/O + KERNAL、 I/O visible) |
-
-#### `VICM_*` 定数 (= `C64_VIC.LIB` に追記)
-
-| 名前 | 値 | mode |
-|---|---|---|
-| `VICM_TEXT` | 0 | standard text |
-| `VICM_TEXT_MC` | 1 | text multicolor |
-| `VICM_TEXT_ECM` | 2 | text extended color mode |
-| `VICM_HIRES` | 3 | hires bitmap |
-| `VICM_HIRES_MC` | 4 | hires multicolor bitmap |
-
-#### MEMCPY / MEMSET の caveat
-
-`MEMCPY` / `MEMSET` は **現在の CPU memory map に従う**。 C64 では $D000-$DFFF が mmap 状態で I/O / CHAR ROM / RAM に切替わるため、 想定 memory layout 確認後に呼ぶこと:
-
-- `VIC_SETMODE` / `SID_*` / `KIO_*` 等の **I/O register を叩く binding は I/O visible mmap で呼ぶ必要** (= `MMAP_NO_BASIC` / `MMAP_NO_ROM` / `MMAP_ROM`)。 `MMAP_RAM` 中は I/O 不可視で hang
-- CHAR ROM 複写 (= 例 `memcpy($D000, $D000, 2048)` で MMAP_CHAR_ROM 中に同 addr 複写) は oscar64 `memcpy` の byte 順依存で挙動不安定、 v0.25.0 では非推奨。 安全 wrapper は v0.26 以降検討
-
-#### sample
-
-`examples/c64/MMAPVIC.SL` (= 自前 charset 切替 → 画面中央に絵文字 3 個 → キー → ROM CHARSET 戻し → '@' 3 個):
-
-flow:
-1. `MMAP_TRAMPOLINE` + `MMAP_SET(MMAP_NO_BASIC)` で BASIC disable + I/O visible
-2. SLANG ARRAY に bake-in した「空白 char (= 全 0)」 と「顔風 char (= 8x8 outline)」 を `MEMCPY` で自前 font area ($3000) の char 32 / char 0 に書込
-3. `VIC_SETMODE(VICM_TEXT, $0400, $3000)` で自前 font 切替
-4. `MEMSET` で screen RAM 全 1000 byte を char 32 で fill (= 起動時 BASIC 残骸 clear)
-5. `MEMSET` で screen 中央 3 char に char 0 (= 顔) を書込
-6. キー押下後、 `VIC_SETMODE` で font を ROM CHARSET (`VIC_FONT_ROM`) に戻すと、 screen char index 0 が ROM の '@' 3 個に変化 (= font 切替の visual 確認)
-
-```sh
-slangbuild -E c64 -I include examples/c64/MMAPVIC.SL -o MMAPVIC
-x64sc MMAPVIC.prg
-```
-
-**c64 backend INKEY 注意**: `INKEY(mode)` は **常時 non-blocking** (= mode 値関係なし、 押下中なら PETSCII / 未押下で 0)。 wait したい場合は `WHILE K == 0 { K = INKEY(0); }` 自前 loop が必要 (= 既存 SIDBGM.SL / SIDSFX.SL 同 pattern)。
 
 ## CFUNC 宣言 (自前 C 関数を呼ぶ)
 
@@ -202,9 +197,9 @@ slangbuild -E c64 myapp.SL --c-source mylib.c -o myapp
 
 ## スコープと制約
 
-**動作確認済**: PRINT / INPUT / 整数算術 / FLOAT 演算 / リアルタイム key 入力 / sprite (1 個アニメ、VSYNC 同期) / joystick 入力 / KERNAL file I/O (save/load 往復) / SID 単発 SFX (= 音色 preset 切替) / HVSC `.sid` BGM 再生 (= disk load 経由) / priority SFX overlay (= oscar64 `audio/sidfx` bridge、 BGM + voice 2 SFX 並列) + ユーザー C 任意関数 (= CFUNC + `--c-source`)。`examples/FMANDEL.SL` / `examples/FURUI.SL` / `examples/STARS.SL` / `examples/c64/SPRITE.SL` / `examples/c64/FMANDEL.SL` (= 40 桁版) / `examples/c64/JOYSPR.SL` (= joystick) / `examples/c64/SIDSFX.SL` (= SID 単発 SFX) / `examples/c64/SIDBGM.SL` (= HVSC SID BGM) / `examples/c64/SIDOVERLAY.SL` (= 自前 melody + SIDFX 重ね) / `examples/c64/SIDBGM_SFX.SL` (= HVSC BGM + SIDFX 重ね) / `examples/c64/HISCORE.SL` (= KERNAL file I/O) が実機 (VICE) で動作。
+**動作確認済**: PRINT / INPUT / 整数算術 / FLOAT 演算 / リアルタイム key 入力 / sprite (1 個アニメ、VSYNC 同期) / joystick 入力 / KERNAL file I/O (save/load 往復) / SID 単発 SFX (= 音色 preset 切替) / HVSC `.sid` BGM 再生 (= disk load 経由) / priority SFX overlay (= oscar64 `audio/sidfx` bridge、 BGM + voice 2 SFX 並列) / 最低限ゲーム API (= mmap 切替 + 自前 charset + memcpy / memset) + ユーザー C 任意関数 (= CFUNC + `--c-source`)。`examples/FMANDEL.SL` / `examples/FURUI.SL` / `examples/STARS.SL` / `examples/c64/SPRITE.SL` / `examples/c64/FMANDEL.SL` (= 40 桁版) / `examples/c64/JOYSPR.SL` (= joystick) / `examples/c64/SIDSFX.SL` (= SID 単発 SFX) / `examples/c64/SIDBGM.SL` (= HVSC SID BGM) / `examples/c64/SIDOVERLAY.SL` (= 自前 melody + SIDFX 重ね) / `examples/c64/SIDBGM_SFX.SL` (= HVSC BGM + SIDFX 重ね) / `examples/c64/HISCORE.SL` (= KERNAL file I/O) / `examples/c64/MMAPVIC.SL` (= 自前 charset) が実機 (VICE) で動作。
 
-**未対応 / 今後の拡張**: sprite multiplex / VIC bitmap mode / CRT / overlay (`#MODULE`)。これらは bridge 関数を追加する形で順次対応予定。
+**未対応 / 今後の拡張**: sprite multiplex / VIC bitmap mode (= 高レベル draw helper) / CRT / overlay (`#MODULE`)。これらは bridge 関数を追加する形で順次対応予定。
 
 **Z80 固有機能**: `MACHINE` 宣言 / inline `#ASM` ブロック / `PORT IN/OUT` / `#MODULE` を含む SLANG コードは C backend では診断 error。`#IF BACKEND==1` (= OscarC) または `#IF ENV_TYPE==7` (= c64) で C backend 専用コードを gate できます (`BACKEND` は env で自動定義: 0=Z80、1=OscarC)。
 

--- a/docs/SLFS.md
+++ b/docs/SLFS.md
@@ -1,78 +1,40 @@
 # SLFS (SLANG File System)
 
-ゲーム専用 minimal file I/O system。 x1native env で D88 disk image から asset を読込む。
+ゲーム専用 minimal file I/O system。 x1native env で D88 disk image から asset を読込む。 HuBASIC IPL 互換 boot sector + 独自 file system 構成で、 X1 IPL ROM がそのまま起動できる。
 
-- target: **x1native のみ** (= sosx1 / pc88 等への展開は scope 外)
-- spec: Issue #212
+## Quick start
 
-## 設計思想
+```sh
+# 1. ホスト側で asset を D88 に pack + SLANG プログラム build
+slangbuild --emit disk -E x1native_slfs examples/X1NATIVE_SLFS/SLFSDEMO.SL -o SLFSDEMO \
+  --slfs-add examples/X1NATIVE_SLFS/assets/
+# → SLFSDEMO.d88 (= 2D 320 KB、 IPL + main + asset 入り) を生成
+#   (= asset ID 用の SLFSDEMO.assets.inc は slangbuild が compile 前に生成し、
+#    sample 内の #INCLUDE で取り込まれる。 通常は build 後に cleanup される。
+#    inc を残したい場合は --keep-asm を追加する)
 
-- **read-only main + small save area + 256 file 上限** で割り切る (= libmag / libm8a 互換は重い)
-- HuBASIC IPL 互換 boot sector のみで起動性確保、 中身は独自 FS
-- 「program loader」 化しない (= load/exec addr 等 program 属性は dir entry に入れない、 asset FS に徹する)
-
-## 全体 layout (= 2D 320 KB 固定)
-
-```
-予約領域 (= logical sector 0 〜 data_area_start_sector - 1):
-  sector 0: ブートセクタ (= HuBASIC IPL header 32 byte + 残り 0 fill、 X1 IPL ROM が読込)
-  sector 1: SLFS スーパーブロック ("SLFS" magic + fields)
-  sector 2〜: ディレクトリ (= 16 byte entry × 16 / sector)
-  sector M〜: main program 本体 (= packer が data_area_start_sector の手前に配置)
-
-データ領域 (= data_area_start_sector 以降): asset 連続配置 (= sorted by filename、 READ ONLY)
-
-セーブ領域 (= save_area_start_sector 以降): free area (= FS_SAVE_R / FS_SAVE_W で read/write、 アプリ自前 slot 管理)
+# 2. emulator で起動 (= IPL が D88 を読んで auto boot)
+xmil -fd SLFSDEMO.d88
 ```
 
-## boot sector (= sector 0、 HuBASIC IPL header)
+SLANG 側は generated header を `#INCLUDE` して symbol 名で asset を参照:
 
-X1 IPL ROM (= X1_compatible_rom 等) が起動時に sector 0 を `$FE00` に load → header parse → main program 本体を `LoadAddress` に連続 read → IPL ROM OFF → `ExecuteAddress` に jp。 **boot loader Z80 code は不要**。
+```sl
+#INCLUDE SLFSDEMO.assets.inc   // slfs-pack が出力 = CONST FILE_<NAME>
 
-| offset | size | name | 説明 |
-|---|---|---|---|
-| +00 | 1 | BootFlag | $01 = 起動可 |
-| +01 | 13 | FileName | ASCII space-padded |
-| +0E | 3 | Extension | "Sys" 推奨 |
-| +11 | 1 | Password | $20 = none |
-| +12 | 2 | DataSize | byte (LE)、 main program 全 size |
-| +14 | 2 | LoadAddress | LE、 default $1000 |
-| +16 | 2 | ExecuteAddress | LE、 default $1000 |
-| +18 | 5 | Date | 0 fill OK |
-| +1D | 3 | DiskOffset | byte (LE)、 main program の disk image 内 byte 開始位置 |
+VAR SIZE;
+MAIN()
+BEGIN
+    SIZE = FS_READ_BY_ID(FILE_GREETING_TXT, $4000);
+    IF SIZE != 0 THEN PRINT("OK SIZE=", SIZE, /);
+END;
+```
 
-## superblock (= sector 1、 256 byte)
-
-| offset | size | name | 説明 |
-|---|---|---|---|
-| +00 | 4 | Magic | "SLFS" |
-| +04 | 1 | Version | 1 |
-| +05 | 1 | Sides | 2 (= 2D 固定) |
-| +06 | 1 | Tracks | 40 |
-| +07 | 1 | SectorsPerTrack | 16 |
-| +08 | 2 | DirStartSector | logical sector index (LE) |
-| +0A | 2 | DirEntryCount | LE |
-| +0C | 2 | DataAreaStartSector | LE |
-| +0E | 2 | SaveAreaStartSector | LE |
-| +10 | 2 | SaveSectorCount | LE |
-| +12 | 16 | VolumeName | ASCII space-padded |
-| +22 | 0xDE | Reserved | 0 fill |
-
-## directory entry (= 16 byte、 16 entry / sector)
-
-| offset | size | name | 説明 |
-|---|---|---|---|
-| +00 | 11 | FileName | ASCII space-padded (= 8.3 風 or 自由、 11 char 超 切詰め) |
-| +0B | 1 | Type | 0 = raw、 1+ = reserved |
-| +0C | 2 | StartSector | logical sector index (LE) |
-| +0E | 2 | ByteSize | LE、 範囲 **1..65535** (= 0 / 64 KB 超は packer reject) |
-
-- ファイル名 sort 前提 (= 11 byte normalized ordinal 昇順、 packer が保証)
-- ID = sorted directory entry index、 範囲 **0..255** (= Phase 1、 SLANG `FS_READ_BY_ID(id, buf)` の id 8-bit)
+sample: `examples/X1NATIVE_SLFS/SLFSDEMO.SL`。 詳細は以下の各節を参照。
 
 ## SLANG API
 
-### Phase 1: `FS_READ_BY_ID`
+### `FS_READ_BY_ID` (= asset 読込)
 
 ```sl
 SIZE = FS_READ_BY_ID(id, buffer);   // id: 0..255、 buffer: addr
@@ -83,9 +45,9 @@ IF SIZE == 0 THEN ... END            // 失敗判定 (HL = 0)
 - 戻り値: **HL = 実 byte_size (1..65535)、 失敗時 HL = 0**
 - buffer 容量: **sector round-up 分必要** (= `ceil(byte_size / 256) * 256 byte`)
 - ID = packer の normalized filename sort 順依存
-  - Phase 3 で **generated header (= `#INCLUDE <stem>.assets.inc`)** で `CONST FILE_<NAME>` 経由が推奨、 numeric 直書きは非推奨
+  - **generated header (= `#INCLUDE <stem>.assets.inc`)** で `CONST FILE_<NAME>` 経由が推奨、 numeric 直書きは非推奨
 
-### Phase 2: `FS_SAVE_R` / `FS_SAVE_W` (= save area read/write)
+### `FS_SAVE_R` / `FS_SAVE_W` (= save area read/write)
 
 ```sl
 SIZE = FS_SAVE_W(offset_sec, count_sec, buffer);  // save area へ書込み
@@ -97,7 +59,7 @@ IF SIZE == 0 THEN ... END                          // 失敗判定
 - 戻り値: **HL = 実 byte_size (= count_sec × 256)、 失敗時 HL = 0**
 - buffer 容量: count_sec × 256 byte 必要 (= SLANG `ARRAY BYTE BUF[count_sec * 256 - 1]` で確保、 SLANG ARRAY[N] = N+1 要素)
 - range check: `(offset_sec + count_sec) <= save_sector_count` (= asset / boot / dir 領域への意図しない書込を防止、 違反で fail)
-- save 領域 = aplication 自前 slot 管理 (= packer は中身知らない、 spec 通り)
+- save 領域 = application 自前 slot 管理 (= packer は中身知らない)
 
 #### save slot 例
 
@@ -116,11 +78,11 @@ FS_SAVE_R(1, 2, SLOT2);
 
 sample: `examples/X1NATIVE_SLFS/SLFSDEMO_SAVE.SL` (= 1 sector save/load + sum 比較)
 
-### Phase 3: generated header (= `#INCLUDE` で `CONST FILE_<NAME>`)
+## asset ID と generated header
 
 asset id を numeric 直書きでなく **compile-time `CONST`** で扱う仕組み。 packer 側で asset id 順を `CONST FILE_GREETING_TXT = 0, FILE_NUMBERS_BIN = 1;` 形式の `.inc` に出力、 SLANG sample で `#INCLUDE` で取り込む。
 
-#### sample (Phase 3)
+### sample
 
 ```sl
 #INCLUDE SLFSDEMO.assets.inc   // generated by slfs-pack
@@ -133,7 +95,7 @@ BEGIN
 END;
 ```
 
-#### identifier 規則
+### identifier 規則
 
 - prefix `FILE_` + user 入力 file 名ベース (= packer 内部 11 byte 切詰めは隠蔽)
 - `ToUpperInvariant()` (= locale 非依存)
@@ -144,13 +106,13 @@ END;
   - `MY ASSET-1.BIN` → `FILE_MY_ASSET_1_BIN`
 - **identifier collision** (= 例 `FILE-A.BIN` / `FILE_A.BIN` 両方 `FILE_FILE_A_BIN`) は packer reject (= rename で回避)
 
-#### header 名 + 配置
+### header 名 + 配置
 
 - header 名 = **input SL stem 基準** (= 例 `SLFSDEMO.SL` → `SLFSDEMO.assets.inc`)、 `-o` basename と decoupling
 - 配置 = `outputDir` (= `-o` の dir)、 slangc に `-I <outputDir>` 自動追加で `#INCLUDE` 解決
 - `--keep-asm` 指定なければ build 成功後 cleanup
 
-#### slfs-pack standalone での `--header`
+### slfs-pack standalone での `--header`
 
 ```sh
 slfs-pack pack -o game.d88 --main main.bin \
@@ -158,7 +120,7 @@ slfs-pack pack -o game.d88 --main main.bin \
   --header game.assets.inc
 ```
 
-### sample (= 数値 ID 直書き)
+### sample (= 数値 ID 直書き、 非推奨)
 
 ```sl
 VAR SIZE;
@@ -170,11 +132,11 @@ BEGIN
 END;
 ```
 
-## slangbuild 使い方
+## slfs-pack CLI
 
-### env file 設定
+### slangbuild 経由
 
-`runtime/env/x1native_slfs.env` (= x1native.env fork + disk: section):
+`runtime/env/x1native_slfs.env` (= `x1native.env` の disk variant):
 
 ```yaml
 defines:
@@ -191,20 +153,20 @@ libraries:
   - ... (= x1native.env と同期、 末尾に libx1native_slfs.yml 追加)
 ```
 
-**注意**: `x1native_slfs.env` は `x1native.env` の disk variant、 **env include 機構未実装のため libraries 同期が必要**。 x1native.env を変更したら slfs.env も合わせて更新する。 将来的 env include は別 issue。
+**注意**: `x1native_slfs.env` は `x1native.env` の disk variant、 env include 機構が未対応のため libraries 同期が必要。 `x1native.env` を変更したら `x1native_slfs.env` も合わせて更新する。
 
-### build
+build:
 
 ```sh
-slangbuild --emit disk -E x1native_slfs SLFSDEMO.SL -o SLFSDEMO \
-  --slfs-add GREETING:examples/X1NATIVE_SLFS/GREETING.TXT \
-  --slfs-add NUMBERS:examples/X1NATIVE_SLFS/NUMBERS.BIN
+slangbuild --emit disk -E x1native_slfs examples/X1NATIVE_SLFS/SLFSDEMO.SL -o SLFSDEMO \
+  --slfs-add GREETING:examples/X1NATIVE_SLFS/assets/GREETING.TXT \
+  --slfs-add NUMBERS:examples/X1NATIVE_SLFS/assets/NUMBERS.BIN
 # または dir 指定で一括 (= non-recursive walk、 各 file の name = basename を 11 char に切詰め)
-slangbuild --emit disk -E x1native_slfs SLFSDEMO.SL -o SLFSDEMO \
+slangbuild --emit disk -E x1native_slfs examples/X1NATIVE_SLFS/SLFSDEMO.SL -o SLFSDEMO \
   --slfs-add examples/X1NATIVE_SLFS/assets/
 ```
 
-### slfs-pack (standalone CLI、 subcommand 構成)
+### standalone CLI
 
 ```sh
 slfs-pack pack    -o <out.d88> --main <main.bin> [--add <spec>] [options]
@@ -247,33 +209,101 @@ slfs-pack extract-save game.d88 -o save_full.bin               # save 全 dump
 slfs-pack extract-save game.d88 --offset 0 --count 2 -o slot1.bin  # 特定 slot
 ```
 
-save 抽出は **raw dump** (= slot 解釈はアプリ側責任、 spec 通り)。 Phase 2 で `FS_SAVE_R/W` API 追加時に同 slot spec で対称化予定。
+save 抽出は **raw dump** (= slot 解釈はアプリ側責任、 spec 通り)。 `FS_SAVE_R` / `FS_SAVE_W` API が同 slot spec で対称化されている。
 
-## 実装
+## 制約
 
-- runtime/libx1native_slfs.asm (= FDC + FS_READ_BY_ID + X1FDC_WORK)
-- runtime/env/x1native_slfs.env
-- src/SLANGCompiler.SlfsPack/ (= packer library + standalone CLI、 C# net8.0)
-- src/SLANGCompiler.Build/DiskImageBuilder.cs (= BuildSlfsPack 分岐、 library 直接呼出)
-- examples/X1NATIVE_SLFS/ (= SLFSDEMO.SL + assets/)
-
-## 制約 (Phase 1)
-
-- 2D 固定 (= 2 sides × 40 tracks × 16 sectors × 256 bytes = 320 KB)、 2HD は Phase 2 以降
+- 2D 固定 (= 2 sides × 40 tracks × 16 sectors × 256 bytes = 320 KB)、 2HD は現状未対応
 - asset 最大 **256 file** (= ID 8-bit)
 - 1 file 最大 **65535 byte** (= byte_size 16-bit、 0 / 上限超は packer reject)
-- save area read/write は `FS_SAVE_R` / `FS_SAVE_W` で対応 (= Phase 2 で実装済、 アプリ自前 slot 管理)
-- name lookup 未実装 (= 数値 ID 直書き、 Phase 3 で `FS_OPEN` 予定)
+- save area read/write は `FS_SAVE_R` / `FS_SAVE_W` で対応 (= アプリ自前 slot 管理)
+- name lookup (`FS_OPEN`) 未実装。 数値 ID 直書きを避けたい場合は generated header (= `#INCLUDE <stem>.assets.inc`) で asset 名 → numeric ID の compile-time 変換が利用可能
 - buffer = sector round-up 分必要 (= byte_size mod 256 切詰めなし、 呼出側責任)
 
-## Phase 3 以降 (= scope 外)
+## ディスク形式
+
+### 全体 layout (= 2D 320 KB 固定)
+
+```
+予約領域 (= logical sector 0 〜 data_area_start_sector - 1):
+  sector 0: ブートセクタ (= HuBASIC IPL header 32 byte + 残り 0 fill、 X1 IPL ROM が読込)
+  sector 1: SLFS スーパーブロック ("SLFS" magic + fields)
+  sector 2〜: ディレクトリ (= 16 byte entry × 16 / sector)
+  sector M〜: main program 本体 (= packer が data_area_start_sector の手前に配置)
+
+データ領域 (= data_area_start_sector 以降): asset 連続配置 (= sorted by filename、 READ ONLY)
+
+セーブ領域 (= save_area_start_sector 以降): free area (= FS_SAVE_R / FS_SAVE_W で read/write、 アプリ自前 slot 管理)
+```
+
+### boot sector (= sector 0、 HuBASIC IPL header)
+
+X1 IPL ROM (= X1_compatible_rom 等) が起動時に sector 0 を `$FE00` に load → header parse → main program 本体を `LoadAddress` に連続 read → IPL ROM OFF → `ExecuteAddress` に jp。 **boot loader Z80 code は不要**。
+
+| offset | size | name | 説明 |
+|---|---|---|---|
+| +00 | 1 | BootFlag | $01 = 起動可 |
+| +01 | 13 | FileName | ASCII space-padded |
+| +0E | 3 | Extension | "Sys" 推奨 |
+| +11 | 1 | Password | $20 = none |
+| +12 | 2 | DataSize | byte (LE)、 main program 全 size |
+| +14 | 2 | LoadAddress | LE、 default $1000 |
+| +16 | 2 | ExecuteAddress | LE、 default $1000 |
+| +18 | 5 | Date | 0 fill OK |
+| +1D | 3 | DiskOffset | byte (LE)、 main program の disk image 内 byte 開始位置 |
+
+### superblock (= sector 1、 256 byte)
+
+| offset | size | name | 説明 |
+|---|---|---|---|
+| +00 | 4 | Magic | "SLFS" |
+| +04 | 1 | Version | 1 |
+| +05 | 1 | Sides | 2 (= 2D 固定) |
+| +06 | 1 | Tracks | 40 |
+| +07 | 1 | SectorsPerTrack | 16 |
+| +08 | 2 | DirStartSector | logical sector index (LE) |
+| +0A | 2 | DirEntryCount | LE |
+| +0C | 2 | DataAreaStartSector | LE |
+| +0E | 2 | SaveAreaStartSector | LE |
+| +10 | 2 | SaveSectorCount | LE |
+| +12 | 16 | VolumeName | ASCII space-padded |
+| +22 | 0xDE | Reserved | 0 fill |
+
+### directory entry (= 16 byte、 16 entry / sector)
+
+| offset | size | name | 説明 |
+|---|---|---|---|
+| +00 | 11 | FileName | ASCII space-padded (= 8.3 風 or 自由、 11 char 超 切詰め) |
+| +0B | 1 | Type | 0 = raw、 1+ = reserved |
+| +0C | 2 | StartSector | logical sector index (LE) |
+| +0E | 2 | ByteSize | LE、 範囲 **1..65535** (= 0 / 64 KB 超は packer reject) |
+
+- ファイル名 sort 前提 (= 11 byte normalized ordinal 昇順、 packer が保証)
+- ID = sorted directory entry index、 範囲 **0..255** (= SLANG `FS_READ_BY_ID(id, buf)` の id 8-bit)
+
+## 内部情報
+
+### 設計思想
+
+- **read-only main + small save area + 256 file 上限** で割り切る (= libmag / libm8a 互換は重い)
+- HuBASIC IPL 互換 boot sector のみで起動性確保、 中身は独自 FS
+- 「program loader」 化しない (= load/exec addr 等 program 属性は dir entry に入れない、 asset FS に徹する)
+
+### 実装
+
+- `runtime/libx1native_slfs.asm` (= FDC + FS_READ_BY_ID + X1FDC_WORK)
+- `runtime/env/x1native_slfs.env`
+- `src/SLANGCompiler.SlfsPack/` (= packer library + standalone CLI、 C# net8.0)
+- `src/SLANGCompiler.Build/DiskImageBuilder.cs` (= BuildSlfsPack 分岐、 library 直接呼出)
+- `examples/X1NATIVE_SLFS/` (= SLFSDEMO.SL + assets/)
+
+### 将来の拡張 (= 現状未対応)
 
 - `FS_OPEN` name lookup + `FS_READ` low-level API
 - 圧縮 type 内部処理 / 物理 CHS API / 2HD geometry
 - env include 機構 (= x1native_slfs.env と x1native.env の drift 解消)
-- 数値 ID → generated `#define` header (= compile 前 packer 走らせて #include)
 
-## reference
+### 出典 / spec
 
 - Issue #212: spec 確定
 - X1 互換 IPL ROM: https://github.com/meister68k/X1_compatible_rom (CC0)、 FDC routine / boot sector spec の fork 元

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -1,7 +1,6 @@
 # SLANG X1 環境ガイド
 
-SLANG compiler の X1 (= シャープ X1 / X1turbo 系) 向け環境一覧と、 OS 非依存
-`x1native` env の使い方。
+SLANG compiler の X1 (= シャープ X1 / X1turbo 系) 向け環境一覧と、 OS 非依存 `x1native` env の使い方。
 
 ## 環境一覧
 
@@ -10,28 +9,64 @@ SLANG compiler の X1 (= シャープ X1 / X1turbo 系) 向け環境一覧と、
 | `x1` | LSX-Dodgers (= 主に X1 上の disk OS) | D88 disk image で配布、 LSX 上で実行 |
 | `lsx` | LSX-Dodgers (= 汎用 LSX) | LSX 系 一般 |
 | `sosx1` | S-OS for X1 / X1turbo | S-OS 系 disk |
-| `x1native` (**新規 Phase A**) | **OS なし** (= X1 hardware 直) | tape boot / monitor load 想定 |
+| `x1native` | **OS なし** (= X1 hardware 直) | cassette tape boot / monitor load |
+| `x1native_slfs` | **OS なし** + SLFS | D88 disk image 配布 + asset I/O ([SLFS](SLFS.md) 参照) |
+
+### 使い分け
+
+X1 / X1turbo 向けでは、 配布形態 (= disk / cassette tape) と OS 依存度 (= LSX-Dodgers / S-OS / OS なし) に応じて環境を使い分けると良いでしょう:
+
+| 状況 | 推奨 env | 補足 |
+|---|---|---|
+| LSX-Dodgers 上で実行する disk file I/O を使うプログラム | `x1` | text 表示は X1 用に高速化、 OS としては LSX-Dodgers に依存 |
+| S-OS for X1 上で実行する disk file I/O を使うプログラム | `sosx1` | X1 固有 (`GRDISP` / PCG / PSG 等) も同梱 |
+| OS なしで起動する cassette tape ゲーム / 単体 binary | `x1native` | `slangbuild --emit tape` で `.tap` / `.wav` を生成、 多段 cassette tape ロードや 1 binary 配布に |
+| OS なしで起動する D88 disk image ゲーム (= asset I/O 含む) | `x1native_slfs` (= [SLFS](SLFS.md)) | `slangbuild --emit disk` で `.d88` を生成、 `FS_READ_BY_ID` / `FS_SAVE_R` / `FS_SAVE_W` で asset 読み書き |
+
+## `x1` env / `lsx` env / `sosx1` env (= 既存 OS 上で動かす)
+
+LSX-Dodgers や S-OS が動いている X1 上で SLANG プログラムを動かす環境。 OS 側の disk file I/O / text I/O を利用できる。
+
+### `lsx` env
+
+LSX-Dodgers ([https://github.com/tablacus/LSX-Dodgers](https://github.com/tablacus/LSX-Dodgers)、 X1 / MZ-700 / 1500 / PC-8801mkIISR 等で CP/M80 や MSX-DOS のソフトを実行するための OS) の標準環境。 機種非依存だが、 X1 専用の text 高速化や PCG 関連は含まれない。 **LSX-Dodgers 1.62c が必要** (= ランタイムが 1.62c の内部アドレスに依存、 詳細は [README.md](../README.md) の「LSX-Dodgers バージョン依存について」)。
+
+### `x1` env
+
+`lsx` env をベースに、 X1 上での text 表示を高速化 + PCG 定義関数を追加した環境。 同じく LSX-Dodgers 1.62c が必要。 `WIDTH` 関数も正常動作する。
+
+### `sosx1` env
+
+S-OS for X1 / X1turbo 上で SLANG プログラムを動かす環境。 S-OS BIOS call ベースの text I/O / file I/O に加えて、 X1 固有のグラフィックス (`GRDISP` / `libx1_grp` / `libx1_sgl`)、 PCG、 PSG、 MAGIC、 CTC 検出 + X1turbo 用 IRQ ベクタパッチを同梱。 X1 / X1turbo 上の S-OS 専用 (= 他機種の S-OS では動作しない)。
+
+build 例:
+```sh
+slangbuild -E x1 -I include examples/STARS_X1.SL -o STARS_X1 --emit disk
+# → images/LSXPROG.d88 (= LSX-Dodgers 1.62c の template disk に書込)
+```
+
+`-E` を `lsx` / `sosx1` に変えると同様に LSX 標準 / S-OS X1 環境の disk image が生成される。
 
 ## `x1native` env — OS 非依存 runtime
 
-LSX / S-OS が動いてない素の X1 上で boot して動く binary を生成する env。
-目標: X1 tape (.tap / .wav) で配布 = Phase B で対応予定 (= 本ガイドは Phase A 完成時点)。
+LSX / S-OS が動いてない素の X1 上で boot して動く binary を生成する env。 cassette tape (`.tap` / `.wav`) または D88 disk image (= [SLFS](SLFS.md) 経由) で配布する。
 
-### scope (Phase A)
+### 対応機能
 
-- **対応**:
-  - **SLANGINIT 初期化**: DI + SP set + __WORK__ clear + **8255 init (port B 入力 mode)** + **text/attribute VRAM clear ($3000-$37FF を space + $2000-$27FF を白)** + cursor 初期化 + MAIN call + inline HALT loop
-  - PRINT: 文字列 + 改行 + 数値、 native sPRINT (= port-mapped text VRAM 書込 + attribute 白で書込)
-  - INKEY (= 0: no-wait, 1: wait 1 回, else: ループ wait)
-  - VSYNC (= 既存 libx1_base.asm reuse)
-- **未対応 (= Phase A scope 外)**:
-  - **PRINT scroll**: 25 行目到達で **最終行に固定上書き** (= port-mapped VRAM の LDIR 不可、 1920 cell × IN+OUT loop 後続 PR で実装)
-  - **CRTC 初期化**: emulator boot ROM / IPL が **WIDTH 80 mode で初期化済** の前提 (= X1_compatible_rom INIT_CRTC は WIDTH 40、 WIDTH 80 パラメタ別途必要、 後続 PR)
-  - WIDTH / SCREEN / LOCATE / PRMODE (= S-OS BIOS 依存、 後続段階で native 実装予定)
-  - file I/O API (FOPEN / FCLOSE / FREAD / FWRITE / FSEEK) = **linker undefined symbol** で reject、 必要なら `lsx` or `sosx1` env を使う
-  - D88 disk image boot (= 既存 `DiskImageBuilder` は OS 上で動く binary を template に追加する流儀、 OS なしには loader 設計が別途必要)
-  - graphics / PSG / PCG / SGL / magic chars (= `libx1_psg.asm` 等が OS_TYPE==0 で LSX 固定 addr 使用、 後続 Phase で native branch 追加)
-  - **unit test の runtime asm 内容検証**: 現状 env YAML pin の 5 件のみ、 「実 SLANG → asm 生成 + 内容 grep」 は CodeGenerator + RuntimeManager setup の複雑性で別 PR (= integration test として slangc CLI spawn ベース予定)。 現状は本 docs の manual verification 手順で代替。
+- **SLANGINIT 初期化**: DI + SP set + __WORK__ clear + 8255 init (port B 入力 mode) + text / attribute VRAM clear (`$3000-$37FF` を space + `$2000-$27FF` を白) + cursor 初期化 + MAIN call + inline HALT loop
+- **PRINT** (= native sPRINT、 port-mapped text VRAM 書込 + attribute 白、 25 行目到達時の自動 scroll 対応)
+- **INKEY** (= 0: no-wait、 1: wait 1 回、 else: ループ wait)
+- **VSYNC** (= 既存 `libx1_base.asm` reuse)
+- **CRTC 初期化** + **WIDTH** / **LOCATE** / **SCREEN** + **HOME** / **CLEAR** + kanji selector
+- **graphics** (`GRDISP` / `GRCLS`) + sPRINT attribute (= 既存 X1 graphics 4 library reuse)
+- **PSG** (= `libx1_psg` 統合 + CTC IM2 vector + 高位 RAM ISR trampoline、 `PSG_INIT(0)` 後の不正 OUT guard)
+
+### 未対応
+
+- file I/O API (= `FOPEN` / `FCLOSE` / `FREAD` / `FWRITE` / `FSEEK`) は linker undefined symbol で reject、 必要なら `lsx` / `sosx1` env を使う。 asset 配布は [SLFS](SLFS.md) (`x1native_slfs` env) で対応
+- D88 disk image を OS 経由で boot する経路 (= `x1` / `sosx1` 経路) は対象外。 disk image 配布は `x1native_slfs` env (= SLFS)
+- `PRMODE` 等の S-OS BIOS 系関数は native 未実装
+- PCG / SGL / magic chars (= `libx1_pcg` / `libx1_sgl` / `libx1_magic` 内一部関数が OS_TYPE==0 で LSX 固定 addr 使用)
 
 ### env 設定
 
@@ -41,15 +76,15 @@ env_type: 1           # X1 hardware (= 既存 x1.env と同じ identity)
 os_type: 4            # 新規割当、 X1 native / no OS
 defines:
   X1NATIVE: 1         # SLANG `#IF X1NATIVE` 条件分岐用
-default_org: "$1000"  # X1 tape boot 慣習 (= Phase B で tap header load addr と整合)
-output: bin           # Phase A = flat binary のみ
+default_org: "$1000"  # X1 tape boot 慣習 (= tape header load addr と整合)
+output: bin           # flat binary のみ
 libraries:
   - runtime.yml
   - libfloat.yml
-  - libx1native_base.yml   # SLANGINIT / STOP / sWORK (新規)
-  - libx1native_input.yml  # sGETKY 等 (新規、 X1 sub CPU $1900 polling)
-  - libx1native_print.yml  # sPRINT 等 (新規、 X1 text VRAM $3000 直書き)
-  - libx1_base.yml         # VSYNC reuse (既存、 LSX 非依存)
+  - libx1native_base.yml   # SLANGINIT / STOP / sWORK
+  - libx1native_input.yml  # sGETKY 等 (= X1 sub CPU $1900 polling)
+  - libx1native_print.yml  # sPRINT 等 (= X1 text VRAM $3000 直書き)
+  - libx1_base.yml         # VSYNC reuse (= LSX 非依存)
   - libcompress.yml
   - libsoroban.yml
 ```
@@ -73,41 +108,15 @@ END;
 
 build:
 ```sh
-SLANGC=src/SLANGCompiler.CLI/bin/Debug/net8.0/slangc.dll
-dotnet $SLANGC -E x1native -o HELLO.asm examples/X1NATIVE_HELLO.SL
-# AILZ80ASM 等で HELLO.asm → HELLO.bin
+slangbuild -E x1native -I include examples/X1NATIVE_HELLO.SL -o HELLO --emit tape
+# → HELLO.tap (= cassette tape image、 X1 emulator で tape mount + boot)
 ```
 
-### 動作確認 (= Phase A は emulator memory load)
-
-1. `HELLO.bin` を X1 emulator (xmil / X-millenium 等) の monitor / memory load 機能で `$1000` に流し込む
-2. PC = `$1000` にセットして実行
-3. 期待: `HELLO, X1 NATIVE!` 表示 + キー入力で停止解除
-
-D88 boot による実用的な配布は **Phase B (= tap / wav 出力対応)** で対応予定。
-
-### 検証 (= LSX 切り離し confirm)
-
-生成 asm 内に LSX 痕跡が含まれていないことを確認:
-```sh
-# comment / attribution 行を除外してから check
-grep -v '^\s*;' HELLO.asm | grep -E "CALL.*\\\$0005|\(\\\$0001\)|\\\$EE8C|\\\$EE8E|\\\$EE92"
-# 何も出ないこと (= LSX BDOS call / LSX work area / LSX 固定 addr 不在)
-```
-
-### ライセンス / 出典
-
-x1native runtime asm は以下を出典明示で参考実装:
-- **LSX-Dodgers** (MIT、 Gaku 1995): SLANGINIT 構造 / sWORK pattern / 上位 routine 構造
-- **X1_compatible_rom** (CC0、 Meister 2020-、 https://github.com/meister68k/X1_compatible_rom): KBHIT / WAIT_80C49_WR / READ_80C49 / VRAM layout / TXTCUR 定数
-
-各 asm file の header に attribution comment あり。
+cassette tape (`.tap` / `.wav`) や D88 disk image での配布手順は次節以降を参照してください。
 
 ## tape (.tap / .wav) 出力
 
-`x1native` env の bin を **X1 cassette tape format (.tap)** または **PCM WAV** で
-出力する。 tape header の load / exec address で **OS なし auto boot** を実現
-(= IPL ROM が tape header を読んで自動 load + exec)。
+`x1native` env の bin を **X1 cassette tape format (.tap)** または **PCM WAV** で出力する。 tape header の load / exec address で **OS なし auto boot** を実現 (= IPL ROM が tape header を読んで自動 load + exec)。
 
 ### env file `tape:` section
 
@@ -139,8 +148,7 @@ slangbuild ... --emit tape --tape-load 0x8000  # 0x prefix も可
 CLI option:
 - `--emit tape` (= `--emit bin|disk|tape` の 3 番目)
 - `--wav` (= .wav も同時生成、 `--emit tape` 必須)
-- `--tape-name <s>` / `--tape-load <addr>` / `--tape-exec <addr>` (= env override、
-  `--emit tape` 必須)
+- `--tape-name <s>` / `--tape-load <addr>` / `--tape-exec <addr>` (= env override、 `--emit tape` 必須)
 
 ### emulator 動作確認
 
@@ -156,7 +164,7 @@ CLI option:
 
 ### 制限
 
-- file I/O API (FOPEN/FCLOSE 等) は x1native 同様 未対応 (= ゲーム asset 用途は **SLFS** 参照、 下記)
+- file I/O API (FOPEN/FCLOSE 等) は x1native 同様未対応 (= ゲーム asset 用途は [SLFS](SLFS.md) 参照)
 - raw bin output env のみ対応 (= `output: cmt` 系 / c64 oscar_c 系では `--emit tape` 不可)
 
 ## SLFS (= SLANG File System、 ゲーム専用 minimal file I/O)
@@ -164,7 +172,7 @@ CLI option:
 x1native env 専用、 D88 disk image から asset 読込。 詳細は [docs/SLFS.md](SLFS.md)。
 
 - env: `x1native_slfs` (= x1native.env の disk variant)
-- API: `FS_READ_BY_ID(id, buffer)` (= 数値 ID で asset 読込、 戻り HL=byte_size / 0=fail)
+- API: `FS_READ_BY_ID(id, buffer)` (= 数値 ID で asset 読込、 戻り HL=byte_size / 0=fail)、 `FS_SAVE_R` / `FS_SAVE_W` (= save area read/write)
 - 制約: 2D 320 KB 固定、 256 file 上限、 1 file 65535 byte 上限
 - build: `slangbuild --emit disk -E x1native_slfs SAMPLE.SL -o SAMPLE --slfs-add path/to/assets/`
 
@@ -190,13 +198,13 @@ SLANG の `#MODULE $XXXX [RESIDENT] ~ #END` で overlay 定義すると、 `slan
 
 #### Local mode (= RESIDENT 指定なし、 default)
 
-`#MODULE $XXXX` (= RESIDENT 省略) では overlay 内に runtime routine が **local copy** される (= 各 overlay が独立 runtime 持つ)。 runtime work sym (= `sXYADR` / `AT_WIDTH` 等) は main 側 sWORK を **EXTERN 参照** (= main work area 共有、 Issue #209 fix で対応)。 overlay binary は RESIDENT mode より大きい (= 例: 36 → 517 byte) が、 通常の overlay 運用 (= main work area 共有) で動作する。
+`#MODULE $XXXX` (= RESIDENT 省略) では overlay 内に runtime routine が **local copy** される (= 各 overlay が独立 runtime 持つ)。 runtime work sym (= `sXYADR` / `AT_WIDTH` 等) は main 側 sWORK を **EXTERN 参照** (= main work area 共有)。 overlay binary は RESIDENT mode より大きい (= 例: 36 → 517 byte) が、 通常の overlay 運用 (= main work area 共有) で動作する。
 
 両 mode とも overlay 内で `PRINT` 等 SLANG runtime call が使える。 sample 例:
 - RESIDENT mode: `examples/X1NATIVE_MTREAD/MTREADSMP.SL` (= overlay 36 byte、 推奨)
 - Local mode: `examples/X1NATIVE_MTREAD/MTREADSMP_LOCAL.SL` (= overlay 517 byte、 self-contained 寄り)
 
-注意: **self-contained overlay (= main work area 完全上書き、 overlay 単独動作)** は本 PR scope 外 (= 別 Issue で検討)。
+注意: **self-contained overlay (= main work area 完全上書き、 overlay 単独動作)** は現状未対応。
 
 例 (= `examples/X1NATIVE_MTREAD/MTREADSMP.SL`):
 ```sl
@@ -231,20 +239,32 @@ slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
 #    overlay 36 byte の小型)
 ```
 
-### 注意点 / 制約
+### 注意点
 
 - X1 tape は **1 段目読込完了で auto stop**、 2 段目読込時 MTREAD/MTREADJP が sub CPU 経由で自動再生再開
-- tape read は bit-level timing critical (~185µs/bit)、 bit-stream read 部分 (= `_mtload_block` 内) は完全 DI 維持 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
-- ただし MTREAD 内の deck control 呼出 (= `MT_CTRL_PLAY` / `MT_CTRL_STOP` 経由 `MT_CTRL`) は sub CPU 通信 sync のため **一時 EI** する (= X1_compatible_rom 元 source 由来、 数十 cycle 程度の短い window)、 PSG IRQ 等が間に入る可能性あり (= 元 source の必要 sync で削除不可)。 bit-stream read 部分は影響なし
 - load 先 addr は `$1000-$FFDF` 範囲推奨 (= ISR trampoline / stack 衝突回避)
 - **overlay tape stage の exec addr は意味なし** (= header 上 formality で load と同値書込、 MTREAD は次 block の data を読むだけで exec は使わない)
-- `RESIDENT` 指定推奨 (= 上記)、 Local default では overlay 内 SLANG runtime call assemble fail する
+- `RESIDENT` 指定で overlay binary が小型化 (= shared promotion で main runtime を再利用)、 推奨。 Local default も `_CRTCD` 等の sWORK BSS sym を main 側と共有して動作する。 self-contained overlay (= main work area 完全上書き、 overlay 単独動作) は現状未対応
 
 ### 既存 1 binary tape との互換
 
 `#MODULE` 未使用 (= overlay 0 件) の SLANG コードは従来通り 1 binary .tap として build される (= bit-exact 互換)。 既存 sample (`X1NATIVE_HELLO.SL` 等) は影響なし。
 
-## x1native ABI 予約領域 + IRQ 設計
+## 制約 / 注意点
+
+### tape build size 制約
+
+- 実質上限 `load + size - 1 <= $FFDF` (= 末尾 32 byte は runtime 予約)
+- 現状 size reject は未実装 (= 本 docs 明記のみ、 `--emit tape` 時の `> $FFDF` reject 強化は今後の課題)
+
+### interrupt 制約
+
+- x1native runtime は **BIOS ROM routine を使わない前提** で動作
+- user SLANG コードが ROM call 中に interrupt 発生した場合、 RETI 後の復帰先が ROM routine だと破綻し得る (= 「ROM call 中の interrupt 復帰までは保証しない」)
+
+## `x1native` 内部設計
+
+(= 以下は `x1native` / `x1native_slfs` env のみに関する設計詳細。 `x1` / `lsx` / `sosx1` 環境には適用されない)
 
 ### 予約領域
 
@@ -268,23 +288,15 @@ x1native runtime は以下のメモリ領域を予約しており、 SLANG プ�
   - 将来 Arkos Tracker 等 別 IRQ driver 入れたとき干渉しない設計
 - 機種判定 / `CALL $1FF7` / S-OS vector 借用 (`$0058` / `$F830`) は使わない、 自前 IM2 vector のため normal / turbo 区別不要 (= ROM bank が $0000-$7FFF にあっても `$FFE0-$FFFF` は常に RAM)
 
-### tape build size 制約
+### tape read 内部処理
 
-- 実質上限 `load + size - 1 <= $FFDF` (= 末尾 32 byte は runtime 予約)
-- 現状 size reject は未実装 (= MVP では本 docs 明記のみ、 別 PR で `--emit tape` 時の `> $FFDF` reject 強化予定)
+- tape read は bit-level timing critical (~185µs/bit)、 bit-stream read 部分 (= `_mtload_block` 内) は完全 DI 維持 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
+- ただし MTREAD 内の deck control 呼出 (= `MT_CTRL_PLAY` / `MT_CTRL_STOP` 経由 `MT_CTRL`) は sub CPU 通信 sync のため一時 EI する (= X1_compatible_rom 元 source 由来、 数十 cycle 程度の短い window)、 PSG IRQ 等が間に入る可能性あり (= 元 source の必要 sync で削除不可)。 bit-stream read 部分は影響なし
 
-### interrupt 制約
+### ライセンス / 出典
 
-- x1native runtime は **BIOS ROM routine を使わない前提** で動作
-- user SLANG コードが ROM call 中に interrupt 発生した場合、 RETI 後の復帰先が ROM routine だと破綻し得る (= 「ROM call 中の interrupt 復帰までは保証しない」)
+x1native runtime asm は以下を出典明示で参考実装:
+- **LSX-Dodgers** (MIT、 Gaku 1995): SLANGINIT 構造 / sWORK pattern / 上位 routine 構造
+- **X1_compatible_rom** (CC0、 Meister 2020-、 https://github.com/meister68k/X1_compatible_rom): KBHIT / WAIT_80C49_WR / READ_80C49 / VRAM layout / TXTCUR 定数
 
-## 既存 env (= LSX / S-OS) との比較
-
-既存 `x1.env` (LSX-Dodgers) / `sosx1.env` (S-OS X1) は **完全に無触**、 既存 SLANG
-コード regression なし。 必要に応じて使い分け:
-
-| 要件 | 推奨 env |
-|---|---|
-| LSX-Dodgers disk 上で配布 / disk file I/O 使う | `x1` |
-| S-OS for X1 disk 上で配布 | `sosx1` |
-| **OS なしで起動 / tape boot 用 / 単体 binary** | `x1native` (Phase A) |
+各 asm file の header に attribution comment あり。

--- a/src/SLANGCompiler.Build/Program.cs
+++ b/src/SLANGCompiler.Build/Program.cs
@@ -13,7 +13,7 @@ namespace SLANGCompiler.Build;
 /// </summary>
 internal class Program
 {
-    private const string Version = "0.24.1";
+    private const string Version = "0.25.0";
 
     public static int Main(string[] args)
     {

--- a/src/SLANGCompiler.Build/SLANGCompiler.Build.csproj
+++ b/src/SLANGCompiler.Build/SLANGCompiler.Build.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slangbuild</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.13.0</Version>
+    <Version>0.25.0</Version>
     <AssemblyTitle>SLANG Build Driver (two-stage assembler)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -10,7 +10,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.24.1";
+    const string Version = "0.25.0";
 
     static int Main(string[] args)
     {

--- a/src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj
+++ b/src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slangc</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.13.0</Version>
+    <Version>0.25.0</Version>
     <AssemblyTitle>SLANG Compiler</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SLANGCompiler.SlfsPack/SLANGCompiler.SlfsPack.csproj
+++ b/src/SLANGCompiler.SlfsPack/SLANGCompiler.SlfsPack.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slfs-pack</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.1.0</Version>
+    <Version>0.25.0</Version>
     <AssemblyTitle>SLFS packer (SLANG ゲーム専用 file system)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary

- v0.24.1 以降に積んだ x1native env / cassette tape 出力 / SLFS / Local mode overlay fix (#209) / C64 最低限ゲーム API / ARRAY initializer 全網羅 を v0.25.0 として取りまとめ。
- Version 表記 (CLI / Build / README) を 0.25.0 に bump、 CHANGELOG の Unreleased を Version 0.25.0 にまとめ直し、 開発内部タグ (Phase A/B、 v3b-E、 scope 外 等) を削除して user 視点のカテゴリで再構成。
- README / docs/X1.md / docs/SLFS.md / docs/C64.md を v0.25.0 時点の状態に整理 (= x1native / x1native_slfs 環境節追加、 SLFS docs を Quick start ファーストの user 向け順序に reorder、 C64 backend の experimental タグ外し + 最小ゲーム API sample section 独立、 x1native 内部設計を scope 明示)。

## Test plan

- [x] `dotnet test tests/SLANGCompiler.Tests/SLANGCompiler.Tests.csproj` 全 pass (= ローカル環境で完走確認)
- [x] README / docs/X1.md / docs/SLFS.md / docs/C64.md / CHANGELOG.md の最終 review
- [x] `slangbuild -E x1native -I include examples/X1NATIVE_HELLO.SL -o /tmp/HELLO --emit tape` smoke
- [x] `slangbuild --emit disk -E x1native_slfs examples/X1NATIVE_SLFS/SLFSDEMO.SL -o /tmp/SLFSDEMO --slfs-add examples/X1NATIVE_SLFS/assets/` smoke
- [x] `slangbuild -E c64 -I include examples/c64/MMAPVIC.SL -o /tmp/MMAPVIC` smoke
- [x] release tag (= annotated `v0.25.0`) + GitHub Release (= \`--prerelease\`) はマージ後

🤖 Generated with [Claude Code](https://claude.com/claude-code)