### PR TITLE
X1: GETCGROM(CODE, ADR) 追加 + libx1_pcg 整理

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- ランタイムに `GETCGROM(CODE, ADR)` を追加 — X1 CGROM (ANK) フォントを 1 文字分 (8 ライン × 1 バイト) 読み出す (`x1` / `x1native` / `x1native_slfs`)。 ADR から 8 バイトに指定 ANK コードの字形を格納。 sample `examples/X1CGROM.SL` (CGROM フォントを読み出して太字化 + 3 倍幅化し PCG 定義)
+- ランタイムに `GETCGROM(CODE, ADR)` を追加 — X1 CGROM (ANK) フォントを 1 文字分 (8 ライン × 1 バイト) 読み出す (`x1` / `sosx1` / `x1native` / `x1native_slfs`)。 ADR から 8 バイトに指定 ANK コードの字形を格納。 sample `examples/X1CGROM.SL` (CGROM フォントを読み出して太字化 + 3 倍幅化し PCG 定義)
 
 ## Version 0.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # 更新履歴
 
+## Unreleased
+
+- ランタイムに `GETCGROM(CODE, ADR)` を追加 — X1 CGROM (ANK) フォントを 1 文字分 (8 ライン × 1 バイト) 読み出す (`x1` / `x1native` / `x1native_slfs`)。 ADR から 8 バイトに指定 ANK コードの字形を格納。 sample `examples/X1CGROM.SL` (CGROM フォントを読み出して太字化 + 3 倍幅化し PCG 定義)
+
 ## Version 0.26.0
 
 - X1 に Arkos Tracker (AKG / AKM) サウンドドライバを統合 — PSG の BGM と SFX (効果音) を SLANG から再生、 詳細は [docs/X1.md](docs/X1.md)

--- a/examples/X1CGROM.SL
+++ b/examples/X1CGROM.SL
@@ -1,0 +1,75 @@
+// CGROMから文字フォントを読み出し、太字にしてPCGに定義するサンプル
+
+CONST WD = 40;
+ARRAY BYTE BUF[24-1];
+
+TATR_FILL(X1,Y1,X2,Y2,ATR)
+VAR I,J;
+{
+    X2--;
+    Y2--;
+
+    FOR J=Y1 TO Y2
+        FOR I=X1 TO X2
+        {
+            PORT[$2800+I+J*WD]=ATR;
+        }
+}
+
+DEFFONT(FROM_CODE, TO_CODE)
+VAR I,J,ADR
+VAR BYTE DAT;
+{
+    FOR I=FROM_CODE TO TO_CODE
+    {
+        // ROMからフォントを取得
+        GETCGROM(I, BUF);
+        // 太字にする(左シフトしたものをORする)
+        FOR J=0 TO 7
+        {
+            DAT = BUF[J];
+            BUF[J] = DAT OR (DAT << 1);
+        }
+        // PCG定義用に3倍化(末尾から埋める)
+        FOR J=0 TO 7
+        {
+            ADR = 23 - J*3;
+            DAT = BUF[7-J];
+            BUF[ADR] = DAT;
+            ADR--;
+            BUF[ADR] = DAT; 
+            ADR--;
+            BUF[ADR] = DAT;
+        }
+        PCGDEF(I,BUF);
+    }
+}
+
+
+MAIN()
+VAR I;
+BEGIN
+    WIDTH(WD);
+    DEFFONT($21, $7A);
+    // 4行はPCG
+    TATR_FILL(0,0,40,4,$27);
+    // 5行目からは非PCG
+    TATR_FILL(0,5,40,15,$7);
+
+    PRINT("Hello, SLANG!",/);
+
+    // PCGでの表示
+    FOR I=$21 TO $7A
+    {
+        PRINT(CHR$(I));
+    }
+
+    // CGROMでの表示
+    LOCATE(0,5);
+    FOR I=$21 TO $7A
+    {
+        PRINT(CHR$(I));
+    }
+
+    LOOP{}
+END;

--- a/runtime/libsos_pcg.asm
+++ b/runtime/libsos_pcg.asm
@@ -144,3 +144,114 @@ DW 0
 ; DW $07D0  ; WIDTH 80
 
 
+; @name GETCGROM
+; @resident shared
+; @param_count 2
+; @calls SOSCALLS
+; HL = CODE (ANK; 実際は L のみ使用、H は無視), DE = ADR (格納先、 8 バイト書込)
+; CGROM(ANK) フォントを 1 文字分 (8 ライン × 1 バイト) ADR へ読み出す。
+; S-OS 版は既存 PCGDEF と同じく sWIDTH を参照して no-display span を決める。
+SCG_RDDLYVAL    EQU     $0E     ; 250T loop 用 delay 初期値
+SCG_P14         EQU     $14     ; CGROM read port 上位 ($14xx)
+
+LD A,L
+LD (SCG_CODE),A        ; ANK コード保存 (L のみ使用)
+EX DE,HL
+LD (SCG_DEST),HL       ; 格納先 ADR を退避 (cell fill で DE/HL を潰すため)
+
+; 幅依存の no-display 範囲を決定 (PCGDEF と同一: 40桁=$03E8/24cell, 80桁=$07D0/48cell)
+LD A,(sWIDTH)          ; 40 or 80
+CP 40
+JR Z,SCG_W40
+LD HL,$07D0
+LD A,48
+JR SCG_SETSPAN
+SCG_W40:
+LD HL,$03E8
+LD A,24
+SCG_SETSPAN:
+LD (SCG_NODISPADR),HL
+LD (SCG_SPAN),A
+
+CALL SCG_SETCELLS      ; no-display span に attr=$07 / kanji=0 / text=CODE を敷く
+
+; --- 互換モード read (1 plane): raster sync を 1 回 + 250T ループで 8 ライン読む ---
+LD HL,(SCG_DEST)       ; HL = ADR
+LD B,SCG_P14           ; BC = CGROM read port ($1400)
+LD C,0
+LD E,8                 ; line counter
+EXX                    ; read regs を alternate に退避し、 sync 用 BC を使えるようにする
+DI
+LD BC,$1A01            ; raster status sync (= SETPCG の VDSP と同一)
+SCG_VDSP0:
+IN A,(C)
+JP P,SCG_VDSP0
+SCG_VDSP1:
+IN A,(C)
+JP M,SCG_VDSP1
+EXX                    ; HL=dest, BC=$1400, E=8
+SCG_RDLOOP:
+IN A,(C)               ; 12, GET DATA
+LD (HL),A              ; 7, STORE 1 BYTE
+INC HL                 ; 6, INC POINTER
+NOP                    ; 4, DUMMY
+NOP                    ; 4, DUMMY
+LD A,SCG_RDDLYVAL      ; 7
+; 12+7+6+4+4+7=40
+SCG_RDDLY:
+DEC A                  ; 4
+JP NZ,SCG_RDDLY        ; 10
+; (4+10)*14=196
+DEC E                  ; 4
+JP NZ,SCG_RDLOOP       ; 10
+; 40+196+14 = 250
+EI
+RET
+
+SCG_SETCELLS:
+LD BC,$1FD0
+XOR A
+OUT (C),A
+; attribute VRAM ($2800+offset) ← $07 (非 PCG)
+LD A,(SCG_SPAN)
+LD D,A
+LD BC,(SCG_NODISPADR)
+LD HL,$2800
+LD A,$07
+CALL SCG_FILL
+; kanji plane ($3800+offset) ← 0 (ANK 選択。これが無いと漢字側状態に依存)
+LD A,(SCG_SPAN)
+LD D,A
+LD BC,(SCG_NODISPADR)
+LD HL,$3800
+XOR A
+CALL SCG_FILL
+; text VRAM ($3000+offset) ← CODE
+LD A,(SCG_SPAN)
+LD D,A
+LD BC,(SCG_NODISPADR)
+LD HL,$3000
+LD A,(SCG_CODE)
+CALL SCG_FILL
+RET
+
+; HL=base, BC=offset, A=value, D=count → port (base|offset) から D cell に A を OUT
+SCG_FILL:
+ADD HL,BC
+LD B,H
+LD C,L
+SCG_FILL2:
+OUT (C),A
+INC BC
+DEC D
+JR NZ,SCG_FILL2
+RET
+
+SCG_DEST:
+DW 0
+SCG_CODE:
+DB 0
+SCG_SPAN:
+DB 0
+SCG_NODISPADR:
+DW 0

--- a/runtime/libx1_pcg.asm
+++ b/runtime/libx1_pcg.asm
@@ -1,6 +1,62 @@
 ; Converted from lib/libdef/libx1_pcg.yml
 ; SLANG Runtime Library (new format)
 
+
+; @name PCGCOMMON
+; @resident shared
+; @param_count 0
+
+; no-display span (GCG_SPAN cells) へ 3 プレーンを敷く
+; attribute=$2800+ / kanji=$3800+ / text=$3000+ (PCGSET0 の base + kanji plane 追加)
+
+SETPCGCELLS:
+    LD BC,$1FD0
+    XOR A
+    OUT (C),A
+    ; attribute VRAM ($2800+offset) ← .GCG_ATTR ($20=PCG / $07=ANK CGROM)
+    LD A,(.GCG_SPAN)
+    LD D,A
+    LD BC,(.GCG_NODISPADR)
+    LD HL,$2800
+    LD A,(.GCG_ATTR)
+    CALL .GCG_FILL
+    ; kanji plane ($3800+offset) ← 0 (ANK 選択。 これが無いと漢字側状態に依存)
+    LD A,(.GCG_SPAN)
+    LD D,A
+    LD BC,(.GCG_NODISPADR)
+    LD HL,$3800
+    XOR A
+    CALL .GCG_FILL
+    ; text VRAM ($3000+offset) ← CODE
+    LD A,(.GCG_SPAN)
+    LD D,A
+    LD BC,(.GCG_NODISPADR)
+    LD HL,$3000
+    LD A,(.GCG_CODE)
+    CALL .GCG_FILL
+    RET
+
+; HL=base, BC=offset, A=value, D=count → port (base|offset) から D cell に A を OUT
+.GCG_FILL
+    ADD HL,BC
+    LD B,H
+    LD C,L
+.GCG_FILL2
+    OUT (C),A
+    INC BC
+    DEC D
+    JR NZ,.GCG_FILL2
+    RET
+
+.GCG_CODE
+    DB 0
+.GCG_SPAN
+    DB 0
+.GCG_NODISPADR
+    DW 0
+.GCG_ATTR
+    DB 0
+
 ; @name PCGDEFS
 ; @resident shared
 ; @param_count 3
@@ -8,134 +64,107 @@
 ; HL = STARTIDX (ascii code), DE = ADDR (24 bytes/tile), BC = COUNT
 ; ADDR から 24 バイト × COUNT バイトの連続 PCG パターンを STARTIDX から順に登録。
 ; 各タイル定義毎に CRTC vblank 待ちが入るため COUNT 個の処理に約 COUNT/60 秒かかる。
-.pcgdefs_loop:
-LD A,B
-OR C
-RET Z
+.pcgdefs_loop
+    LD A,B
+    OR C
+    RET Z
 
-PUSH HL
-PUSH DE
-PUSH BC
-CALL PCGDEF
-POP BC
-POP DE
-POP HL
+    PUSH HL
+    PUSH DE
+    PUSH BC
+    CALL PCGDEF
+    POP BC
+    POP DE
+    POP HL
 
-INC L
-PUSH HL
-LD HL,24
-ADD HL,DE
-EX DE,HL
-POP HL
-DEC BC
-JR .pcgdefs_loop
+    INC L
+    PUSH HL
+    LD HL,24
+    ADD HL,DE
+    EX DE,HL
+    POP HL
+    DEC BC
+    JR .pcgdefs_loop
 
 ; @name PCGDEF
 ; @resident shared
+; @calls PCGCOMMON,sWORK,X1WORK
 ; HL = ascii code DE = address
-PUSH DE
-LD E,L
+    PUSH DE
+    LD E,L
+    LD A,E
+    LD (SETPCGCELLS.GCG_CODE),A        ; ANK コード保存
 
-LD A,(AT_WIDTH)  ; 40 or 80
-CP 40
-JR Z,PCGDEF40
+    LD A,(AT_WIDTH)  ; 40 or 80
+    CP 40
+    JR Z,.PCGDEF40
 
-; WIDTH 80
-LD HL,$07D0
-LD D,48
-JR PCG_SETNODISP
+    ; WIDTH 80
+    LD HL,$07D0
+    LD A,48
+    JR .PCG_SETNODISP
 
-PCGDEF40:
-; WIDTH 40(screen 0)
-LD HL,$03E8
-LD D,24
+.PCGDEF40
+    ; WIDTH 40(screen 0)
+    LD HL,$03E8
+    LD A,24
 
-PCG_SETNODISP:
-LD (PCG_NODISPADR),HL
+.PCG_SETNODISP
+    LD (SETPCGCELLS.GCG_NODISPADR),HL
+    LD (SETPCGCELLS.GCG_SPAN),A
+    LD A,$20
+    LD (SETPCGCELLS.GCG_ATTR),A
 
-POP HL
-CALL PCGSET0
-CALL SETPCG
-RET
-
-PCGSET0:
-PUSH HL
-PUSH DE
-LD BC,$1FD0
-XOR A
-OUT (C),A
-;
-LD BC,(PCG_NODISPADR)
-LD HL,$2800 ; ATTRIBUTE
-POP DE
-PUSH DE
-LD A,20H    ; PCG COLOR 0
-CALL PCGSET1
-;
-LD BC,(PCG_NODISPADR)
-LD HL,$3000 ; VRAM
-POP DE
-LD A,E      ; ASCII CODE
-CALL PCGSET1
-;
-POP HL
-RET
-
-PCGSET1:
-ADD HL,BC
-LD B,H
-LD C,L
-PCGSET2:
-OUT (C),A
-INC BC
-DEC D
-JR NZ,PCGSET2
-RET
+    CALL SETPCGCELLS
+    POP HL
+    CALL SETPCG
+    RET
 
 PCGBLUE EQU $15+1
 PCGRED EQU $16+1
 PCGGREEN EQU $17+1
+
 SETPCG:
-LD B,PCGBLUE
-LD C,0
-LD D,PCGRED
-LD E,PCGGREEN
-LD A,$08
-EX AF,AF'
-EXX
-;
-DI
-LD BC,$1A01
-PCGVDSP0:
-IN A,(C)
-JP P,PCGVDSP0
-PCGVDSP1:
-IN A,(C)
-JP M,PCGVDSP1
-;
-EXX
-EX AF,AF'
-PCGSETP:
-OUTI
-LD B,D
-OUTI
-LD B,E
-OUTI
-;
-LD B,PCGBLUE
-EX AF,AF'
-LD A,0BH
-PCGDLY:
-DEC A
-JP NZ,PCGDLY
-EX AF,AF'
-;
-INC C
-DEC A
-JP NZ,PCGSETP
-;
-EI
-RET
+    LD B,PCGBLUE
+    LD C,0
+    LD D,PCGRED
+    LD E,PCGGREEN
+    LD A,$08
+    EX AF,AF'
+    EXX
+    ;
+    DI
+    LD BC,$1A01
+.PCGVDSP0
+    IN A,(C)
+    JP P,.PCGVDSP0
+.PCGVDSP1
+    IN A,(C)
+    JP M,.PCGVDSP1
+    ;
+    EXX
+    EX AF,AF'
+.PCGSETP
+    OUTI
+    LD B,D
+    OUTI
+    LD B,E
+    OUTI
+    ;
+    LD B,PCGBLUE
+    EX AF,AF'
+    LD A,0BH
+.PCGDLY
+    DEC A
+    JP NZ,.PCGDLY
+    EX AF,AF'
+    ;
+    INC C
+    DEC A
+    JP NZ,.PCGSETP
+    ;
+    EI
+    RET
 
 PCG_NODISPADR:
 DW 0
@@ -143,4 +172,81 @@ DW 0
 ; DW $07E8  ; WIDTH 40 SCREEN 1
 ; DW $07D0  ; WIDTH 80
 
+; @name GETCGROM
+; @resident shared
+; @param_count 2
+; @calls sWORK,X1WORK,PCGCOMMON
+; HL = CODE (ANK; 実際は L のみ使用、H は無視), DE = ADR (格納先、 8 バイト書込)
+; CGROM(ANK) フォントを 1 文字分 (8 ライン × 1 バイト) ADR へ読み出す。
+; X1 の CG/PCG は「画面走査中セルの I/O」という間接アクセスのため、 no-display
+; 領域に対象 CODE を非 PCG (attr=$07) + kanji=0 で span 敷きし、 ラスタ同期して
+; $14xx (CGROM read port) を 8 ライン読む。 span 全 cell を同一 CODE で埋めるので
+; どの cell が走査されても同じ字形が返り、 read タイミングに寛容になる (PCGDEF 同様)。
+; AT_WIDTH provider は @calls sWORK,X1WORK でリンク時に解決 (実行時 WIDTH 不要)。
+; 設計: CG ROM read は 1FD0.bit5=0 の「互換モード」を使う (高速モードは turbo 以上限定)。
+; 互換モードは CRTC が今スキャン中の CG コード+ラスタ位置が返る = ライン番号は raster で
+; 決まり、 ソフトで timing 同期が要る。 PCG の 1 プレーン定義 250T ループを
+; read に反転し、 固定 $1400 read の 25T ブロック + dummy 8T + delay 217T で
+; 1 ライン 250T に合わせて読む。
+GCG_RDDLYVAL    EQU     $0E     ; 250T loop 用 delay 初期値
+GCG_P14         EQU     $14     ; CGROM read port 上位 ($14xx)
 
+    LD A,L
+    LD (SETPCGCELLS.GCG_CODE),A        ; ANK コード保存 (L のみ使用)
+    EX DE,HL
+    LD (.GCG_DEST),HL       ; 格納先 ADR を退避 (cell fill で DE/HL を潰すため)
+
+; 幅依存の no-display 範囲を決定 (PCGDEF と同一: 40桁=$03E8/24cell, 80桁=$07D0/48cell)
+    LD A,(AT_WIDTH)        ; 40 or 80 (provider は @calls sWORK,X1WORK でリンク)
+    CP 40
+    JR Z,.GCG_W40
+    LD HL,$07D0
+    LD A,48
+    JR .GCG_SETSPAN
+.GCG_W40
+    LD HL,$03E8
+    LD A,24
+.GCG_SETSPAN
+    LD (SETPCGCELLS.GCG_NODISPADR),HL
+    LD (SETPCGCELLS.GCG_SPAN),A
+    LD A,$07
+    LD (SETPCGCELLS.GCG_ATTR),A
+
+    CALL SETPCGCELLS      ; no-display span に attr=$07 / kanji=0 / text=CODE を敷く
+
+; --- 互換モード read (1 plane): raster sync を 1 回 + 250T ループで 8 ライン読む ---
+    LD HL,(.GCG_DEST)       ; HL = ADR
+    LD B,GCG_P14           ; BC = CGROM read port ($1400)
+    LD C,0
+    LD E,8                 ; line counter
+    EXX                    ; read regs を alternate に退避し、 sync 用 BC を使えるようにする
+    DI
+    LD BC,$1A01           ; raster status sync (= SETPCG の VDSP と同一)
+.GCG_VDSP0
+    IN A,(C)
+    JP P,.GCG_VDSP0
+.GCG_VDSP1
+    IN A,(C)
+    JP M,.GCG_VDSP1
+    EXX                    ; HL=dest, BC=$1400, E=8
+.GCG_RDLOOP
+    IN A,(C)              ; 12, GET DATA
+    LD (HL),A             ; 7, STORE 1 BYTE
+    INC HL                ; 6, INC POINTER
+    NOP                   ; 4, DUMMY
+    NOP                   ; 4, DUMMY
+    LD A,GCG_RDDLYVAL     ; 7
+    ; 12+7+6+4+4+7=40
+.GCG_RDDLY
+    DEC A                 ; 4
+    JP NZ,.GCG_RDDLY       ; 10
+    ; (4+10)*14=196
+    DEC E                 ; 4
+    JP NZ,.GCG_RDLOOP      ; 10
+    ; 40+196+14 = 250
+    EI
+    RET
+
+
+.GCG_DEST
+    DW 0


### PR DESCRIPTION
## 概要

X1 の CGROM(ANK) フォントを 1 文字分読み出すランタイム関数 `GETCGROM(CODE, ADR)` を追加し、あわせて `libx1_pcg.asm` を整理しました。サンプル `examples/X1CGROM.SL` も追加しています。

## 変更点

### `GETCGROM(CODE, ADR)` (新規ランタイム関数)
- X1 CGROM(ANK) フォントを 1 文字分 (8 ライン × 1 バイト) 読み出し、`ADR` から 8 バイトに格納（BASIC `CGPAT$` 相当）。
- `CODE` は ANK コード（HL の L のみ使用）、`ADR` は格納先。
- 仕組み: no-display span (40 桁=$03E8/24cell, 80 桁=$07D0/48cell) に `attr=$07` / `kanji=0` / `text=CODE` を敷き、互換モード (`$1FD0.bit5=0`) で `$14xx` をラスタ同期しながら 8 ライン読む。span 全 cell を同一 CODE で埋めるため、どの cell が走査されても同じ字形が返る (PCGDEF と同じ寛容さ)。
- `AT_WIDTH` は `@calls sWORK,X1WORK` でリンク時に解決（実行時 WIDTH 前提なし）。
- 公開 env: `x1` / `x1native` / `x1native_slfs`（`libx1_pcg.asm` のみの変更で 3 env に公開）。

### `libx1_pcg.asm` の整理
- `PCGDEF` / `GETCGROM` 共通の「no-display span にプレーンを敷く」処理を `PCGCOMMON` (`SETPCGCELLS`) に集約（`@resident shared` で 1 回だけ実体化）。`PCGDEF` は従来どおりの挙動。
- ローカルラベルの `:` を除去（AILZ80ASM の W9005 警告対応）。

### `examples/X1CGROM.SL` (新規サンプル)
- `GETCGROM` で読み出したフォントを太字化（左シフト OR）+ 3 倍幅化して `PCGDEF` で PCG 定義するデモ。
- 上段を PCG、下段を非 PCG (CGROM) で同じ文字を表示して比較。

## 検証
- `slangc -E x1native` で `examples/X1CGROM.SL` のコンパイルが通り、`GETCGROM` / `PCGDEF` が解決、共通化した `PCGCOMMON` / `SETPCGCELLS` が 1 回だけ実体化されることを確認。
- 生成 asm を `AILZ80ASM` でアセンブルし **0 error**（残る W9005 は libx1_pcg 以外の既存関数のローカルラベル `:` に対するもので、本変更で libx1_pcg からは `:` を除去済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)