### PR TITLE
release: v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## Version 0.26.0 (2026-06-03)
+
 - X1 に Arkos Tracker (AKG / AKM) サウンドドライバを統合 — PSG の BGM と SFX (効果音) を SLANG から再生、 詳細は [docs/X1.md](docs/X1.md)
   - MACHINE 中間層 `libx1_arkos` (`ARKOS_INIT`/`_SET_CTC_PORT`/`_BGM_PLAY`/`_STOP`/`_PAUSE`/`_RESUME` + `ARKOS_SFX_INIT`/`_PLAY`/`_STOP`、 AKG/AKM 共通)、 4 env (x1 / sosx1 / x1native / x1native_slfs) 対応、 CTC ch1 割込 (IM2) / VSYNC polling 両対応
   - BGM は `.akg` (generic) / `.akm` (minimalist)、 SFX は `.akx` バンクを番号 + channel (0-2) 指定で再生。 player bin は RASM ビルドを固定 ORG ロード、 sample `examples/X1_ARKOS`
@@ -14,6 +16,8 @@
   - Furnace `.fur` → Z80 データ変換 (`tools/json2sms_x1.py` ほか)、 raw bin → X1 cassette tape 変換 (`tools/bin2x1tap.py`)
   - 複数楽曲/SFX を manifest で一括登録 → bundle 連結 + アドレス CONST (`MUSIC_*` / `SFX_*`) 自動生成する `tools/banjo_pack_assets.py` と sample `examples/X1_BANJO_MULTI` (人手のアドレス計算不要、 `BANJO_PLAY(MUSIC_xxx)` で再生)
   - 出典: banjo (https://github.com/joffb/banjo、 MIT、 Joe Kennedy)。 LICENSE / THIRD_PARTY_NOTICES に attribution
+
+- `dotnet test` が無限ハングする問題を修正 — MSBuild ノード再利用デッドロックとパイプバッファデッドロックを解消 (IntegrationTests / BuildIntegrationTests / SlfsBuildIntegrationTests)
 
 ## Version 0.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # 更新履歴
 
-## Unreleased
-
-## Version 0.26.0 (2026-06-03)
+## Version 0.26.0
 
 - X1 に Arkos Tracker (AKG / AKM) サウンドドライバを統合 — PSG の BGM と SFX (効果音) を SLANG から再生、 詳細は [docs/X1.md](docs/X1.md)
   - MACHINE 中間層 `libx1_arkos` (`ARKOS_INIT`/`_SET_CTC_PORT`/`_BGM_PLAY`/`_STOP`/`_PAUSE`/`_RESUME` + `ARKOS_SFX_INIT`/`_PLAY`/`_STOP`、 AKG/AKM 共通)、 4 env (x1 / sosx1 / x1native / x1native_slfs) 対応、 CTC ch1 割込 (IM2) / VSYNC polling 両対応

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SLANG-compiler
-SLANG Compiler (Z80 + C64/oscar64) 0.25.0
+SLANG Compiler (Z80 + C64/oscar64) 0.26.0
 
 # 概要
 
@@ -35,7 +35,7 @@ slangbuild -E c64 -I include examples/c64/SPRITE.SL -o SPRITE
 ## slangc 単体 (= compile のみ、 link しない)
 
 ```
-SLANG Compiler v0.25.0
+SLANG Compiler v0.26.0
 Usage: slangc [options] <input.sl>
 
 Options:

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -363,11 +363,13 @@ WLA-DX は **PATH の通った場所に `wla-z80` / `wlalink` があれば OK** 
 
 banjo は Arkos と異なり、driver entry の固定 jump table を持たず、さらに曲データ内に driver 関数の絶対アドレスを含む。そのため X1 統合では次の 2 段構成にしている:
 
-| 物 | 既定アドレス | 生成方法 |
-|---|---:|---|
-| driver bin | `$8000` | WLA-DX で banjo Core + chip driver (AY / OPM / both) + X1 wrapper を固定 ORG ビルド |
-| song bin | `$B000` | `.fur` → json → song asm → driver symbol の EQU 注入 → 固定 ORG ビルド |
-| banjo RAM | `$C000`〜 | driver build 時に WLA-DX RAM section として固定 |
+| 物 | sample での配置 | 生成方法 | アドレス変更方法 |
+|---|---:|---|---|
+| driver bin | `$8000` | WLA-DX で banjo Core + chip driver (AY / OPM / both) + X1 wrapper を指定 ORG でビルド | `build_driver.sh` の `BANJO_BASE` 引数で任意アドレスに変更可 |
+| song bin | `$B000` | `.fur` → json → song asm → driver symbol の EQU 注入 → 指定 ORG でビルド | `json2sms_x1.py` の `--org` オプション (bundle 時は `banjo_pack_assets.py` が自動算出) |
+| banjo RAM | `$C000`〜 | driver build 時に WLA-DX RAM section として配置 | driver ビルドアドレスに応じて自動的に決まる |
+
+上記の配置アドレスは sample のデフォルト値であり、ビルド時に変更できる。ただし位置依存バイナリのため、ビルド時に指定したアドレスと実行時のロード先は必ず一致させること。
 
 SLANG 側は `runtime/libx1_banjo.asm` の MACHINE 関数を呼ぶだけでよい。driver のロード先と `BANJO_BASE` は一致させる (`SONG_ADDR` / `SFX_ADDR` は chip 別配置のため Makefile が `BANJOMP.config.inc` に生成する):
 

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -365,11 +365,12 @@ banjo は Arkos と異なり、driver entry の固定 jump table を持たず、
 
 | 物 | sample での配置 | 生成方法 | アドレス変更方法 |
 |---|---:|---|---|
-| driver bin | `$8000` | WLA-DX で banjo Core + chip driver (AY / OPM / both) + X1 wrapper を指定 ORG でビルド | `build_driver.sh` の `BANJO_BASE` 引数で任意アドレスに変更可 |
-| song bin | `$B000` | `.fur` → json → song asm → driver symbol の EQU 注入 → 指定 ORG でビルド | `json2sms_x1.py` の `--org` オプション (bundle 時は `banjo_pack_assets.py` が自動算出) |
-| banjo RAM | `$C000`〜 | driver build 時に WLA-DX RAM section として配置 | driver ビルドアドレスに応じて自動的に決まる |
+| driver bin | `$8000` | WLA-DX で banjo Core + chip driver (AY / OPM / both) + X1 wrapper を指定 ORG でビルド | `build_driver.sh --org <addr>` |
+| song bin | `$B000` | `.fur` → json → song asm → driver symbol の EQU 注入 → 指定 ORG でビルド | Makefile の `SONG_ORG` (→ `banjo_prep_song.py --load-addr`)。bundle 時は `banjo_pack_assets.py --base` が自動算出 |
+| SFX bin | `$B000` | 同上 (`json2sms_x1.py -s <ch>` で単一 ch 抽出) | Makefile の `SFX_ORG`。bundle 時は同上 |
+| banjo RAM | `$C000`〜 | driver build 時に WLA-DX RAM section として配置 | `build_driver.sh --ram <addr>` |
 
-上記の配置アドレスは sample のデフォルト値であり、ビルド時に変更できる。ただし位置依存バイナリのため、ビルド時に指定したアドレスと実行時のロード先は必ず一致させること。
+上記の配置アドレスは sample のデフォルト値であり、ビルド時に変更できる。ただし位置依存バイナリのため、ビルド時に指定したアドレスと実行時のロード先は必ず一致させること。ツールの詳細は後述の「ドライバのビルド」「楽曲・SFX の変換」を参照。
 
 SLANG 側は `runtime/libx1_banjo.asm` の MACHINE 関数を呼ぶだけでよい。driver のロード先と `BANJO_BASE` は一致させる (`SONG_ADDR` / `SFX_ADDR` は chip 別配置のため Makefile が `BANJOMP.config.inc` に生成する):
 
@@ -409,6 +410,58 @@ SFX は **AY/PSG 専用** (OPM driver では no-op)。同時に鳴らせる SFX 
 
 sample は `X1_CTC_PORT()` が 0 以外を返した場合に CTC ch1 を使い、無い場合だけ `VSYNC_PROC` から `BANJO_UPDATE()` を呼ぶ (CTC mode では driver 側が poll を no-op 化)。BGM と SFX は同じ update 経路 (polling / CTC ISR) で同時に進む。CTC mode では x1native は ISR trampoline (`_ISRADR` → wrapper handler) 経由、x1 / sosx1 は driver `$8000` 以上配置前提の direct vector で動作する。
 
+### ドライバのビルド (`build_driver.sh`)
+
+`runtime/x1/banjo/build_driver.sh` が WLA-DX でドライバ bin をビルドする。主な引数:
+
+| 引数 | 既定値 | 説明 |
+|---|---|---|
+| `--chip opm\|ay\|both` | (必須) | 使用チップ。`opm` = OPM/YM2151 (8ch)、`ay` = AY/PSG (3ch)、`both` = 両方 (11ch) |
+| `--org <addr>` | `0x8000` | driver コードの配置アドレス (= `BANJO_BASE`) |
+| `--ram <addr>` | `0xC000` | banjo ワーク RAM のベースアドレス |
+| `--max-channels N` | chip 依存 | 最大チャンネル数の override |
+| `--outdir <dir>` | (必須) | `driver.bin` と `driver.sym` の出力先 |
+
+ビルド手順: WLA-Z80 で `banjo_driver_x1.asm` をアセンブル → WlaLink でリンク → `banjo_trim_to_end.py` で実使用域だけにトリム。出力 `driver.sym` は後述の曲変換で driver シンボルの EQU 注入に使う。
+
+sample の Makefile では `DRV_ORG` / `BANJO_RAM` 変数が `build_driver.sh` に渡される:
+
+```sh
+# 既定 ($8000 / $C000) でビルド
+build_driver.sh --chip ay --org 0x8000 --ram 0xC000 --outdir .
+
+# アドレスを変える場合 (例: driver を $6000、RAM を $A000 に)
+build_driver.sh --chip ay --org 0x6000 --ram 0xA000 --outdir .
+```
+
+### 楽曲・SFX の変換 (単独の曲)
+
+`.fur` → Z80 バイナリの変換パイプライン (sample Makefile がこの手順を自動化):
+
+1. **`furnace2json.py`** — Furnace `.fur` を JSON に変換
+2. **`json2sms_x1.py`** — JSON を Z80 アセンブリに変換
+
+| 引数 | 既定値 | 説明 |
+|---|---|---|
+| `--ay-master-clock <freq>` | `3579545` | AY マスタークロック。**X1 では `4000000`** (2MHz 駆動 PSG のため) |
+| `-s <ch>` | `-1` (無効) | SFX モード。`0`〜`2` で指定した AY ch のみ抽出 |
+| `-i <name>` | — | 生成ラベルの識別子 |
+| `-o <file>` | — | 出力 `.asm` |
+
+3. **`banjo_extract_syms.py`** — `driver.sym` から driver ラベルの絶対アドレスを `.define` 文として抽出 (`banjo_syms.inc`)
+4. **`banjo_prep_song.py`** — 曲 asm を WLA memorymap でラップし、指定アドレスに配置
+
+| 引数 | 説明 |
+|---|---|
+| `--load-addr <addr>` | 曲の配置アドレス (= Makefile の `SONG_ORG` / `SFX_ORG`) |
+| `--syms-include <file>` | `banjo_extract_syms.py` の出力 |
+| `-o <file>` | 出力 `.asm` |
+
+5. **WLA-Z80 + WlaLink** — アセンブル・リンク
+6. **`banjo_trim_to_end.py`** — 実使用域にトリム (`--load <addr>` / `--ram-base <addr>`)
+
+sample Makefile の `SONG_ORG` / `SFX_ORG` が `banjo_prep_song.py --load-addr` に渡され、曲バイナリの配置アドレスが決まる。Makefile はこの値から SLANG 用の `BANJOMP.config.inc` も生成するため、ビルド側と SLANG 側のアドレスは自動的に一致する。
+
 ### ビルド (= `examples/X1_BANJO/Makefile`)
 
 `examples/X1_BANJO` は driver/song を本体に embed せず、各 env のネイティブ手段で実行時ロードする 4 env 共通 sample。曲データは配布に含めないため、Furnace の AY または OPM 曲を `examples/X1_BANJO/assets/song.fur` に置いてから build する。
@@ -422,7 +475,7 @@ make x1native_slfs CHIP=opm # SLFS disk、--slfs-add で driver/song を格納
 make all
 ```
 
-`CHIP` は `opm` / `ay` / `both` を指定できる。AY 曲では `tools/json2sms_x1.py --ay-master-clock 4000000` により、X1 PSG の 2MHz 駆動に合わせて tone period と envelope period を焼き込む。Makefile は WLA-DX (`wla-z80` / `wlalink`) と banjo 変換ツールを使う。
+`CHIP` は `opm` / `ay` / `both` を指定できる。AY 曲では `json2sms_x1.py --ay-master-clock 4000000` により、X1 PSG の 2MHz 駆動に合わせて tone period と envelope period を焼き込む。Makefile は WLA-DX (`wla-z80` / `wlalink`) と banjo 変換ツールを使う。
 
 SFX は **`CHIP=ay` のときだけ** sample に組み込まれる。`assets/sfx.fur` (AY/PSG の効果音) を用意し、`SFX_CH=0..2` で SFX を載せる PSG ch を指定する (既定 `0`)。SFX を載せた ch は SFX 再生中だけ BGM 側が mute される。
 
@@ -437,11 +490,35 @@ make x1 CHIP=ay SFX_CH=2 SONG_FUR=../../refs/banjo/examples/cmajor_ay.fur  # AY 
 | `CHIP=opm` / `both` | `$8000` | `$B000` | — | `$C000`〜 |
 | `CHIP=ay` (SFX 有) | `$8000` | `$9000` | `$B000` | `$C000`〜 |
 
-driver/song/RAM の配置を変える場合は、Makefile の `DRV_ORG` / `SONG_ORG` / `SFX_ORG` / `BANJO_RAM` と SLANG 側 (config.inc 生成の `SONG_ADDR` / `SFX_ADDR` 含む) を同時に揃える。
+配置を変える場合は Makefile の変数を変更する。Makefile が `build_driver.sh` と `banjo_prep_song.py` に正しい値を渡し、`BANJOMP.config.inc` も同じ値で生成するため、Makefile の変数を揃えるだけで SLANG 側も自動的に一致する:
+
+| Makefile 変数 | 既定値 | 渡される先 |
+|---|---|---|
+| `DRV_ORG` | `0x8000` | `build_driver.sh --org` |
+| `BANJO_RAM` | `0xC000` | `build_driver.sh --ram` |
+| `SONG_ORG` | chip 依存 | `banjo_prep_song.py --load-addr` → `BANJOMP.config.inc` の `SONG_ADDR` |
+| `SFX_ORG` | chip 依存 | 同上 → `SFX_ADDR` |
 
 ### 複数楽曲・複数SFX (`examples/X1_BANJO_MULTI`)
 
-曲/SFX を複数まとめて 1 アプリに入れる場合は `examples/X1_BANJO_MULTI` を参照。manifest (`assets/banjo_assets.txt`) に `music <file.fur>` / `sfx <file.fur> <ch>` を列挙すると、`tools/banjo_pack_assets.py` が各 blob を driver 直後から順次アドレスでビルド→1 つの bundle に連結し、各先頭アドレスを SLANG CONST (`MUSIC_<NAME>` / `SFX_<NAME>`、`BANJODAT_BASE` 等) として `*.assets.addr.inc` に生成する。SLANG は bundle を 1 回ロードし `BANJO_PLAY(MUSIC_XXX, ...)` / `BANJO_SFX_PLAY(SFX_XXX)` で再生でき、アドレス計算は不要。位置依存 blob のため全アセットは固定アドレス常駐 (合計が `$C000` を超えるとビルド時 error)。1 bundle = 単一チップ (`CHIP=ay` 曲+SFX / `CHIP=opm` 曲のみ)。
+曲/SFX を複数まとめて 1 アプリに入れる場合は `examples/X1_BANJO_MULTI` を参照。manifest (`assets/banjo_assets.txt`) に `music <file.fur>` / `sfx <file.fur> <ch>` を列挙すると、`tools/banjo_pack_assets.py` が各 blob を driver 直後から順次アドレスでビルド → 1 つの bundle に連結し、各先頭アドレスを SLANG CONST (`MUSIC_<NAME>` / `SFX_<NAME>`、`BANJODAT_BASE` 等) として `*.assets.addr.inc` に生成する。SLANG は bundle を 1 回ロードし `BANJO_PLAY(MUSIC_XXX, ...)` / `BANJO_SFX_PLAY(SFX_XXX)` で再生でき、アドレス計算は不要。位置依存 blob のため全アセットは固定アドレス常駐 (合計が RAM base を超えるとビルド時 error)。1 bundle = 単一チップ (`CHIP=ay` 曲+SFX / `CHIP=opm` 曲のみ)。
+
+`banjo_pack_assets.py` の主な引数:
+
+| 引数 | 既定値 | 説明 |
+|---|---|---|
+| `--manifest <file>` | (必須) | アセット一覧。`music <file.fur>` / `sfx <file.fur> <ch>` を 1 行 1 エントリ |
+| `--driver-sym <file>` | (必須) | driver.sym (EQU 注入に使う) |
+| `--driver-bin <file>` | (必須) | driver.bin (サイズ算出に使う) |
+| `--chip opm\|ay\|both` | (必須) | 使用チップ (SFX は `ay` のみ許可) |
+| `--base <addr>` | (必須) | 先頭アセットの配置アドレス。通常は `DRV_ORG + driver.bin のサイズ` (Makefile が自動算出) |
+| `--ram-base <addr>` | `0xC000` | RAM 境界。bundle 全体がこのアドレス未満に収まることを検証する |
+| `--ay-master-clock <freq>` | `4000000` | AY tone/envelope 計算用クロック |
+| `--out-bin <file>` | (必須) | 連結 bundle の出力先 |
+| `--out-inc <file>` | (必須) | 生成 CONST の `.inc` 出力先 |
+| `--const-prefix <str>` | (空) | 生成 CONST 名の接頭辞 (bundle 分割時に名前空間化) |
+
+Makefile の `DRV_ORG` / `BANJO_RAM` を変更すると、`--base` (= `DRV_ORG + driver サイズ`) と `--ram-base` も連動して変わる。個々のアセットアドレスは `banjo_pack_assets.py` が順次自動算出するため、手動指定は不要。
 
 メモリ節約のため **bundle を分けたい場合** (例: SFX だけ常駐パックし、BGM は曲ごと別 bin にしてディスクからスワップロードする) は、`banjo_pack_assets.py` を bundle ごとに別々に実行 (`--base` / `--out-bin` / `--out-inc` を分ける) し、`--const-prefix` で生成 CONST を名前空間化する (例: SFX 側 `--const-prefix SFX_`、 BGM 側 `--const-prefix BGM_`)。これで各 `.inc` を 1 プログラムで衝突なく `#INCLUDE` できる。BGM スワップは全 BGM を同じスロットアドレス (`--base`) でビルドしておき、ロード時に入れ替える。
 

--- a/docs/X1.md
+++ b/docs/X1.md
@@ -250,6 +250,57 @@ slangbuild -E x1native -I include examples/X1NATIVE_MTREAD/MTREADSMP.SL \
 
 `#MODULE` 未使用 (= overlay 0 件) の SLANG コードは従来通り 1 binary .tap として build される (= bit-exact 互換)。 既存 sample (`X1NATIVE_HELLO.SL` 等) は影響なし。
 
+## x1native 制約 / 注意点
+
+### tape build size 制約
+
+- 実質上限 `load + size - 1 <= $FFDF` (= 末尾 32 byte は runtime 予約)
+- 現状 size reject は未実装 (= 本 docs 明記のみ、 `--emit tape` 時の `> $FFDF` reject 強化は今後の課題)
+
+### interrupt 制約
+
+- x1native runtime は **BIOS ROM routine を使わない前提** で動作
+- user SLANG コードが ROM call 中に interrupt 発生した場合、 RETI 後の復帰先が ROM routine だと破綻し得る (= 「ROM call 中の interrupt 復帰までは保証しない」)
+
+## `x1native` 内部設計
+
+(= 以下は `x1native` / `x1native_slfs` env のみに関する設計詳細。 `x1` / `lsx` / `sosx1` 環境には適用されない)
+
+### 予約領域
+
+x1native runtime は以下のメモリ領域を予約しており、 SLANG プログラムからは触らないこと:
+
+- `$1000-$FFDF`: SLANG プログラム + work area (= `default_org=$1000`)
+- **`$FFE0-$FFFF`: ISR trampoline reserved area (32 byte)**
+  - `$FFE0-$FFE7`: IM2 vector table (= CTC ch0-3 vector × 2 byte)
+  - `$FFE8-$FFEA`: ISR_DUMMY (= 想定外 interrupt 安全網、 `EI; RETI`)
+  - `$FFEB-$FFFF`: ISR_ENTRY (= CTC ch1 用 handler trampoline)
+  - SLANGINIT 内の SETUP_ISR_AREA が初期化、 vector 全 entry は ISR_DUMMY で init
+  - `LD I, $FF` + CTC vector register = `$E0` で IM2 vector base = `$FFE0`
+
+### IRQ 設計 (= 責任分割)
+
+- **runtime (SLANGINIT)**: SETUP_ISR_AREA + `LD I, $FF` + `IM 2` まで実行 (= IRQ 土台のみ)
+  - **EI は SLANGINIT では行わない**
+  - **SEARCHCTC は SLANGINIT では呼ばない** (= 利用 library 側)
+- **device library (PSG_INIT(1) 等)**: SEARCHCTC + CTC ch1 設定 + vector slot 差替
+  - **EI は initialization 完了後** に共通末尾 (= 既存 PSG_INIT INITEND) で実行
+  - 将来 Arkos Tracker 等 別 IRQ driver 入れたとき干渉しない設計
+- 機種判定 / `CALL $1FF7` / S-OS vector 借用 (`$0058` / `$F830`) は使わない、 自前 IM2 vector のため normal / turbo 区別不要 (= ROM bank が $0000-$7FFF にあっても `$FFE0-$FFFF` は常に RAM)
+
+### tape read 内部処理
+
+- tape read は bit-level timing critical (~185µs/bit)、 bit-stream read 部分 (= `_mtload_block` 内) は完全 DI 維持 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
+- ただし MTREAD 内の deck control 呼出 (= `MT_CTRL_PLAY` / `MT_CTRL_STOP` 経由 `MT_CTRL`) は sub CPU 通信 sync のため一時 EI する (= X1_compatible_rom 元 source 由来、 数十 cycle 程度の短い window)、 PSG IRQ 等が間に入る可能性あり (= 元 source の必要 sync で削除不可)。 bit-stream read 部分は影響なし
+
+### ライセンス / 出典
+
+x1native runtime asm は以下を出典明示で参考実装:
+- **LSX-Dodgers** (MIT、 Gaku 1995): SLANGINIT 構造 / sWORK pattern / 上位 routine 構造
+- **X1_compatible_rom** (CC0、 Meister 2020-、 https://github.com/meister68k/X1_compatible_rom): KBHIT / WAIT_80C49_WR / READ_80C49 / VRAM layout / TXTCUR 定数
+
+各 asm file の header に attribution comment あり。
+
 ## Arkos Tracker music driver (AKG / AKM)
 
 [Arkos Tracker](https://www.julien-nevo.com/arkostracker/) で作成した楽曲 / 効果音バンク (`.akx`) を X1 の PSG (AY-3-8910 相当) で再生する driver。 楽曲フォーマットは 2 種に対応する:
@@ -525,54 +576,3 @@ Makefile の `DRV_ORG` / `BANJO_RAM` を変更すると、`--base` (= `DRV_ORG +
 ### 既存 PSG driver / Arkos との関係
 
 banjo AY は X1 内蔵 PSG を直接使うため、既存 `libx1_psg` や `libx1_arkos` との同時使用は不可。banjo OPM のみを使う場合は FM 音源ボード側なので PSG とは競合しない。
-
-## 制約 / 注意点
-
-### tape build size 制約
-
-- 実質上限 `load + size - 1 <= $FFDF` (= 末尾 32 byte は runtime 予約)
-- 現状 size reject は未実装 (= 本 docs 明記のみ、 `--emit tape` 時の `> $FFDF` reject 強化は今後の課題)
-
-### interrupt 制約
-
-- x1native runtime は **BIOS ROM routine を使わない前提** で動作
-- user SLANG コードが ROM call 中に interrupt 発生した場合、 RETI 後の復帰先が ROM routine だと破綻し得る (= 「ROM call 中の interrupt 復帰までは保証しない」)
-
-## `x1native` 内部設計
-
-(= 以下は `x1native` / `x1native_slfs` env のみに関する設計詳細。 `x1` / `lsx` / `sosx1` 環境には適用されない)
-
-### 予約領域
-
-x1native runtime は以下のメモリ領域を予約しており、 SLANG プログラムからは触らないこと:
-
-- `$1000-$FFDF`: SLANG プログラム + work area (= `default_org=$1000`)
-- **`$FFE0-$FFFF`: ISR trampoline reserved area (32 byte)**
-  - `$FFE0-$FFE7`: IM2 vector table (= CTC ch0-3 vector × 2 byte)
-  - `$FFE8-$FFEA`: ISR_DUMMY (= 想定外 interrupt 安全網、 `EI; RETI`)
-  - `$FFEB-$FFFF`: ISR_ENTRY (= CTC ch1 用 handler trampoline)
-  - SLANGINIT 内の SETUP_ISR_AREA が初期化、 vector 全 entry は ISR_DUMMY で init
-  - `LD I, $FF` + CTC vector register = `$E0` で IM2 vector base = `$FFE0`
-
-### IRQ 設計 (= 責任分割)
-
-- **runtime (SLANGINIT)**: SETUP_ISR_AREA + `LD I, $FF` + `IM 2` まで実行 (= IRQ 土台のみ)
-  - **EI は SLANGINIT では行わない**
-  - **SEARCHCTC は SLANGINIT では呼ばない** (= 利用 library 側)
-- **device library (PSG_INIT(1) 等)**: SEARCHCTC + CTC ch1 設定 + vector slot 差替
-  - **EI は initialization 完了後** に共通末尾 (= 既存 PSG_INIT INITEND) で実行
-  - 将来 Arkos Tracker 等 別 IRQ driver 入れたとき干渉しない設計
-- 機種判定 / `CALL $1FF7` / S-OS vector 借用 (`$0058` / `$F830`) は使わない、 自前 IM2 vector のため normal / turbo 区別不要 (= ROM bank が $0000-$7FFF にあっても `$FFE0-$FFFF` は常に RAM)
-
-### tape read 内部処理
-
-- tape read は bit-level timing critical (~185µs/bit)、 bit-stream read 部分 (= `_mtload_block` 内) は完全 DI 維持 + IFF2 復元 guard (= `LD A, I; DI; PUSH AF` 順) で entry 時状態維持
-- ただし MTREAD 内の deck control 呼出 (= `MT_CTRL_PLAY` / `MT_CTRL_STOP` 経由 `MT_CTRL`) は sub CPU 通信 sync のため一時 EI する (= X1_compatible_rom 元 source 由来、 数十 cycle 程度の短い window)、 PSG IRQ 等が間に入る可能性あり (= 元 source の必要 sync で削除不可)。 bit-stream read 部分は影響なし
-
-### ライセンス / 出典
-
-x1native runtime asm は以下を出典明示で参考実装:
-- **LSX-Dodgers** (MIT、 Gaku 1995): SLANGINIT 構造 / sWORK pattern / 上位 routine 構造
-- **X1_compatible_rom** (CC0、 Meister 2020-、 https://github.com/meister68k/X1_compatible_rom): KBHIT / WAIT_80C49_WR / READ_80C49 / VRAM layout / TXTCUR 定数
-
-各 asm file の header に attribution comment あり。

--- a/src/SLANGCompiler.Build/Program.cs
+++ b/src/SLANGCompiler.Build/Program.cs
@@ -13,7 +13,7 @@ namespace SLANGCompiler.Build;
 /// </summary>
 internal class Program
 {
-    private const string Version = "0.25.0";
+    private const string Version = "0.26.0";
 
     public static int Main(string[] args)
     {

--- a/src/SLANGCompiler.Build/SLANGCompiler.Build.csproj
+++ b/src/SLANGCompiler.Build/SLANGCompiler.Build.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slangbuild</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.25.0</Version>
+    <Version>0.26.0</Version>
     <AssemblyTitle>SLANG Build Driver (two-stage assembler)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -10,7 +10,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.25.0";
+    const string Version = "0.26.0";
 
     static int Main(string[] args)
     {

--- a/src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj
+++ b/src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slangc</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.25.0</Version>
+    <Version>0.26.0</Version>
     <AssemblyTitle>SLANG Compiler</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SLANGCompiler.SlfsPack/SLANGCompiler.SlfsPack.csproj
+++ b/src/SLANGCompiler.SlfsPack/SLANGCompiler.SlfsPack.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slfs-pack</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.25.0</Version>
+    <Version>0.26.0</Version>
     <AssemblyTitle>SLFS packer (SLANG ゲーム専用 file system)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Version 0.26.0 リリース準備
- バージョン表記を 0.25.0 → 0.26.0 に更新 (6 箇所)
- CHANGELOG.md の Unreleased を Version 0.26.0 (2026-06-03) にリネーム

## 0.26.0 の主な変更点
- X1 に Arkos Tracker (AKG / AKM) サウンドドライバを統合
- X1 に banjo (Furnace tracker → Z80) サウンドドライバを統合 (AY/OPM BGM + AY SFX)
- `dotnet test` 無限ハング修正 (PR #227)

## Release checklist
- [x] Version 表記更新 (CLI/Build/SlfsPack csproj + Program.cs + README)
- [x] CHANGELOG.md リネーム (Unreleased → Version 0.26.0)
- [x] publish.sh は images/templates のみ配布 (確認済み)
- [ ] マージ後: `git tag -a v0.26.0` + `gh release create --prerelease`

🤖 Generated with [Claude Code](https://claude.com/claude-code)