### PR TITLE
chore(x1 Arkos): publish.sh に X1_ARKOS sample 収載 + .gitignore の runtime asm trap 修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,11 @@ apps/PROG.*
 !tests/**/fixtures/**/*.asm
 !tests/**/fixtures/**/*.ASM
 
+# runtime/ 配下は全て source asm (= build はここで行わない)。 *.ASM rule が
+# case-insensitive FS で source の .asm も巻き込むため明示的に ignore 除外する
+# (= 新規 runtime asm を git add -f せずに済むように)。
+!runtime/**/*.asm
+
 # disk image build 出力先 (= make ENV=lsx disk_image / slangbuild --emit disk
 # で書き換えられる作業ファイル)。pristine template は images/templates/ に
 # 分離済み (PR #157)。

--- a/publish.sh
+++ b/publish.sh
@@ -54,6 +54,20 @@ createRelease() {
     cp ../../examples/zxn/Makefile examples/zxn/ 2>/dev/null
   fi
 
+  # examples/X1_ARKOS は Arkos Tracker driver sample (AKG / AKM)。 SL + Makefile +
+  # README + 楽曲/効果音データ (.AKG / .AKM / .AKX、 Arkos export 生データ) を配布。
+  # driver bin (PSGAK*_8000.bin) / *.sizes.inc / *.assets.inc / *.d88 / *.tap 等の
+  # ビルド成果物は Makefile が RASM / slangbuild で再生成するため含めない。
+  if [ -d "../../examples/X1_ARKOS" ]; then
+    mkdir -p examples/X1_ARKOS
+    cp ../../examples/X1_ARKOS/*.SL       examples/X1_ARKOS/ 2>/dev/null
+    cp ../../examples/X1_ARKOS/README.md  examples/X1_ARKOS/ 2>/dev/null
+    cp ../../examples/X1_ARKOS/Makefile   examples/X1_ARKOS/ 2>/dev/null
+    cp ../../examples/X1_ARKOS/*.AKG      examples/X1_ARKOS/ 2>/dev/null
+    cp ../../examples/X1_ARKOS/*.AKM      examples/X1_ARKOS/ 2>/dev/null
+    cp ../../examples/X1_ARKOS/*.AKX      examples/X1_ARKOS/ 2>/dev/null
+  fi
+
   # assets: UILIB 用フォント / CHARMAP 再生成ソース (PNG, JSON)
   if [ -d "../../assets" ]; then
     cp -r ../../assets .


### PR DESCRIPTION
## 概要

Arkos Tracker driver sample (AKG / AKM、 PR #222 / #223) の後始末。 配布 zip への収載と、 開発時の地味な papercut 2 件を解消する軽い chore。

## 変更点

### publish.sh: examples/X1_ARKOS を配布対象に追加
- `ARKOSMP.SL` (AKG) / `AKMMP.SL` (AKM) / `README.md` / `Makefile` + 楽曲/効果音データ (`.AKG` / `.AKM` / `.AKX`、 Arkos export 生データ) を配布
- driver bin (`PSGAK*_8000.bin`) / `*.sizes.inc` / `*.assets.inc` / `*.d88` / `*.tap` 等のビルド成果物は含めない (= Makefile が RASM / slangbuild で再生成)
- zxn / X1NATIVE_SLFS と同じ whitelist 方式

### .gitignore: runtime source asm の trap 修正
- `*.ASM` rule が case-insensitive FS (macOS) で runtime source の `.asm` も巻き込み、 新規 runtime asm 追加時に `git add -f` が必要だった (PR #222 で踏んだ)
- `!runtime/**/*.asm` で明示除外。 `examples/` / `apps/` の build 成果物 (`*.ASM` 大文字) の ignore は維持

### runtime/x1/prebuilt/ の dev cruft 削除
- AKG 開発初期の `PSGAKG_4000.bin` / `PSGAKG_C300.bin` (untracked、 現在未参照) をローカル削除 (= git 管理外のため diff には出ない)

## 検証

- publish.sh の X1_ARKOS コピーブロックを temp staging で実行 → source/asset 7 file のみ収載、 ビルド成果物の混入なしを確認
- `.gitignore`: `git add -n` の実挙動で「runtime の新規 .asm は add 可能 / examples の .ASM は依然 ignored」を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)