### PR TITLE
fix(x1native): HEX2$/HEX4$ の表示崩れ修正 + SPC$/TAB$ 追加 (#221)

### DIFF
--- a/examples/PRINTTEST/Makefile
+++ b/examples/PRINTTEST/Makefile
@@ -1,0 +1,40 @@
+# ====================================================================================================
+# PRINTTEST — PRINT 系メソッド表示確認サンプル (Issue #221 回帰確認も兼ねる)
+#
+#   make x1            → PRINTTEST_x1.d88       (LSX-Dodgers、 基準)
+#   make sosx1         → PRINTTEST_sosx1.d88    (S-OS for X1、 基準)
+#   make x1native      → PRINTTEST_x1native.tap (OS なし cassette tape)
+#   make x1native_slfs → PRINTTEST_slfs.d88     (OS なし SLFS disk)
+#   make all / make clean
+#
+# x1 / sosx1 を正常表示の基準として、 x1native / x1native_slfs と見比べる。
+# tool override 可: SLANGBUILD= / NDC= / HUDISK= / MONO=
+# ====================================================================================================
+
+SLANGBUILD ?= slangbuild
+NDC        ?= ndc
+HUDISK     ?= $(HOME)/.config/SLANG/tools/HuDisk.exe
+MONO       ?= mono
+
+INCDIR = -I ../../include -I .
+SRC    = PRINTTEST.SL
+
+x1:
+	$(SLANGBUILD) -E x1 $(INCDIR) $(SRC) -o PRINTTEST_x1 --emit disk
+
+sosx1:
+	$(SLANGBUILD) -E sosx1 $(INCDIR) $(SRC) -o PRINTTEST_sosx1 --emit disk
+
+x1native:
+	$(SLANGBUILD) -E x1native $(INCDIR) $(SRC) -o PRINTTEST_x1native --emit tape
+
+x1native_slfs:
+	$(SLANGBUILD) -E x1native_slfs $(INCDIR) $(SRC) -o PRINTTEST_slfs --emit disk
+
+all: x1 sosx1 x1native x1native_slfs
+
+clean:
+	rm -f PRINTTEST_x1.* PRINTTEST_sosx1.* PRINTTEST_x1native.* PRINTTEST_slfs.* \
+	      *.ASM *.LST *.sym *.bin
+
+.PHONY: x1 sosx1 x1native x1native_slfs all clean

--- a/examples/PRINTTEST/PRINTTEST.SL
+++ b/examples/PRINTTEST/PRINTTEST.SL
@@ -1,0 +1,50 @@
+// ====================================================================================================
+// PRINTTEST.SL — PRINT 系メソッド表示確認サンプル
+//
+// PRINT と各書式関数を一通り出力する。 全 X1 系 env (x1 / sosx1 / x1native /
+// x1native_slfs) で同じ表示になることを確認する (= Issue #221 の HEX2$/HEX4$
+// 並び順バグ + SPC$/TAB$ 欠落の回帰確認も兼ねる)。 各行の右に期待値コメント付き。
+//
+// 網羅する print 系関数 (= 内部の fall-through chain 別):
+//   P10           : PRINT(数値)
+//   MPRNT         : PRINT("文字列リテラル")
+//   PCRONE→PCR→PCR1→PSTR→PRT : / (改行)
+//   PHEX4→PHEX2→PHEX : HEX4$ / HEX2$        ← #221 で崩れる報告
+//   P10toN        : FORM$(v, n)
+//   P10to5→P10toN : DECI$(v)
+//   PSIGN→P10     : PN$(v)
+//   PCHR→PRT      : CHR$(v)
+//   PSTR→PRT      : STR$(char, n)
+//   PSPC          : SPC$(n)    ← 旧 x1native では未定義、 #221 修正で追加
+//   PTAB          : TAB$(n)    ← 同上
+//
+// 注: FL$ (PFLOAT) / MSG$ / MSX$ は別途 (float / 文字列アドレス要)。
+// ====================================================================================================
+
+VAR K;
+
+MAIN()
+{
+    PRINT("=== PRINT TEST (#221) ===", /);
+
+    // 期待値は右コメント (= x1 / sosx1 基準)
+    PRINT("DEC : ", 12345, /);                       // DEC : 12345
+    PRINT("PN- : ", PN$(0 - 123), /);                // PN- : -123
+    PRINT("PN+ : ", PN$(123), /);                    // PN+ : 123
+    PRINT("HEX2: ", HEX2$($AB), /);                  // HEX2: AB
+    PRINT("HEX4: ", HEX4$($1FA2), /);                // HEX4: 1FA2   ← 報告された崩れ
+    PRINT("HEX4: ", HEX4$($00FF), /);                // HEX4: 00FF
+    PRINT("HEX4: ", HEX4$($EEC0), /);                // HEX4: EEC0
+    PRINT("FORM: [", FORM$(42, 6), "]", /);          // FORM: [    42]
+    PRINT("DECI: [", DECI$(42), "]", /);             // DECI: [   42]
+    PRINT("CHR : ", CHR$(65), CHR$(66), CHR$(67), /);// CHR : ABC
+    PRINT("STR : ", STR$($2A, 10), /);               // STR : **********
+    PRINT("SPC : [", SPC$(5), "]", /);               // SPC : [     ]  (5 空白)
+    PRINT("TAB : [", TAB$(3), "]", /);               // TAB : [<tab×3>]
+
+    PRINT("=== END ===", /);
+
+    // キー待ち (= x1native は OS に戻らないので画面保持。 x1/sosx1 でも待つ)
+    K = 0;
+    WHILE K == 0 { K = INKEY(0); }
+}

--- a/runtime/libx1native_print.asm
+++ b/runtime/libx1native_print.asm
@@ -340,6 +340,22 @@ DEC DE
 JR .pstr1
 
 
+; @name PSPC
+; @resident shared
+; @param_count 1
+; @calls PCR1
+LD E,' '
+JR PCR1
+
+
+; @name PTAB
+; @resident shared
+; @param_count 1
+; @calls PCR1
+LD E,$09
+JR PCR1
+
+
 ; @name PCHR
 ; @resident shared
 ; @calls PRT
@@ -352,13 +368,6 @@ LD A, L
 OR A
 JR NZ, PRT
 RET
-
-
-; @name PRT
-; @resident shared
-; @param_count 1
-; @calls sPRINT
-JP sPRINT
 
 
 ; @name PHEX4
@@ -390,6 +399,16 @@ CALL PRT
 
 POP AF
 CALL SASC
+; 2 桁目 (low nibble) は直後の PRT へ fall-through して出力する。
+; PRT は必ず PHEX の直後に置くこと (= libx1_print.asm と同じ並び。 順序を
+; 崩すと PHEX が次関数へ落ちて暴走する: Issue #221)。
+
+
+; @name PRT
+; @resident shared
+; @param_count 1
+; @calls sPRINT
+JP sPRINT
 
 
 ; @name PMSG


### PR DESCRIPTION
Closes #221

## 概要

`x1native` / `x1native_slfs` で `HEX2$()` / `HEX4$()` が大量のゴミを無限に出力して暴走する問題 (Issue #221) を修正する。 あわせて x1native の print library に欠落していた `SPC$` / `TAB$` を補完する。

## 根本原因

`libx1native_print.asm` の `PHEX` (hex 2 桁出力) は、 **2 桁目 (low nibble) を「直後に置かれた `PRT` へ fall-through して出力する」設計** (末尾に `CALL PRT` も `RET` も書かれていない)。 正常動作する `libx1_print.asm` (x1 / sosx1) では `PHEX` の直後が `PRT` なので成立していた。

ところが `libx1native_print.asm` では `PRT` が `PHEX4` より**前**に置かれ、 `PHEX` の直後が `PMSG` (= HL から `$0D` が出るまで memory を print し続けるループ) になっていた。 このため `PHEX` が `PMSG` → `PMSX1` に落下し、 **memory のゴミを `$0D` に当たるまで延々出力 = 「無限にゴミ」** という症状になっていた。 `PHEX` のコード自体は x1 版と同一で、 **関数の並び順だけが違っていた**。

## 修正

- `PRT` ブロックを `PHEX` の直後へ移動 (= `libx1_print.asm` と同じ並び)。 `PHEX` が `PRT` (`JP sPRINT`) に fall-through して 2 桁目を出力し、 呼出元へ復帰するよう修正
- `PHEX` 末尾に「`PRT` は必ず直後に置くこと」の依存コメントを追記 (再発防止)
- `libx1native_print.asm` に欠落していた `PSPC` (`SPC$`) / `PTAB` (`TAB$`) を `libx1_print.asm` から移植 (= `LD E,x` / `JR PCR1` の自己完結型)
- `examples/PRINTTEST/` を追加 (PRINT 系メソッド一覧表示サンプル + Makefile)。 全 X1 系 env で表示一致を確認でき、 #221 の回帰確認も兼ねる

## 検証

- リンク後 ASM で `PHEX → CALL SASC → PRT (JP sPRINT) → PMSG` の並びを静的確認
- **x1native 実機/emu で全行が x1 / sosx1 と同じ表示**になることを確認 (HEX2$ `AB` / HEX4$ `1FA2` / `00FF` / `EEC0`、 FORM$ / DECI$ / CHR$ / STR$ / SPC$ / TAB$、 `=== END ===` まで到達)
- 全 4 env (x1 / sosx1 / x1native / x1native_slfs) で PRINTTEST ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)