### PR TITLE
fix(tests): resolve dotnet test hang (pipe-buffer & MSBuild node-reuse deadlock)

### DIFF
--- a/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/BuildIntegrationTests.cs
@@ -66,6 +66,7 @@ public class BuildIntegrationTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
         psi.ArgumentList.Add("publish");
         psi.ArgumentList.Add("src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj");
         psi.ArgumentList.Add("-c");
@@ -76,7 +77,15 @@ public class BuildIntegrationTests : IDisposable
         psi.ArgumentList.Add("true");
         psi.ArgumentList.Add("-p:PublishSingleFile=true");
         using var proc = Process.Start(psi)!;
-        proc.WaitForExit(180_000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(180_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            Assert.Fail("dotnet publish timed out after 180s");
+        }
+        stdoutTask.GetAwaiter().GetResult();
+        stderrTask.GetAwaiter().GetResult();
         Assert.Equal(0, proc.ExitCode);
         Assert.True(File.Exists(exePath), $"slangc publish output not found: {exePath}");
         return exePath;
@@ -113,6 +122,7 @@ public class BuildIntegrationTests : IDisposable
         // 古い env を参照しないようにし、新 disk: セクション込みの repo 内 lsx.env を
         // 読ませる)。InstalledEnv テスト等は mock install dir を渡す
         psi.Environment["SLANG_HOME"] = slangHome;
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
         psi.ArgumentList.Add("run");
         psi.ArgumentList.Add("--project");
         psi.ArgumentList.Add(buildProject);
@@ -127,9 +137,15 @@ public class BuildIntegrationTests : IDisposable
         foreach (var a in extraArgs) psi.ArgumentList.Add(a);
 
         using var proc = Process.Start(psi)!;
-        var stdout = proc.StandardOutput.ReadToEnd();
-        var stderr = proc.StandardError.ReadToEnd();
-        proc.WaitForExit(120_000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(120_000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            Assert.Fail("slangbuild timed out after 120s");
+        }
+        var stdout = stdoutTask.GetAwaiter().GetResult();
+        var stderr = stderrTask.GetAwaiter().GetResult();
         return (proc.ExitCode, stdout, stderr);
     }
 

--- a/tests/SLANGCompiler.Tests/IntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/IntegrationTests.cs
@@ -53,10 +53,17 @@ public class IntegrationTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
 
         using var proc = Process.Start(psi)!;
-        var stderr = proc.StandardError.ReadToEnd();
-        proc.WaitForExit(30000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(30000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            Assert.Fail("slangc timed out after 30s");
+        }
+        var stderr = stderrTask.GetAwaiter().GetResult();
 
         Assert.Equal(0, proc.ExitCode);
         Assert.True(File.Exists(outputPath), $"Output file not created. stderr: {stderr}");
@@ -81,10 +88,17 @@ public class IntegrationTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
 
         using var proc = Process.Start(psi)!;
-        var stderr = proc.StandardError.ReadToEnd();
-        proc.WaitForExit(30000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(30000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            Assert.Fail("slangc timed out after 30s");
+        }
+        var stderr = stderrTask.GetAwaiter().GetResult();
 
         Assert.NotEqual(0, proc.ExitCode);
         return stderr;
@@ -110,10 +124,17 @@ public class IntegrationTests : IDisposable
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
 
         using var proc = Process.Start(psi)!;
-        var stderr = proc.StandardError.ReadToEnd();
-        proc.WaitForExit(30000);
+        var stdoutTask = proc.StandardOutput.ReadToEndAsync();
+        var stderrTask = proc.StandardError.ReadToEndAsync();
+        if (!proc.WaitForExit(30000))
+        {
+            try { proc.Kill(entireProcessTree: true); } catch { }
+            Assert.Fail("slangc timed out after 30s");
+        }
+        var stderr = stderrTask.GetAwaiter().GetResult();
 
         Assert.Equal(0, proc.ExitCode);
         Assert.True(File.Exists(outputPath), $"Output file not created. stderr: {stderr}");

--- a/tests/SLANGCompiler.Tests/SlfsBuildIntegrationTests.cs
+++ b/tests/SLANGCompiler.Tests/SlfsBuildIntegrationTests.cs
@@ -28,6 +28,7 @@ public class SlfsBuildIntegrationTests
             RedirectStandardError = true,
             UseShellExecute = false,
         };
+        psi.Environment["MSBUILDDISABLENODEREUSE"] = "1";
         psi.ArgumentList.Add("run");
         psi.ArgumentList.Add("--project");
         psi.ArgumentList.Add(Path.Combine(repo, "src", "SLANGCompiler.Build"));


### PR DESCRIPTION
## Summary
- `dotnet test` で IntegrationTests / BuildIntegrationTests / SlfsBuildIntegrationTests が無限ハングする問題を修正
- **原因 1: MSBuild ノード再利用デッドロック** — 子プロセスの `dotnet run` が親 `dotnet test` の MSBuild worker node を共有し、デッドロック発生
- **原因 2: パイプバッファ デッドロック** — `CompileWithCliDetail()` 等が stdout を redirect しつつ読まない、または stdout/stderr を同期的に直列 ReadToEnd() するため、OS パイプバッファが満杯になると子プロセスがブロック → 親もブロック

## Changes
- **IntegrationTests.cs**: `CompileWithCliDetail()` / `CompileExpectError()` / `CompileWithOverlays()` を `ReadToEndAsync()` + `WaitForExit(timeout)` + `Kill(entireProcessTree)` パターンに統一、`MSBUILDDISABLENODEREUSE=1` 注入
- **BuildIntegrationTests.cs**: `RunSlangbuildWithSlangHome()` / `EnsureSlangcExePath()` を同パターンに統一、`MSBUILDDISABLENODEREUSE=1` 注入
- **SlfsBuildIntegrationTests.cs**: 既に async パターン済みのため `MSBUILDDISABLENODEREUSE=1` のみ追加

## Test plan
- [x] IntegrationTests: 69 passed / 0 failed (5m12s)
- [x] BuildIntegrationTests: 35 passed / 0 failed (8m47s)
- [x] SlfsBuildIntegrationTests: 4 passed / 0 failed (29s)
- [x] 外部環境変数なし (コード修正のみ) でハング解消を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)