### PR TITLE
release: v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # 更新履歴
 
-## Unreleased
+## Version 0.27.0
 
 - x1native: X1turbo/Z 実機向け CRTC 初期化を修正 — start port `$1FF0` で 15kHz/24kHz table を自動選択し、`WIDTH(40/80)` でも同じ判定を使用。`$1FD0` の shadow (`_WK1FD0`) も CRTC table と同期。
 - ランタイムに `GETCGROM(CODE, ADR)` を追加 — X1 CGROM (ANK) フォントを 1 文字分 (8 ライン × 1 バイト) 読み出す (`x1` / `sosx1` / `x1native` / `x1native_slfs`)。 ADR から 8 バイトに指定 ANK コードの字形を格納。 sample `examples/X1CGROM.SL` (CGROM フォントを読み出して太字化 + 3 倍幅化し PCG 定義)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SLANG-compiler
-SLANG Compiler (Z80 + C64/oscar64) 0.26.0
+SLANG Compiler (Z80 + C64/oscar64) 0.27.0
 
 # 概要
 
@@ -35,7 +35,7 @@ slangbuild -E c64 -I include examples/c64/SPRITE.SL -o SPRITE
 ## slangc 単体 (= compile のみ、 link しない)
 
 ```
-SLANG Compiler v0.26.0
+SLANG Compiler v0.27.0
 Usage: slangc [options] <input.sl>
 
 Options:

--- a/src/SLANGCompiler.Build/Program.cs
+++ b/src/SLANGCompiler.Build/Program.cs
@@ -13,7 +13,7 @@ namespace SLANGCompiler.Build;
 /// </summary>
 internal class Program
 {
-    private const string Version = "0.26.0";
+    private const string Version = "0.27.0";
 
     public static int Main(string[] args)
     {

--- a/src/SLANGCompiler.Build/SLANGCompiler.Build.csproj
+++ b/src/SLANGCompiler.Build/SLANGCompiler.Build.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slangbuild</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.26.0</Version>
+    <Version>0.27.0</Version>
     <AssemblyTitle>SLANG Build Driver (two-stage assembler)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SLANGCompiler.CLI/Program.cs
+++ b/src/SLANGCompiler.CLI/Program.cs
@@ -10,7 +10,7 @@ namespace SLANGCompiler.CLI;
 
 class Program
 {
-    const string Version = "0.26.0";
+    const string Version = "0.27.0";
 
     static int Main(string[] args)
     {

--- a/src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj
+++ b/src/SLANGCompiler.CLI/SLANGCompiler.CLI.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slangc</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.26.0</Version>
+    <Version>0.27.0</Version>
     <AssemblyTitle>SLANG Compiler</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>

--- a/src/SLANGCompiler.SlfsPack/SLANGCompiler.SlfsPack.csproj
+++ b/src/SLANGCompiler.SlfsPack/SLANGCompiler.SlfsPack.csproj
@@ -8,7 +8,7 @@
     <AssemblyName>slfs-pack</AssemblyName>
     <Copyright>Copyright (c) 2022-2026 OGINO Hiroshi / H.O SOFT</Copyright>
     <Company>H.O SOFT</Company>
-    <Version>0.26.0</Version>
+    <Version>0.27.0</Version>
     <AssemblyTitle>SLFS packer (SLANG ゲーム専用 file system)</AssemblyTitle>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## 概要

Version 0.27.0 リリース準備。

- バージョン表記を 0.26.0 → 0.27.0 に更新 (6 箇所: CLI/Build/SlfsPack の csproj、CLI/Build の Program.cs、README)
- CHANGELOG.md の Unreleased を Version 0.27.0 にリネーム

## 0.27.0 の主な変更点

- x1native: X1turbo/Z 実機向け CRTC 初期化を修正 (#230)
- ランタイムに `GETCGROM(CODE, ADR)` を追加 — X1 CGROM (ANK) フォント読み出し (#229)
- x1: テキスト表示の CRTC テーブル値を正典 (LSX-Dodgers / S-OS) に合わせて修正 (#231)

## 検証

- `dotnet build -c Release` 成功 (0 警告 / 0 エラー)。

## リリース手順の残り (このPRマージ後に別途実施)

- `git tag -a v0.27.0 -m "Release v0.27.0"` + push
- `gh release create v0.27.0 --prerelease` (リリースノートは CHANGELOG から)
- `bash publish.sh 0.27.0` で 4 プラットフォーム分 zip 生成 → `gh release upload` で添付