### PR TITLE
publish.sh: examples X1NATIVE_SLFS / X1NATIVE_MTREAD / c64 の漏れ修正 (v0.25.0 hotfix)

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -16,11 +16,12 @@ createRelease() {
   cp -r ../../runtime .
   # examples: SLANGソースのみ（ビルド成果物除外）
   # top-level の *.SL と、サブディレクトリ chip / spr / tile / tilespr / ui /
-  # pc80mk2 から *.SL / *.sl / README.md / *.json / *.mml のみ whitelist 方式で
-  # 拾う。*.ASM / *.LST / *.SYM / *.bin / PROG.com 等のビルド成果物は含めない。
+  # pc80mk2 / c64 / X1NATIVE_MTREAD から *.SL / *.sl / README.md / *.json /
+  # *.mml のみ whitelist 方式で拾う。*.ASM / *.LST / *.SYM / *.bin / PROG.com
+  # 等のビルド成果物は含めない。
   mkdir -p examples
   cp ../../examples/*.SL examples/ 2>/dev/null
-  for sub in chip spr tile tilespr ui pc80mk2; do
+  for sub in chip spr tile tilespr ui pc80mk2 c64 X1NATIVE_MTREAD; do
     if [ -d "../../examples/$sub" ]; then
       mkdir -p "examples/$sub"
       cp ../../examples/$sub/*.SL        "examples/$sub/" 2>/dev/null
@@ -30,6 +31,16 @@ createRelease() {
       cp ../../examples/$sub/*.mml       "examples/$sub/" 2>/dev/null
     fi
   done
+
+  # examples/X1NATIVE_SLFS: SLFS demo の SL + asset (= 任意 binary、 *.TXT /
+  # *.BIN 等)。 SLANG runtime 同梱の slfs-pack が pack するための材料。
+  # asset は whitelist 拡張子に当てはまらないため assets/ subdir を丸ごと拾う
+  # (= 現状 GREETING.TXT / NUMBERS.BIN のみ、 将来 asset 追加時も拡張不要)。
+  if [ -d "../../examples/X1NATIVE_SLFS" ]; then
+    mkdir -p examples/X1NATIVE_SLFS/assets
+    cp ../../examples/X1NATIVE_SLFS/*.SL          examples/X1NATIVE_SLFS/         2>/dev/null
+    cp ../../examples/X1NATIVE_SLFS/assets/*      examples/X1NATIVE_SLFS/assets/  2>/dev/null
+  fi
 
   # examples/zxn は ZX Spectrum Next 用 (= asset binary も配布対象)。
   # NextDAW Runtime Player (= NextDAW_RuntimePlayer_E000.bin) は


### PR DESCRIPTION
## Summary

v0.25.0 リリース後の publish.sh で 4 platform 配布 zip を生成したところ、 v0.25.0 で新規追加した examples subdir 3 件が **全て漏れ**ていたため修正。

- `examples/c64/` (= 9 sample: SPRITE / FMANDEL / JOYSPR / SIDSFX / SIDBGM / SIDOVERLAY / SIDBGM_SFX / HISCORE / MMAPVIC)
- `examples/X1NATIVE_MTREAD/` (= MTREADSMP.SL / MTREADSMP_LOCAL.SL)
- `examples/X1NATIVE_SLFS/` (= SLFSDEMO.SL / SLFSDEMO_SAVE.SL + assets/GREETING.TXT / assets/NUMBERS.BIN)

原因は publish.sh の sub directory whitelist が `chip / spr / tile / tilespr / ui / pc80mk2` 固定で、 v0.25.0 で増えた 3 subdir が拾われていなかった。

修正方針:
- `c64` / `X1NATIVE_MTREAD` は既存 whitelist (= `*.SL` / `*.sl` / `README.md` / `*.json` / `*.mml`) で十分なので sub list に追加
- `X1NATIVE_SLFS` は asset binary (= `*.TXT` / `*.BIN` 等) を含む必要があるため、 `assets/` subdir を丸ごと cp する dedicated block を追加 (= 既存 `zxn` block と同 pattern)

merge 後の流れ:

1. main 同期 → 既存 tag `v0.25.0` を main の新 head に re-point (= delete + re-create)
2. tag push (force) → `gh release` 未作成のため draft 化 risk なし
3. `./publish.sh 0.25.0` 再実行 → `gh release create --prerelease` で公開

## Test plan

- [x] `./publish.sh 0.25.0` ローカル再実行で 4 zip 生成
- [x] `unzip -l SLANG-compiler-0.25.0-osx-arm64.zip` で `examples/c64/` / `examples/X1NATIVE_MTREAD/` / `examples/X1NATIVE_SLFS/` (+ `assets/`) を確認
- [x] build 産物 (= `.bin` / `.LST` / `.tap` / `.wav` / `.prg` / `.asm` / `.map` / `.lbl` / `.int` / `.log`) が examples/ 配下に含まれていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)